### PR TITLE
Bug fix for restart outputs

### DIFF
--- a/src/CalcByLOBPCG.c
+++ b/src/CalcByLOBPCG.c
@@ -602,8 +602,10 @@ int LOBPCG_Main(
   */
   if (X->Def.iReStart == RESTART_OUT || X->Def.iReStart == RESTART_INOUT){
       Output_restart(X, wxp[1]);
-      sprintf(sdt, "%s", cLogLanczos_EigenValueNotConverged);
-      return 1;
+      if(iconv != 0) {
+          sprintf(sdt, "%s", cLogLanczos_EigenValueNotConverged);
+          return 1;
+      }
   }
   /**@brief
   <li>Just Move wxp[1] into ::L_vec. The latter must be start from 0-index (the same as FullDiag)</li>
@@ -680,9 +682,11 @@ int CalcByLOBPCG(
 
     int iret = LOBPCG_Main(&(X->Bind));
     if (iret != 0) {
-      fprintf(stdoutMPI, "  LOBPCG is not converged in this process.\n");
       if(iret ==1) return (TRUE);
-      else return(FALSE);
+      else{
+          fprintf(stdoutMPI, "  LOBPCG is not converged in this process.\n");
+          return(FALSE);
+      }
     }
   }/*if (X->Bind.Def.iInputEigenVec == FALSE)*/
   else {// X->Bind.Def.iInputEigenVec=true :input v1:

--- a/src/Lanczos_EigenValue.c
+++ b/src/Lanczos_EigenValue.c
@@ -290,9 +290,11 @@ int Lanczos_EigenValue(struct BindStruct *X) {
       OutputTMComponents(X, alpha, beta, dnorm, stp - 1);
       OutputLanczosVector(X, v0, v1, stp - 1);
     }
+    if (iconv !=0){
       sprintf(sdt, "%s", cLogLanczos_EigenValueNotConverged);
       fprintf(stdoutMPI, "  Lanczos Eigenvalue is not converged in this process.\n");
       return 1;
+    }
   }
 
   sprintf(sdt, cFileNameTimeKeep, X->Def.CDataFileHead);

--- a/test/lanczos_genspin_ladder_restart.sh
+++ b/test/lanczos_genspin_ladder_restart.sh
@@ -37,6 +37,7 @@ paste output/zvo_energy.dat reference.dat > paste1.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste1.dat`
 
 # Check value for Restart_inout
+rm output/zvo_energy.dat
 cp ./stan.in stan3.in
 sed -i -e "s/Restart = \"Restart_out\"/Restart = \"Restart\"/g" stan3.in
 sed -i -e "s/Lanczos_max = 10/Lanczos_max = 1000/g" stan3.in 

--- a/test/lanczos_hubbard_square_restart.sh
+++ b/test/lanczos_hubbard_square_restart.sh
@@ -36,6 +36,7 @@ paste output/zvo_energy.dat reference.dat > paste1.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste1.dat`
 
 # Check value for Restart_inout
+rm output/zvo_energy.dat
 cp ./stan.in stan3.in
 sed -i -e "s/Restart = \"Restart_out\"/Restart = \"Restart\"/g" stan3.in
 sed -i -e "s/Lanczos_max = 10/Lanczos_max = 1000/g" stan3.in 

--- a/test/lanczos_kondo_chain_restart.sh
+++ b/test/lanczos_kondo_chain_restart.sh
@@ -36,6 +36,7 @@ paste output/zvo_energy.dat reference.dat > paste1.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste1.dat`
 
 # Check value for Restart_inout
+rm output/zvo_energy.dat
 cp ./stan.in stan3.in
 sed -i -e "s/Restart = \"Restart_out\"/Restart = \"Restart\"/g" stan3.in
 sed -i -e "s/Lanczos_max = 10/Lanczos_max = 1000/g" stan3.in 

--- a/test/lanczos_spin_kagome_restart.sh
+++ b/test/lanczos_spin_kagome_restart.sh
@@ -39,6 +39,7 @@ paste output/zvo_energy.dat reference.dat > paste1.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste1.dat`
 
 # Check value for Restart_inout
+rm output/zvo_energy.dat
 cp ./stan.in stan3.in
 sed -i -e "s/Restart = \"Restart_out\"/Restart = \"Restart\"/g" stan3.in
 sed -i -e "s/Lanczos_max = 10/Lanczos_max = 1000/g" stan3.in 

--- a/test/lobcg_genspin_ladder_restart.sh
+++ b/test/lobcg_genspin_ladder_restart.sh
@@ -46,6 +46,7 @@ paste output/zvo_energy.dat reference.dat > paste.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste.dat`
 
 # Check value for Restart_inout
+rm output/zvo_energy.dat
 cp ./stan.in stan3.in
 sed -i -e "s/Restart = \"Restart_out\"/Restart = \"Restart\"/g" stan3.in
 sed -i -e "s/Lanczos_max = 10/Lanczos_max = 1000/g" stan3.in 

--- a/test/lobcg_hubbard_square_restart.sh
+++ b/test/lobcg_hubbard_square_restart.sh
@@ -48,6 +48,7 @@ cat > reference.dat <<EOF
 EOF
 paste output/zvo_energy.dat reference.dat > paste.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste.dat`
+rm output/zvo_energy.dat
 
 # Check value for Restart_inout
 cp ./stan.in stan3.in

--- a/test/lobcg_kondo_chain_restart.sh
+++ b/test/lobcg_kondo_chain_restart.sh
@@ -40,6 +40,7 @@ cat > reference.dat <<EOF
 EOF
 paste output/zvo_energy.dat reference.dat > paste.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste.dat`
+rm output/zvo_energy.dat
 
 # Check value for Restart_inout
 cp ./stan.in stan3.in

--- a/test/lobcg_spin_kagome_restart.sh
+++ b/test/lobcg_spin_kagome_restart.sh
@@ -44,6 +44,7 @@ cat > reference.dat <<EOF
 EOF
 paste output/zvo_energy.dat reference.dat > paste.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($2-$3)*($2-$3))} END{printf "%8.6f", diff}' paste.dat`
+rm output/zvo_energy.dat
 
 # Check value for Restart_inout
 cp ./stan.in stan3.in


### PR DESCRIPTION
1. Update tests for restart calculation (delete zvo_energy.dat before restart_inout calculation)
2. Output physical quantities when the calculation is converged in restart calculation (Lanczos and LOBPCG)