### PR TITLE
Disable GPGPU fulldiag on  NOGPU env

### DIFF
--- a/config/sekirei_acc.cmake
+++ b/config/sekirei_acc.cmake
@@ -20,7 +20,7 @@ set(BLA_VENDOR "Intel10_64lp" CACHE STRING "" FORCE)
 set (MAGMA_FOUND ON)
 set (MAGMA_C_LIBRARIES magma)
 # set magma installed directory
-set (MAGMA /home/issp/materiapps/tool/magma/magma-2.2.0)
+set (MAGMA /home/issp/materiapps/tool/magma/magma-2.4.0)
 include_directories(${MAGMA}/include)
 link_directories(${MAGMA}/lib)
 

--- a/src/matrixlapack_magma.c
+++ b/src/matrixlapack_magma.c
@@ -52,6 +52,11 @@ int diag_magma_cmp(int xNsize, double complex **A,
       magma_int_t maxngpu = 0;
       magma_device_t *dummy;
       magma_getdevices(dummy, 9999, &maxngpu);
+      if(maxngpu <= 0) {
+          fprintf(stdout, "  Error: Your HPhi was built with a GPGPU library but NO GPU device is found.\n");
+          fprintf(stdout, "         To perform fulldiag calculation without GPU, set \"ngpu 0\" in \"calcmod.def\".\n");
+          exit(1);
+      }
       if(ngpu > maxngpu) {
         fprintf(stdout, "  Warning: ngpu is beyond maxgpu. ngpu = %d, maxngpu =  %d\n", ngpu, maxngpu);
         fprintf(stdout, "           MAGMA library executes maxngpu.\n\n");


### PR DESCRIPTION
Show error message and work-around information when performing GPGPU fulldiag calculation on an environment with NO GPU device.