### PR TITLE
add STDFACE_DIR option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ enable_testing()
 project(HPhi NONE)
 option(USE_SCALAPACK "Use Scalapack" OFF)
 
+set(CMAKE_C_FLAGS "-Wall")
+
 if(CONFIG)
   message(STATUS "Loading configration: " ${PROJECT_SOURCE_DIR}/config/${CONFIG}.cmake)
   include(${PROJECT_SOURCE_DIR}/config/${CONFIG}.cmake)
@@ -26,28 +28,37 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_MACOSX_RPATH 1)
 
-# git submodule update
-# ref: https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html
-find_package(Git QUIET)
-if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-  set(STDFACE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace/submodule")
-  # Update submodules as needed
-  if(GIT_SUBMODULE_UPDATE)
-    message(STATUS "Submodule update")
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      RESULT_VARIABLE GIT_SUBMOD_RESULT)
-    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-      message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+if(NOT STDFACE_DIR)
+  # git submodule update
+  # ref: https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html
+  find_package(Git QUIET)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace/clone")
+    set(STDFACE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace/clone")
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace")
+  elseif(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    set(STDFACE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace/submodule")
+    # Update submodules as needed
+    if(GIT_SUBMODULE_UPDATE)
+      message(STATUS "Submodule update")
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        RESULT_VARIABLE GIT_SUBMOD_RESULT)
+      if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+        message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+      endif()
     endif()
+  else()
+    set(STDFACE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace/clone")
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace")
   endif()
 
   if(NOT EXISTS "${STDFACE_DIR}/CMakeLists.txt")
-    message(FATAL_ERROR "The submodule StdFace were not downloaded! GIT_SUBMODULE_UPDATE was turned off or failed. Please update submodules and try again.")
+    message(FATAL_ERROR "Automatic download of the submodule StdFace failed! Please run 'sh ${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace/download.sh' to download manually.")
   endif()
 else()
-  set(STDFACE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace/clone")
-  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/StdFace")
+  if(NOT EXISTS "${STDFACE_DIR}/CMakeLists.txt")
+    message(FATAL_ERROR "STDFACE_DIR is manually set to ${STDFACE_DIR}, but ${STDFACE_DIR}/CMakeLists.txt does not exists")
+  endif()
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Intel")

--- a/doc/en/source/howtouse/installation_en.rst
+++ b/doc/en/source/howtouse/installation_en.rst
@@ -56,3 +56,13 @@ After compilation,
 an execute :math:`{\mathcal H}\Phi` in the ``src`` folder.
 Please note that we must delete the ``build`` folder and
 repeat the above operations when we change the compiler.
+
+
+.. tip::
+
+ | CMake automatically trys to download StdFace package (https://github.com/issp-center-dev/StdFace, parser for standard mode),
+ | but this may fail due to network problem (e.g., IP unreachable)
+ | In such a case, please run ``sh src/StdFace/download.sh`` to download manually.
+ |
+ | If you want to use StdFace downloaded into another directory,
+ | pass ``-DSTDFACE_DIR=<path_to_stdface>`` to cmake command.

--- a/doc/ja/source/howtouse/installation_ja.rst
+++ b/doc/ja/source/howtouse/installation_ja.rst
@@ -61,3 +61,12 @@ MPIライブラリがない場合には、MPI非対応の実行ファイルが�
 なお、コンパイラを変更しコンパイルし直したい場合には、都度buildフォルダごと削除を行った上で、
 新規に上記作業を行うことをお薦めします。
 また、SSE2が使用出来る場合には、cmakeでのコンパイル時\ ``-DHAVE_SSE2``\ を付け加えてください.
+
+
+.. tip::
+
+ | CMake 中に StdFace (https://github.com/issp-center-dev/StdFace, スタンダードモードのパーサー) が自動でダウンロードされます。
+ | もしもこのダウンロードに失敗した場合は、 ``sh src/StdFace/download.sh`` を実行してダウンロードをしてください。
+ | 
+ | もしくは、別の場所にダウンロードした StdFace を使いたい場合は、
+ | ``-DSTDFACE_DIR=<path_to_stdface>`` を cmake コマンドに渡してください。

--- a/src/StdFace/download.sh
+++ b/src/StdFace/download.sh
@@ -1,0 +1,2 @@
+SCRIPT_DIR=$(cd "$(dirname $0)"; pwd)
+git clone https://github.com/issp-center-dev/StdFace ${SCRIPT_DIR}/clone


### PR DESCRIPTION
Added ways to use local (pre-downloaded) [StdFace](https://github.com/issp-center-dev/StdFace), 

`cmake -DSTDFACE_DIR=<StdFace-Dir>`