### PR TITLE
Fix interall interactions

### DIFF
--- a/doc/en/source/filespecification/expertmode_en/InterAll_file_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/InterAll_file_en.rst
@@ -13,7 +13,9 @@ integrals :math:`I_{ijkl\sigma_1\sigma_2\sigma_3\sigma_4}`,
    {\mathcal H}+=\sum_{i,j,k,l}\sum_{\sigma_1,\sigma_2, \sigma_3, \sigma_4}
    I_{ijkl\sigma_1\sigma_2\sigma_3\sigma_4}c_{i\sigma_1}^{\dagger}c_{j\sigma_2}c_{k\sigma_3}^{\dagger}c_{l\sigma_4}.
 
-For spin, the conditions :math:`i=j` and :math:`k=l` must be satisfied. An example of the file format is as follows.
+For the off-diagonal component, be sure to provide a pair of i1 sigma1 i2 sigma2 i3 sigma3 i4 sigma4 and i4 sigma4 i3 sigma3 i2 sigma2 i1 sigma1.
+For spin, the conditions :math:`i=j` and :math:`k=l` must be satisfied.
+An example of the file format is as follows.
 
 ::
 

--- a/doc/ja/source/filespecification/expertmode_ja/InterAll_file_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/InterAll_file_ja.rst
@@ -14,6 +14,7 @@ InterAll指定ファイル
 
 
 なお、スピンに関して計算する場合には、\ :math:`i=j, k=l`\ となるよう設定してください。
+また、オフダイアゴナル成分については、i1 sigma1 i2 sigma2 i3 sigma3 i4 sigma4 とi4 sigma4 i3 sigma3 i2 sigma2 i1 sigma1 のペアを必ず用意するようにしてください。
 以下にファイル例を記載します。
 
 ::

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -2320,7 +2320,8 @@ int CheckInterAllHermite
         }
       } else if (isite1 == itmpsite2 && isite2 == itmpsite1 && isite3 == itmpsite4 &&
                  isite4 == itmpsite3) {      //for spin and Kondo
-        if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
+        //if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
+          if (iCalcModel == Kondo || iCalcModel == KondoGC) {
           if (isigma1 == itmpsigma2 && isigma2 == itmpsigma1 && isigma3 == itmpsigma4 && isigma4 == itmpsigma3) {
             ddiff_intall = ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]);
             if (cabs(ddiff_intall) < eps_CheckImag0) {
@@ -2362,7 +2363,8 @@ int CheckInterAllHermite
     }
   }
 
-  if (icntincorrect != 0) {
+  //if (icntincorrect != 0) {
+  if (icntincorrect != 0 || NInterAllOffDiagonal != 2*icntHermite) {
     return (-1);
   }
 

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -2318,42 +2318,43 @@ int CheckInterAllHermite
             }
           }
         }
-      } else if (isite1 == itmpsite2 && isite2 == itmpsite1 && isite3 == itmpsite4 &&
-                 isite4 == itmpsite3) {      //for spin and Kondo
-        //if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
-          if (iCalcModel == Kondo || iCalcModel == KondoGC) {
-          if (isigma1 == itmpsigma2 && isigma2 == itmpsigma1 && isigma3 == itmpsigma4 && isigma4 == itmpsigma3) {
-            ddiff_intall = ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]);
-            if (cabs(ddiff_intall) < eps_CheckImag0) {
-              itmpret = 1;
-              if (icheckHermiteCount == FALSE) {
-                icheckHermiteCount = TRUE; // for not double-counting
-                if (i <= j) {
-                  if (2 * icntHermite >= NInterAllOffDiagonal) {
-                    fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
-                    return (-1);
-                  }
-                  for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
-                    InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
-                  }
-                  for (itmpIdx = 0; itmpIdx < 4; itmpIdx++) {
-                    InterAll[2 * icntHermite + 1][2 * itmpIdx] = InterAllOffDiagonal[i][6 -
-                                                                                        2 *
-                                                                                        itmpIdx];
-                    InterAll[2 * icntHermite + 1][2 * itmpIdx + 1] = InterAllOffDiagonal[i][7 - 2 *
-                                                                                                itmpIdx];
-
-                  }
-                  ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
-                  ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
-                  icntHermite++;
-                }
-                break;
-              }
-            }
-          }
-        }
       }
+//      else if (isite1 == itmpsite2 && isite2 == itmpsite1 && isite3 == itmpsite4 &&
+//                 isite4 == itmpsite3) {      //for spin and Kondo
+//        //if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
+//          if (iCalcModel == Kondo || iCalcModel == KondoGC) {
+//          if (isigma1 == itmpsigma2 && isigma2 == itmpsigma1 && isigma3 == itmpsigma4 && isigma4 == itmpsigma3) {
+//            ddiff_intall = ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]);
+//            if (cabs(ddiff_intall) < eps_CheckImag0) {
+//              itmpret = 1;
+//              if (icheckHermiteCount == FALSE) {
+//                icheckHermiteCount = TRUE; // for not double-counting
+//                if (i <= j) {
+//                  if (2 * icntHermite >= NInterAllOffDiagonal) {
+//                    fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
+//                    return (-1);
+//                  }
+//                  for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
+//                    InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
+//                  }
+//                  for (itmpIdx = 0; itmpIdx < 4; itmpIdx++) {
+//                    InterAll[2 * icntHermite + 1][2 * itmpIdx] = InterAllOffDiagonal[i][6 -
+//                                                                                        2 *
+//                                                                                        itmpIdx];
+//                    InterAll[2 * icntHermite + 1][2 * itmpIdx + 1] = InterAllOffDiagonal[i][7 - 2 *
+//                                                                                                itmpIdx];
+//
+//                  }
+//                  ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
+//                  ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
+//                  icntHermite++;
+//                }
+//                break;
+//              }
+//            }
+//          }
+//        }
+//      }
     }
     //if counterpart for satisfying hermite conjugate does not exist.
     if (itmpret != 1) {

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -2318,45 +2318,48 @@ int CheckInterAllHermite
       }
 
       if (itmpret != 1) {
-          for (j = 0; j < NInterAllOffDiagonal; j++) {
-              itmpsite1 = InterAllOffDiagonal[j][0];
-              itmpsigma1 = InterAllOffDiagonal[j][1];
-              itmpsite2 = InterAllOffDiagonal[j][2];
-              itmpsigma2 = InterAllOffDiagonal[j][3];
-              itmpsite3 = InterAllOffDiagonal[j][4];
-              itmpsigma3 = InterAllOffDiagonal[j][5];
-              itmpsite4 = InterAllOffDiagonal[j][6];
-              itmpsigma4 = InterAllOffDiagonal[j][7];
-              if (isite1 == itmpsite2 && isite2 == itmpsite1 && isite3 == itmpsite4 &&
-                  isite4 == itmpsite3) {      //for spin and Kondo
-                  if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
-                      if (isigma1 == itmpsigma2 && isigma2 == itmpsigma1 && isigma3 == itmpsigma4 &&
-                          isigma4 == itmpsigma3) {
-                          ddiff_intall = ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]);
-                          if (cabs(ddiff_intall) < eps_CheckImag0) {
-                              itmpret = 1;
-                              if (i <= j) {
-                                  if (icheckHermiteCount == FALSE) {
-                                      icheckHermiteCount = TRUE; // for not double-counting
-                                      if (2 * icntHermite >= NInterAllOffDiagonal) {
-                                          fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
-                                          return (-1);
-                                      }
-                                      for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
-                                          InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
-                                      }
-                                      for (itmpIdx = 0; itmpIdx < 4; itmpIdx++) {
-                                          InterAll[2 * icntHermite + 1][2 * itmpIdx] = InterAllOffDiagonal[i][6 -
-                                                                                                              2 *
-                                                                                                              itmpIdx];
-                                          InterAll[2 * icntHermite + 1][2 * itmpIdx + 1] = InterAllOffDiagonal[i][7 -
+          if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
+              if (isite1 != isite3 && isigma1 != isigma3 && isite2 != isite4 && isigma2 != isigma4) {
+                  for (j = 0; j < NInterAllOffDiagonal; j++) {
+                      itmpsite1 = InterAllOffDiagonal[j][0];
+                      itmpsigma1 = InterAllOffDiagonal[j][1];
+                      itmpsite2 = InterAllOffDiagonal[j][2];
+                      itmpsigma2 = InterAllOffDiagonal[j][3];
+                      itmpsite3 = InterAllOffDiagonal[j][4];
+                      itmpsigma3 = InterAllOffDiagonal[j][5];
+                      itmpsite4 = InterAllOffDiagonal[j][6];
+                      itmpsigma4 = InterAllOffDiagonal[j][7];
+                      if (isite1 == itmpsite2 && isite2 == itmpsite1 && isite3 == itmpsite4 &&
+                          isite4 == itmpsite3) {      //for spin and Kondo
+                          if (isigma1 == itmpsigma2 && isigma2 == itmpsigma1 && isigma3 == itmpsigma4 &&
+                              isigma4 == itmpsigma3) {
+                              ddiff_intall = ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]);
+                              if (cabs(ddiff_intall) < eps_CheckImag0) {
+                                  itmpret = 1;
+                                  if (i <= j) {
+                                      if (icheckHermiteCount == FALSE) {
+                                          icheckHermiteCount = TRUE; // for not double-counting
+                                          if (2 * icntHermite >= NInterAllOffDiagonal) {
+                                              fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
+                                              return (-1);
+                                          }
+                                          for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
+                                              InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
+                                          }
+                                          for (itmpIdx = 0; itmpIdx < 4; itmpIdx++) {
+                                              InterAll[2 * icntHermite + 1][2 * itmpIdx] = InterAllOffDiagonal[i][6 -
                                                                                                                   2 *
                                                                                                                   itmpIdx];
+                                              InterAll[2 * icntHermite + 1][2 * itmpIdx + 1] = InterAllOffDiagonal[i][
+                                                      7 -
+                                                      2 *
+                                                      itmpIdx];
+                                          }
+                                          ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
+                                          ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
+                                          icntHermite++;
+                                          break;
                                       }
-                                      ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
-                                      ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
-                                      icntHermite++;
-                                      break;
                                   }
                               }
                           }

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -2270,98 +2270,107 @@ int CheckInterAllHermite
   icntincorrect = 0;
   icntHermite = 0;
   for (i = 0; i < NInterAllOffDiagonal; i++) {
-    itmpret = 0;
-    isite1 = InterAllOffDiagonal[i][0];
-    isigma1 = InterAllOffDiagonal[i][1];
-    isite2 = InterAllOffDiagonal[i][2];
-    isigma2 = InterAllOffDiagonal[i][3];
-    isite3 = InterAllOffDiagonal[i][4];
-    isigma3 = InterAllOffDiagonal[i][5];
-    isite4 = InterAllOffDiagonal[i][6];
-    isigma4 = InterAllOffDiagonal[i][7];
-    icheckHermiteCount = FALSE;
+      itmpret = 0;
+      isite1 = InterAllOffDiagonal[i][0];
+      isigma1 = InterAllOffDiagonal[i][1];
+      isite2 = InterAllOffDiagonal[i][2];
+      isigma2 = InterAllOffDiagonal[i][3];
+      isite3 = InterAllOffDiagonal[i][4];
+      isigma3 = InterAllOffDiagonal[i][5];
+      isite4 = InterAllOffDiagonal[i][6];
+      isigma4 = InterAllOffDiagonal[i][7];
+      icheckHermiteCount = FALSE;
 
-    for (j = 0; j < NInterAllOffDiagonal; j++) {
-      itmpsite1 = InterAllOffDiagonal[j][0];
-      itmpsigma1 = InterAllOffDiagonal[j][1];
-      itmpsite2 = InterAllOffDiagonal[j][2];
-      itmpsigma2 = InterAllOffDiagonal[j][3];
-      itmpsite3 = InterAllOffDiagonal[j][4];
-      itmpsigma3 = InterAllOffDiagonal[j][5];
-      itmpsite4 = InterAllOffDiagonal[j][6];
-      itmpsigma4 = InterAllOffDiagonal[j][7];
-
-      if (isite1 == itmpsite4 && isite2 == itmpsite3 && isite3 == itmpsite2 && isite4 == itmpsite1) {
-        if (isigma1 == itmpsigma4 && isigma2 == itmpsigma3 && isigma3 == itmpsigma2 && isigma4 == itmpsigma1) {
-          ddiff_intall = cabs(ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]));
-
-          if (cabs(ddiff_intall) < eps_CheckImag0) {
-            itmpret = 1;
-            if (icheckHermiteCount == FALSE) {
-              icheckHermiteCount = TRUE; //for not double counting
-              if (i <= j) {
-                if (2 * icntHermite >= NInterAllOffDiagonal) {
-                  fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
-                  return (-1);
-                }
-
-                for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
-                  InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
-                  InterAll[2 * icntHermite + 1][itmpIdx] = InterAllOffDiagonal[j][itmpIdx];
-                }
-
-                ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
-                ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
-                icntHermite++;
+      for (j = 0; j < NInterAllOffDiagonal; j++) {
+          itmpsite1 = InterAllOffDiagonal[j][0];
+          itmpsigma1 = InterAllOffDiagonal[j][1];
+          itmpsite2 = InterAllOffDiagonal[j][2];
+          itmpsigma2 = InterAllOffDiagonal[j][3];
+          itmpsite3 = InterAllOffDiagonal[j][4];
+          itmpsigma3 = InterAllOffDiagonal[j][5];
+          itmpsite4 = InterAllOffDiagonal[j][6];
+          itmpsigma4 = InterAllOffDiagonal[j][7];
+          if (isite1 == itmpsite4 && isite2 == itmpsite3 && isite3 == itmpsite2 && isite4 == itmpsite1) {
+              if (isigma1 == itmpsigma4 && isigma2 == itmpsigma3 && isigma3 == itmpsigma2 && isigma4 == itmpsigma1) {
+                  ddiff_intall = cabs(ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]));
+                  if (cabs(ddiff_intall) < eps_CheckImag0) {
+                      itmpret = 1;
+                      if (icheckHermiteCount == FALSE) {
+                          if (i <= j) {
+                              icheckHermiteCount = TRUE; //for not double counting
+                              if (2 * icntHermite >= NInterAllOffDiagonal) {
+                                  fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
+                                  return (-1);
+                              }
+                              for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
+                                  InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
+                                  InterAll[2 * icntHermite + 1][itmpIdx] = InterAllOffDiagonal[j][itmpIdx];
+                              }
+                              ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
+                              ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
+                              icntHermite++;
+                              break;
+                          }
+                      }
+                  }
               }
-              break;
-            }
           }
-        }
       }
-//      else if (isite1 == itmpsite2 && isite2 == itmpsite1 && isite3 == itmpsite4 &&
-//                 isite4 == itmpsite3) {      //for spin and Kondo
-//        //if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
-//          if (iCalcModel == Kondo || iCalcModel == KondoGC) {
-//          if (isigma1 == itmpsigma2 && isigma2 == itmpsigma1 && isigma3 == itmpsigma4 && isigma4 == itmpsigma3) {
-//            ddiff_intall = ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]);
-//            if (cabs(ddiff_intall) < eps_CheckImag0) {
-//              itmpret = 1;
-//              if (icheckHermiteCount == FALSE) {
-//                icheckHermiteCount = TRUE; // for not double-counting
-//                if (i <= j) {
-//                  if (2 * icntHermite >= NInterAllOffDiagonal) {
-//                    fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
-//                    return (-1);
-//                  }
-//                  for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
-//                    InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
-//                  }
-//                  for (itmpIdx = 0; itmpIdx < 4; itmpIdx++) {
-//                    InterAll[2 * icntHermite + 1][2 * itmpIdx] = InterAllOffDiagonal[i][6 -
-//                                                                                        2 *
-//                                                                                        itmpIdx];
-//                    InterAll[2 * icntHermite + 1][2 * itmpIdx + 1] = InterAllOffDiagonal[i][7 - 2 *
-//                                                                                                itmpIdx];
-//
-//                  }
-//                  ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
-//                  ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
-//                  icntHermite++;
-//                }
-//                break;
-//              }
-//            }
-//          }
-//        }
-//      }
-    }
-    //if counterpart for satisfying hermite conjugate does not exist.
-    if (itmpret != 1) {
-      fprintf(stdoutMPI, cErrNonHermiteInterAll, isite1, isigma1, isite2, isigma2, isite3, isigma3, isite4, isigma4,
-              creal(ParaInterAllOffDiagonal[i]), cimag(ParaInterAllOffDiagonal[i]));
-      icntincorrect++;
-    }
+
+      if (itmpret != 1) {
+          for (j = 0; j < NInterAllOffDiagonal; j++) {
+              itmpsite1 = InterAllOffDiagonal[j][0];
+              itmpsigma1 = InterAllOffDiagonal[j][1];
+              itmpsite2 = InterAllOffDiagonal[j][2];
+              itmpsigma2 = InterAllOffDiagonal[j][3];
+              itmpsite3 = InterAllOffDiagonal[j][4];
+              itmpsigma3 = InterAllOffDiagonal[j][5];
+              itmpsite4 = InterAllOffDiagonal[j][6];
+              itmpsigma4 = InterAllOffDiagonal[j][7];
+              if (isite1 == itmpsite2 && isite2 == itmpsite1 && isite3 == itmpsite4 &&
+                  isite4 == itmpsite3) {      //for spin and Kondo
+                  if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
+                      if (isigma1 == itmpsigma2 && isigma2 == itmpsigma1 && isigma3 == itmpsigma4 &&
+                          isigma4 == itmpsigma3) {
+                          ddiff_intall = ParaInterAllOffDiagonal[i] - conj(ParaInterAllOffDiagonal[j]);
+                          if (cabs(ddiff_intall) < eps_CheckImag0) {
+                              itmpret = 1;
+                              if (i <= j) {
+                                  if (icheckHermiteCount == FALSE) {
+                                      icheckHermiteCount = TRUE; // for not double-counting
+                                      if (2 * icntHermite >= NInterAllOffDiagonal) {
+                                          fprintf(stdoutMPI, "Elements of InterAll are incorrect.\n");
+                                          return (-1);
+                                      }
+                                      for (itmpIdx = 0; itmpIdx < 8; itmpIdx++) {
+                                          InterAll[2 * icntHermite][itmpIdx] = InterAllOffDiagonal[i][itmpIdx];
+                                      }
+                                      for (itmpIdx = 0; itmpIdx < 4; itmpIdx++) {
+                                          InterAll[2 * icntHermite + 1][2 * itmpIdx] = InterAllOffDiagonal[i][6 -
+                                                                                                              2 *
+                                                                                                              itmpIdx];
+                                          InterAll[2 * icntHermite + 1][2 * itmpIdx + 1] = InterAllOffDiagonal[i][7 -
+                                                                                                                  2 *
+                                                                                                                  itmpIdx];
+                                      }
+                                      ParaInterAll[2 * icntHermite] = ParaInterAllOffDiagonal[i];
+                                      ParaInterAll[2 * icntHermite + 1] = ParaInterAllOffDiagonal[j];
+                                      icntHermite++;
+                                      break;
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+      //if counterpart for satisfying hermite conjugate does not exist.
+      if (itmpret != 1) {
+          fprintf(stdoutMPI, cErrNonHermiteInterAll, isite1, isigma1, isite2, isigma2, isite3, isigma3, isite4, isigma4,
+                  creal(ParaInterAllOffDiagonal[i]), cimag(ParaInterAllOffDiagonal[i]));
+          icntincorrect++;
+      }
   }
 
   //if (icntincorrect != 0) {


### PR DESCRIPTION
When i1 sigma1 i2 sigma2 i3 sigma3 i4 sigma4 val_re val_im is defined and
i4 sigma4 i3 sigma3 i2 sigma2 i1 sigma1 val_re -val_im
and
i2 sigma2 i1 sigma1 i4 sigma4 i3 sigma3 val_re -val_im
exists at the same time in InterAll.def, a branching error will occur.


- Fix  CheckInterAllHermite function in readdef.c as follows:

1. Add a check condition 

Before
```
if (icntincorrect != 0) {
  return (-1);
}
```

After
```
if (icntincorrect != 0　|| NInterAllOffDiagonal != 2*icntHermite) {
  return (-1);
}
```

2. Remove a check condition for spin and spingc

Before
```
if (iCalcModel == Kondo || iCalcModel == KondoGC || iCalcModel == Spin || iCalcModel == SpinGC) {
```

After

```
if (iCalcModel == Kondo || iCalcModel == KondoGC) {
```


- Add the following description for InterAll.def in the manual

```
For the off-diagonal component, be sure to provide a pair of i1 sigma1 i2 sigma2 i3 sigma3 i4 sigma4 and i4 sigma4 i3 sigma3 i2 sigma2 i1 sigma1.
```
