### PR TITLE
Modify message when hamiltonian is outputted.

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -88,7 +88,7 @@ int outputHam(struct BindStruct *X){
     }
   }
 
-  strcpy(cHeader, "%%%%MatrixMarket matrix coordinate complex hermitian\n");
+  strcpy(cHeader, "%%MatrixMarket matrix coordinate complex hermitian\n");
   sprintf(sdt,cFileNamePhys_FullDiag_Ham, X->Def.CDataFileHead);
   if(childfopenMPI(sdt,"w",&fp)!=0){
     return -1;


### PR DESCRIPTION
When using scipy, "%%%%" is not allowed as the market format for matrices and must be "%%".