### PR TITLE
remove too slow tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,11 @@ jobs:
           - os: ubuntu-20.04
             mpisize: 1
             ompsize: 1
+        exclude:
+          - mpisize: 16
+            ompsize: 3
+          - mpisize: 4
+          - ompsize: 3
       fail-fast: false
 
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           - mpisize: 16
             ompsize: 3
           - mpisize: 4
-          - ompsize: 3
+            ompsize: 3
       fail-fast: false
 
     env:


### PR DESCRIPTION
Tests in 16MPI+3OMP and 4MPI+3OMP are too slow in the GitHubActions-hosted server (e.g., one hour per a test)