### PR TITLE
fixed bug in output of two-body Green functions

### DIFF
--- a/src/expec_cisajscktaltdc.c
+++ b/src/expec_cisajscktaltdc.c
@@ -154,9 +154,10 @@ int expec_cisajscktaltdc
     sprintf(sdt_4,cFileName6BGreen_FullDiag, X->Def.CDataFileHead, X->Phys.eigen_num);
     break;
   }
-
-  if(childfopenMPI(sdt, "w", &fp)!=0){
-    return -1;
+  if(X->Def.NCisAjtCkuAlvDC>0){
+    if(childfopenMPI(sdt, "w", &fp)!=0){
+      return -1;
+    }
   }
   if(X->Def.NTBody>0){
     if(childfopenMPI(sdt_2, "w", &fp_2)!=0){
@@ -213,7 +214,9 @@ int expec_cisajscktaltdc
     return -1;
   }
   
-  fclose(fp);
+  if(X->Def.NCisAjtCkuAlvDC>0){
+    fclose(fp);
+  }
   if(X->Def.NTBody>0){
     fclose(fp_2);
   }
@@ -914,7 +917,6 @@ int expec_Sixbody_SpinGCHalf(struct BindStruct *X,double complex *vec, FILE **_f
     i_max=X->Check.idim_max;
 
     for(i=0;i<X->Def.NSBody;i++){
-        //printf("%d %d \n",i,X->Def.NSBody);
         vec_pr_0 = cd_1d_allocate(i_max + 1);
         vec_pr_1 = cd_1d_allocate(i_max + 1);
         vec_pr_2 = cd_1d_allocate(i_max + 1);

--- a/src/expec_cisajscktaltdc.c
+++ b/src/expec_cisajscktaltdc.c
@@ -155,11 +155,13 @@ int expec_cisajscktaltdc
     break;
   }
   if(X->Def.NCisAjtCkuAlvDC>0){
+    // If the number of two-body interactions is zero, the file name is not used.
     if(childfopenMPI(sdt, "w", &fp)!=0){
       return -1;
     }
   }
   if(X->Def.NTBody>0){
+    // If the number of three-body interactions is zero, the file name is not used.
     if(childfopenMPI(sdt_2, "w", &fp_2)!=0){
       return -1;
     }
@@ -167,6 +169,7 @@ int expec_cisajscktaltdc
     fp_2 = fp;
   }
   if(X->Def.NFBody>0){
+    // If the number of four-body interactions is zero, the file name is not used.
     if(childfopenMPI(sdt_3, "w", &fp_3)!=0){
       return -1;
     }
@@ -174,14 +177,13 @@ int expec_cisajscktaltdc
     fp_3 = fp;
   }
   if(X->Def.NSBody>0){
+    // If the number of six-body interactions is zero, the file name is not used.
     if(childfopenMPI(sdt_4, "w", &fp_4)!=0){
       return -1;
     }
   }else{
     fp_4 = fp;
   }
-
-
 
   switch(X->Def.iCalcModel){
   case HubbardGC:
@@ -215,15 +217,19 @@ int expec_cisajscktaltdc
   }
   
   if(X->Def.NCisAjtCkuAlvDC>0){
+    // If the number of two-body interactions is zero, the file name is not used.
     fclose(fp);
   }
   if(X->Def.NTBody>0){
+    // If the number of three-body interactions is zero, the file name is not used.
     fclose(fp_2);
   }
   if(X->Def.NFBody>0){
+    // If the number of four-body interactions is zero, the file name is not used.
     fclose(fp_3);
   }
   if(X->Def.NSBody>0){
+    // If the number of six-body interactions is zero, the file name is not used.
     fclose(fp_4);
   }
   


### PR DESCRIPTION
I fixed a bug where the two-body Green's function was being output even when not explicitly specified, 
while trying to compute the three-, four-, and six-body Green's functions.