### PR TITLE
add `OutputTPQDataHead` option to prefix TPQ/TE output filenames with `CDataFileHead`

### DIFF
--- a/doc/en/source/filespecification/expertmode_en/CalcMod_file_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/CalcMod_file_en.rst
@@ -179,7 +179,7 @@ The parameters correlated with the keywords are as follows.
    | 0: Not output an eigenvector
    | 1: Output an eigenvector.
    
-*  ``OutputTPQDataHead``
+*  ``OutputDataHead``
 
    **Type :** Int (default value: 0)
 

--- a/doc/en/source/filespecification/expertmode_en/CalcMod_file_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/CalcMod_file_en.rst
@@ -179,6 +179,14 @@ The parameters correlated with the keywords are as follows.
    | 0: Not output an eigenvector
    | 1: Output an eigenvector.
    
+*  ``OutputTPQDataHead``
+
+   **Type :** Int (default value: 0)
+
+   | **Description :** Select whether to prefix TPQ/TE physical quantity output filenames (``SS``, ``Norm``, ``Flct``) with the header string defined by ``CDataFileHead`` in the ModPara file:
+   | 0: Do not add a prefix (e.g., ``SS_rand0.dat``).
+   | 1: Add the ``CDataFileHead`` prefix (e.g., ``zvo_SS_rand0.dat``).
+
 *  ``Scalapack``
 
    **Type :** Int (default value: 0)

--- a/doc/ja/source/filespecification/expertmode_ja/CalcMod_file_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/CalcMod_file_ja.rst
@@ -177,6 +177,14 @@ CalcModファイル
    から選択することが出来ます。
 
    
+-  ``OutputTPQDataHead``
+
+   **形式 :** int型 (デフォルト値 0)
+
+   | **説明 :** TPQ/TE計算の物理量出力ファイル (``SS``、``Norm``、``Flct``) のファイル名にModParaファイルの ``CDataFileHead`` で指定したヘッダ文字列をプレフィックスとして付与するかどうかを指定します。
+   | 0: プレフィックスを付与しない (例: ``SS_rand0.dat``)。
+   | 1: ``CDataFileHead`` のプレフィックスを付与する (例: ``zvo_SS_rand0.dat``)。
+
 -  ``Scalapack``
 
    **形式 :** int型 (デフォルト値 0)

--- a/doc/ja/source/filespecification/expertmode_ja/CalcMod_file_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/CalcMod_file_ja.rst
@@ -177,7 +177,7 @@ CalcModファイル
    から選択することが出来ます。
 
    
--  ``OutputTPQDataHead``
+-  ``OutputDataHead``
 
    **形式 :** int型 (デフォルト値 0)
 

--- a/src/CalcByCanonicalTPQ.c
+++ b/src/CalcByCanonicalTPQ.c
@@ -127,9 +127,19 @@ int CalcByCanonicalTPQ(
     X->Bind.Def.St=0;
     fprintf(stdoutMPI, "%s", cLogTPQ_Start);
     for (rand_i = 0; rand_i<rand_max; rand_i++){
-        sprintf(sdt_phys, cFileNameSSRand, rand_i);      
-        sprintf(sdt_norm, cFileNameNormRand, rand_i);
-        sprintf(sdt_flct, cFileNameFlctRand, rand_i);
+        if(X->Bind.Def.iOutputTPQDataHead==1){
+            int prefix_length;
+            prefix_length = sprintf(sdt_phys, "%s_", X->Bind.Def.CDataFileHead);
+            sprintf(sdt_phys + prefix_length, cFileNameSSRand, rand_i);
+            prefix_length = sprintf(sdt_norm, "%s_", X->Bind.Def.CDataFileHead);
+            sprintf(sdt_norm + prefix_length, cFileNameNormRand, rand_i);
+            prefix_length = sprintf(sdt_flct, "%s_", X->Bind.Def.CDataFileHead);
+            sprintf(sdt_flct + prefix_length, cFileNameFlctRand, rand_i);
+        }else{
+            sprintf(sdt_phys, cFileNameSSRand, rand_i);
+            sprintf(sdt_norm, cFileNameNormRand, rand_i);
+            sprintf(sdt_flct, cFileNameFlctRand, rand_i);
+        }
         Ns = 1.0 * X->Bind.Def.NsiteMPI;
         fprintf(stdoutMPI, cLogTPQRand, rand_i+1, rand_max);
         iret=0;

--- a/src/CalcByCanonicalTPQ.c
+++ b/src/CalcByCanonicalTPQ.c
@@ -127,7 +127,7 @@ int CalcByCanonicalTPQ(
     X->Bind.Def.St=0;
     fprintf(stdoutMPI, "%s", cLogTPQ_Start);
     for (rand_i = 0; rand_i<rand_max; rand_i++){
-        if(X->Bind.Def.iOutputTPQDataHead==1){
+        if(X->Bind.Def.iOutputDataHead==1){
             int prefix_length;
             prefix_length = sprintf(sdt_phys, "%s_", X->Bind.Def.CDataFileHead);
             sprintf(sdt_phys + prefix_length, cFileNameSSRand, rand_i);

--- a/src/CalcByTEM.c
+++ b/src/CalcByTEM.c
@@ -103,7 +103,7 @@ int CalcByTEM(
     }
   }
 
-  if(X->Bind.Def.iOutputTPQDataHead==1){
+  if(X->Bind.Def.iOutputDataHead==1){
     sprintf(sdt_phys, "%s_%s", X->Bind.Def.CDataFileHead, cFileNameSS);
   }else{
     sprintf(sdt_phys, "%s", cFileNameSS);
@@ -114,7 +114,7 @@ int CalcByTEM(
   fprintf(fp, "%s",cLogSS);
   fclose(fp);
 
-  if(X->Bind.Def.iOutputTPQDataHead==1){
+  if(X->Bind.Def.iOutputDataHead==1){
     sprintf(sdt_norm, "%s_%s", X->Bind.Def.CDataFileHead, cFileNameNorm);
   }else{
     sprintf(sdt_norm, "%s", cFileNameNorm);
@@ -125,7 +125,7 @@ int CalcByTEM(
   fprintf(fp, "%s",cLogNorm);
   fclose(fp);
 
-  if(X->Bind.Def.iOutputTPQDataHead==1){
+  if(X->Bind.Def.iOutputDataHead==1){
     sprintf(sdt_flct, "%s_%s", X->Bind.Def.CDataFileHead, cFileNameFlct);
   }else{
     sprintf(sdt_flct, "%s", cFileNameFlct);

--- a/src/CalcByTEM.c
+++ b/src/CalcByTEM.c
@@ -103,21 +103,33 @@ int CalcByTEM(
     }
   }
 
-  sprintf(sdt_phys, "%s", cFileNameSS);
+  if(X->Bind.Def.iOutputTPQDataHead==1){
+    sprintf(sdt_phys, "%s_%s", X->Bind.Def.CDataFileHead, cFileNameSS);
+  }else{
+    sprintf(sdt_phys, "%s", cFileNameSS);
+  }
   if (childfopenMPI(sdt_phys, "w", &fp) != 0) {
     return -1;
   }
   fprintf(fp, "%s",cLogSS);
   fclose(fp);
 
-  sprintf(sdt_norm, "%s", cFileNameNorm);
+  if(X->Bind.Def.iOutputTPQDataHead==1){
+    sprintf(sdt_norm, "%s_%s", X->Bind.Def.CDataFileHead, cFileNameNorm);
+  }else{
+    sprintf(sdt_norm, "%s", cFileNameNorm);
+  }
   if (childfopenMPI(sdt_norm, "w", &fp) != 0) {
     return -1;
   }
   fprintf(fp, "%s",cLogNorm);
   fclose(fp);
 
-  sprintf(sdt_flct, "%s", cFileNameFlct);
+  if(X->Bind.Def.iOutputTPQDataHead==1){
+    sprintf(sdt_flct, "%s_%s", X->Bind.Def.CDataFileHead, cFileNameFlct);
+  }else{
+    sprintf(sdt_flct, "%s", cFileNameFlct);
+  }
   if (childfopenMPI(sdt_flct, "w", &fp) != 0) {
     return -1;
   }

--- a/src/CalcByTPQ.c
+++ b/src/CalcByTPQ.c
@@ -74,7 +74,7 @@ int CalcByTPQ(
   X->Bind.Def.St=0;
   fprintf(stdoutMPI, "%s", cLogTPQ_Start);
   for (rand_i = 0; rand_i<rand_max; rand_i++){
-    if(X->Bind.Def.iOutputTPQDataHead==1){
+    if(X->Bind.Def.iOutputDataHead==1){
       int prefix_length;
       prefix_length = sprintf(sdt_phys, "%s_", X->Bind.Def.CDataFileHead);
       sprintf(sdt_phys + prefix_length, cFileNameSSRand, rand_i);

--- a/src/CalcByTPQ.c
+++ b/src/CalcByTPQ.c
@@ -74,9 +74,19 @@ int CalcByTPQ(
   X->Bind.Def.St=0;
   fprintf(stdoutMPI, "%s", cLogTPQ_Start);
   for (rand_i = 0; rand_i<rand_max; rand_i++){
-    sprintf(sdt_phys, cFileNameSSRand, rand_i);      
-    sprintf(sdt_norm, cFileNameNormRand, rand_i);
-    sprintf(sdt_flct, cFileNameFlctRand, rand_i);
+    if(X->Bind.Def.iOutputTPQDataHead==1){
+      int prefix_length;
+      prefix_length = sprintf(sdt_phys, "%s_", X->Bind.Def.CDataFileHead);
+      sprintf(sdt_phys + prefix_length, cFileNameSSRand, rand_i);
+      prefix_length = sprintf(sdt_norm, "%s_", X->Bind.Def.CDataFileHead);
+      sprintf(sdt_norm + prefix_length, cFileNameNormRand, rand_i);
+      prefix_length = sprintf(sdt_flct, "%s_", X->Bind.Def.CDataFileHead);
+      sprintf(sdt_flct + prefix_length, cFileNameFlctRand, rand_i);
+    }else{
+      sprintf(sdt_phys, cFileNameSSRand, rand_i);
+      sprintf(sdt_norm, cFileNameNormRand, rand_i);
+      sprintf(sdt_flct, cFileNameFlctRand, rand_i);
+    }
     Ns = 1.0 * X->Bind.Def.NsiteMPI;
     fprintf(stdoutMPI, cLogTPQRand, rand_i+1, rand_max);
     iret=0;

--- a/src/CalcSpectrumByTPQ.c
+++ b/src/CalcSpectrumByTPQ.c
@@ -49,7 +49,7 @@ int ReadTPQData(
     double dinv_temp;
     double dene, dHvar, dn, ddoublon;
     int istp;
-    if(X->Bind.Def.iOutputTPQDataHead==1){
+    if(X->Bind.Def.iOutputDataHead==1){
         int prefix_length = sprintf(sdt, "%s_", X->Bind.Def.CDataFileHead);
         sprintf(sdt + prefix_length, cFileNameSSRand, X->Bind.Def.irand);
     }else{

--- a/src/CalcSpectrumByTPQ.c
+++ b/src/CalcSpectrumByTPQ.c
@@ -49,10 +49,15 @@ int ReadTPQData(
     double dinv_temp;
     double dene, dHvar, dn, ddoublon;
     int istp;
-    sprintf(sdt, cFileNameSSRand, X->Bind.Def.irand);
+    if(X->Bind.Def.iOutputTPQDataHead==1){
+        int prefix_length = sprintf(sdt, "%s_", X->Bind.Def.CDataFileHead);
+        sprintf(sdt + prefix_length, cFileNameSSRand, X->Bind.Def.irand);
+    }else{
+        sprintf(sdt, cFileNameSSRand, X->Bind.Def.irand);
+    }
     childfopenMPI(sdt, "r", &fp);
     if(fp==NULL){
-        fprintf(stderr, "  Error:  SS_rand%d.dat does not exist.\n", X->Bind.Def.irand);
+        fprintf(stderr, "  Error:  %s does not exist.\n", sdt);
         fclose(fp);
         return FALSE;
     }

--- a/src/include/struct.h
+++ b/src/include/struct.h
@@ -218,7 +218,7 @@ struct DefineList {
   int iOutputHam;/**<brief Switch for outputting a Hamiltonian. 0: no output, 1:output*/
   int iInputHam;/**<brief Switch for reading a Hamiltonian. 0: no input, 1:input*/
   int iOutputExVec; /**<brief Switch for outputting an excited vector. 0: no output, 1:output*/
-  int iOutputTPQDataHead; /**<brief Switch for using CDataFileHead in output
+  int iOutputDataHead; /**<brief Switch for using CDataFileHead in output
                           file names for TPQ/TE physical quantity files (SS,
                           Flct, Norm). 0: no header (default), 1: use header*/
 

--- a/src/include/struct.h
+++ b/src/include/struct.h
@@ -218,6 +218,9 @@ struct DefineList {
   int iOutputHam;/**<brief Switch for outputting a Hamiltonian. 0: no output, 1:output*/
   int iInputHam;/**<brief Switch for reading a Hamiltonian. 0: no input, 1:input*/
   int iOutputExVec; /**<brief Switch for outputting an excited vector. 0: no output, 1:output*/
+  int iOutputTPQDataHead; /**<brief Switch for using CDataFileHead in output
+                          file names for TPQ/TE physical quantity files (SS,
+                          Flct, Norm). 0: no header (default), 1: use header*/
 
     //[s] For Spectrum
   double complex dcOmegaMax;/**<@brief Upper limit of the frequency for the spectrum.*/

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -251,7 +251,7 @@ int ReadcalcmodFile(
   X->iOutputHam=0;
   X->iInputHam=0;
   X->iOutputExVec = 0;
-  X->iOutputTPQDataHead=0;
+  X->iOutputDataHead=0;
   X->iFlgCalcSpec=0;
   X->iReStart=0;
   X->iFlgMPI=0;
@@ -303,8 +303,8 @@ int ReadcalcmodFile(
     else if(CheckWords(ctmp, "OutputExcitedVec")==0|| CheckWords(ctmp, "OutputExVec")==0){
       X->iOutputExVec=itmp;
     }
-    else if(CheckWords(ctmp, "OutputTPQDataHead")==0){
-      X->iOutputTPQDataHead=itmp;
+    else if(CheckWords(ctmp, "OutputDataHead")==0){
+      X->iOutputDataHead=itmp;
     }
     else if(CheckWords(ctmp, "CalcSpec")==0 || CheckWords(ctmp, "CalcSpectrum")==0){
       X->iFlgCalcSpec=itmp;

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -251,6 +251,7 @@ int ReadcalcmodFile(
   X->iOutputHam=0;
   X->iInputHam=0;
   X->iOutputExVec = 0;
+  X->iOutputTPQDataHead=0;
   X->iFlgCalcSpec=0;
   X->iReStart=0;
   X->iFlgMPI=0;
@@ -301,6 +302,9 @@ int ReadcalcmodFile(
     }
     else if(CheckWords(ctmp, "OutputExcitedVec")==0|| CheckWords(ctmp, "OutputExVec")==0){
       X->iOutputExVec=itmp;
+    }
+    else if(CheckWords(ctmp, "OutputTPQDataHead")==0){
+      X->iOutputTPQDataHead=itmp;
     }
     else if(CheckWords(ctmp, "CalcSpec")==0 || CheckWords(ctmp, "CalcSpectrum")==0){
       X->iFlgCalcSpec=itmp;


### PR DESCRIPTION
SS/Norm/Flctの出力ファイルに`CDataFileHead`をプリペンドを行う対応を行いました。
プレフィックスを追加するかどうかを制御するキーワード`OutputTPQDataHead`をCalcmodに追加し、デフォルトを0(オフ)にしています。
TEでも使えるのでキーワード名が不適切かもしれませんが、他にあまり良い名前が思いつきませんでした。

Closes #174 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an opt-in CalcMod flag that only changes TPQ/TE output filenames (default remains unchanged), but could affect downstream scripts expecting the old names when enabled.
> 
> **Overview**
> Adds a new CalcMod keyword `OutputDataHead` (default `0`) that, when enabled, prefixes TPQ and time-evolution physical-quantity output files (`SS`, `Norm`, `Flct`, including `*_rand*.dat`) with the `CDataFileHead` header.
> 
> Updates TPQ/cTPQ/TEM writers and TPQ spectrum reader to honor the prefixed filenames and improves the missing-file error message to print the computed filename. Documentation is updated in both English and Japanese CalcMod specs to describe the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77d57376340f297093d1d9fed69b3dcc1829f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->