### PR TITLE
Feature/offdiag dynamical green

### DIFF
--- a/doc/en/source/filespecification/expertmode_en/List_file_for_the_input_files_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/List_file_for_the_input_files_en.rst
@@ -76,6 +76,8 @@ Use rules
     "TwoBodyG", "Output components for two-body Green’s functions :math:`\langle c_{i\sigma}^{\dagger}c_{j\sigma}c_{k\tau}^{\dagger}c_{l\tau}\rangle`"
     "SingleExcitation", "Operators for generating a single excited state"
     "PairExcitation", "Operators for generating a pair excited state"
+    "SingleExcitationBra", "Bra single excitation operators for the off-diagonal Green's function"
+    "PairExcitationBra", "Bra pair excitation operators for the off-diagonal Green's function"
     "SpectrumVec", "An input vector to calculate a restart vector"
     "OneBodyTE", "Time-dependent transfer integrals"
     "TwoBodyTE", "Time-dependent two-body interactions"

--- a/doc/en/source/filespecification/expertmode_en/PairExcitationBra_file_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/PairExcitationBra_file_en.rst
@@ -1,0 +1,60 @@
+.. highlight:: none
+
+.. _Subsec:pairexcitationbra:
+
+PairExcitationBra file
+----------------------
+
+The operators :math:`B` to generate the **bra** pair excited state
+:math:`B|\phi\rangle`, used to compute the *off-diagonal* dynamical Green's
+function
+
+.. math::
+
+   G_{BA}(z) = \langle \phi | B^{\dagger} \frac{1}{z-H} A | \phi \rangle ,
+
+where the ket operator :math:`A` is given in
+:doc:`PairExcitation <PairExcitation_file_en>`. If this file is omitted, the
+ordinary diagonal Green's function (:math:`B=A`) is calculated.
+
+The file format and parameters are the same as the
+:doc:`PairExcitation <PairExcitation_file_en>` file; only the keyword for the
+number of operators is ``NPairExcitationBra``. An example
+(a density operator :math:`n_{1\uparrow}` on site 1)::
+
+    ===============================
+    NPairExcitationBra    1
+    ===============================
+    ======= Pair Excitation Bra ====
+    ===============================
+        1     0     1     0     1    1.0    0.0
+
+.. _use_rules_pairexcitationbra:
+
+Use rules
+~~~~~~~~~
+
+*  Headers cannot be omitted; the format and parameters are identical to the
+   :doc:`PairExcitation <PairExcitation_file_en>` file.
+
+*  The operator written here is :math:`B`, **not** :math:`B^{\dagger}`. The
+   computed quantity is :math:`\langle\phi|B^{\dagger}(z-H)^{-1}A|\phi\rangle`.
+
+*  The off-diagonal Green's function is available only with the shifted BiCG
+   method (``method="CG"``) and ``CalcSpec="Normal"`` (restart/save spectrum
+   modes are not supported together with a bra operator).
+
+*  The ket (:doc:`PairExcitation <PairExcitation_file_en>`) and bra operators
+   must map :math:`|\phi\rangle` into the **same** excited Hilbert sector (the
+   same change of particle number and :math:`S_z`). All operators within one
+   file must also share the same sector change. Otherwise the program is
+   terminated.
+
+*  Supported models: Hubbard, Spin, and SpinGC. (Other models are not yet
+   supported for the off-diagonal Green's function; the program is terminated for
+   them.) ``SingleExcitationBra`` and ``PairExcitationBra`` cannot be specified
+   at the same time.
+
+.. raw:: latex
+
+   \newpage

--- a/doc/en/source/filespecification/expertmode_en/SingleExcitationBra_file_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/SingleExcitationBra_file_en.rst
@@ -1,0 +1,58 @@
+.. highlight:: none
+
+.. _Subsec:singleexcitationbra:
+
+SingleExcitationBra file
+------------------------
+
+The operators :math:`B=c_{i\sigma_1}(c_{i\sigma_1}^{\dagger})` to generate the
+**bra** single excited state :math:`B|\phi\rangle`, used to compute the
+*off-diagonal* dynamical Green's function
+
+.. math::
+
+   G_{BA}(z) = \langle \phi | B^{\dagger} \frac{1}{z-H} A | \phi \rangle ,
+
+where the ket operator :math:`A` is given in
+:doc:`SingleExcitation <SingleExcitation_file_en>`. If this file is omitted, the
+ordinary diagonal Green's function (:math:`B=A`) is calculated.
+
+The file format and parameters are the same as the
+:doc:`SingleExcitation <SingleExcitation_file_en>` file; only the keyword for the
+number of operators is ``NSingleExcitationBra``. An example::
+
+    ===============================
+    NSingleExcitationBra    1
+    ===============================
+    ====== Single Excitation Bra ===
+    ===============================
+        0     0     0    1.0    0.0
+
+.. _use_rules_singleexcitationbra:
+
+Use rules
+~~~~~~~~~
+
+*  Headers cannot be omitted; the format and parameters are identical to the
+   :doc:`SingleExcitation <SingleExcitation_file_en>` file.
+
+*  The operator written here is :math:`B`, **not** :math:`B^{\dagger}`. The
+   computed quantity is :math:`\langle\phi|B^{\dagger}(z-H)^{-1}A|\phi\rangle`.
+
+*  The off-diagonal Green's function is available only with the shifted BiCG
+   method (``method="CG"``) and ``CalcSpec="Normal"`` (restart/save spectrum
+   modes are not supported together with a bra operator).
+
+*  The ket (:doc:`SingleExcitation <SingleExcitation_file_en>`) and bra operators
+   must map :math:`|\phi\rangle` into the **same** excited Hilbert sector (the
+   same change of particle number and :math:`S_z`). All operators within one
+   file must also share the same sector change. Otherwise the program is
+   terminated.
+
+*  Supported model: Hubbard. (A single excitation is not defined for spin
+   systems, and other models are not yet supported for the off-diagonal Green's
+   function; the program is terminated for them.)
+
+.. raw:: latex
+
+   \newpage

--- a/doc/en/source/filespecification/expertmode_en/index_expertmode_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/index_expertmode_en.rst
@@ -106,6 +106,12 @@ The following table summarizes all input files for expert mode.
    * - :doc:`PairExcitation <PairExcitation_file_en>`
      - Spectrum
      - Pair excitation operator for dynamical Green's functions
+   * - :doc:`SingleExcitationBra <SingleExcitationBra_file_en>`
+     - Optional
+     - Bra single excitation operator for off-diagonal Green's functions
+   * - :doc:`PairExcitationBra <PairExcitationBra_file_en>`
+     - Optional
+     - Bra pair excitation operator for off-diagonal Green's functions
    * - :doc:`SpectrumVec <SpectrumVec_File_en>`
      - Spectrum
      - Input vector for spectrum calculations
@@ -181,6 +187,8 @@ These files are used for dynamical Green's function calculations and time evolut
 
    SingleExcitation_file_en
    PairExcitation_file_en
+   SingleExcitationBra_file_en
+   PairExcitationBra_file_en
    SpectrumVec_File_en
    OneBodyTE_File_en
    TwoBodyTE_File_en

--- a/doc/ja/source/filespecification/expertmode_ja/List_file_for_the_input_files_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/List_file_for_the_input_files_ja.rst
@@ -79,6 +79,8 @@
     "TwoBodyG", "出力する二体グリーン関数 :math:`\langle c_{i\sigma_1}^{\dagger}c_{j\sigma_2}c_{k\sigma_3}^{\dagger}c_{l\sigma_4}\rangle`\ に関する設定をします。"
     "SingleExcitation", "一体励起状態の生成演算子に関する指定をします。"
     "PairExcitation", "二体励起状態の生成演算子に関する指定をします。"
+    "SingleExcitationBra", "非対角グリーン関数用のブラ側一体励起演算子を指定します。"
+    "PairExcitationBra", "非対角グリーン関数用のブラ側二体励起演算子を指定します。"
     "SpectrumVec", "スペクトル関数を計算するためのリスタート用の入力ベクトルを指定します。"                                                               
     "OneBodyTE", "各時刻で付加される一体型の演算子に関する設定をします。"
     "TwoBodyTE", "各時刻で付加される二体型の演算子に関する設定をします。"

--- a/doc/ja/source/filespecification/expertmode_ja/PairExcitationBra_file_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/PairExcitationBra_file_ja.rst
@@ -1,0 +1,52 @@
+.. highlight:: none
+
+.. _Subsec:pairexcitationbra:
+
+PairExcitationBra指定ファイル
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+非対角動的グリーン関数
+
+.. math::
+
+   G_{BA}(z) = \langle \phi | B^{\dagger} \frac{1}{z-H} A | \phi \rangle
+
+を計算するための\ **ブラ側**\ 二体励起演算子\ :math:`B`\ を定義します。
+ケット側演算子\ :math:`A`\ は\ :doc:`PairExcitation <PairExcitation_file_ja>`\ 指定ファイルで定義します。
+本ファイルを省略した場合は、通常の対角グリーン関数（\ :math:`B=A`\ ）が計算されます。
+
+ファイルフォーマットおよびパラメータは\ :doc:`PairExcitation <PairExcitation_file_ja>`\ 指定ファイルと同一で、
+演算子数のキーワードのみ ``NPairExcitationBra`` です。以下にファイル例（サイト 1 の密度演算子\ :math:`n_{1\uparrow}`\ ）を記載します。
+
+::
+
+    ===============================
+    NPairExcitationBra    1
+    ===============================
+    ======= Pair Excitation Bra ====
+    ===============================
+        1     0     1     0     1    1.0    0.0
+
+.. _use_rules_pairexcitationbra_ja:
+
+使用ルール
+^^^^^^^^^^
+
+*  ヘッダの省略はできません。フォーマット・パラメータは\ :doc:`PairExcitation <PairExcitation_file_ja>`\ と同一です。
+
+*  本ファイルに記載する演算子は\ :math:`B`\ であり\ :math:`B^{\dagger}`\ ではありません
+   （計算される量は\ :math:`\langle\phi|B^{\dagger}(z-H)^{-1}A|\phi\rangle`\ です）。
+
+*  非対角グリーン関数はシフト型 BiCG 法（\ ``method="CG"``\ ）かつ ``CalcSpec="Normal"`` のときのみ利用可能です
+   （ブラ演算子を指定した場合、リスタート・保存系のスペクトルモードは利用できません）。
+
+*  ケット（\ :doc:`PairExcitation <PairExcitation_file_ja>`\ ）とブラの演算子は、\ :math:`|\phi\rangle`\ を
+   \ **同一**\ の励起ヒルベルト空間（粒子数・\ :math:`S_z`\ の変化が同じ）へ写す必要があります。
+   1 つのファイル内の全演算子も同一のセクター変化をもつ必要があります。これを満たさない場合はプログラムが終了します。
+
+*  対応モデル：Hubbard, Spin, SpinGC 模型。（その他の模型は非対角グリーン関数に未対応のため、
+   これらの場合はプログラムが終了します。）``SingleExcitationBra`` と ``PairExcitationBra`` を同時に指定することはできません。
+
+.. raw:: latex
+
+   \newpage

--- a/doc/ja/source/filespecification/expertmode_ja/SingleExcitationBra_file_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/SingleExcitationBra_file_ja.rst
@@ -1,0 +1,52 @@
+.. highlight:: none
+
+.. _Subsec:singleexcitationbra:
+
+SingleExcitationBra指定ファイル
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+非対角動的グリーン関数
+
+.. math::
+
+   G_{BA}(z) = \langle \phi | B^{\dagger} \frac{1}{z-H} A | \phi \rangle
+
+を計算するための\ **ブラ側**\ 一体励起演算子\ :math:`B=c_{i\sigma_1}(c_{i\sigma_1}^{\dagger})`\ を定義します。
+ケット側演算子\ :math:`A`\ は\ :doc:`SingleExcitation <SingleExcitation_file_ja>`\ 指定ファイルで定義します。
+本ファイルを省略した場合は、通常の対角グリーン関数（\ :math:`B=A`\ ）が計算されます。
+
+ファイルフォーマットおよびパラメータは\ :doc:`SingleExcitation <SingleExcitation_file_ja>`\ 指定ファイルと同一で、
+演算子数のキーワードのみ ``NSingleExcitationBra`` です。以下にファイル例を記載します。
+
+::
+
+    ===============================
+    NSingleExcitationBra    1
+    ===============================
+    ====== Single Excitation Bra ===
+    ===============================
+        0     0     0    1.0    0.0
+
+.. _use_rules_singleexcitationbra_ja:
+
+使用ルール
+^^^^^^^^^^
+
+*  ヘッダの省略はできません。フォーマット・パラメータは\ :doc:`SingleExcitation <SingleExcitation_file_ja>`\ と同一です。
+
+*  本ファイルに記載する演算子は\ :math:`B`\ であり\ :math:`B^{\dagger}`\ ではありません
+   （計算される量は\ :math:`\langle\phi|B^{\dagger}(z-H)^{-1}A|\phi\rangle`\ です）。
+
+*  非対角グリーン関数はシフト型 BiCG 法（\ ``method="CG"``\ ）かつ ``CalcSpec="Normal"`` のときのみ利用可能です
+   （ブラ演算子を指定した場合、リスタート・保存系のスペクトルモードは利用できません）。
+
+*  ケット（\ :doc:`SingleExcitation <SingleExcitation_file_ja>`\ ）とブラの演算子は、\ :math:`|\phi\rangle`\ を
+   \ **同一**\ の励起ヒルベルト空間（粒子数・\ :math:`S_z`\ の変化が同じ）へ写す必要があります。
+   1 つのファイル内の全演算子も同一のセクター変化をもつ必要があります。これを満たさない場合はプログラムが終了します。
+
+*  対応モデル：Hubbard 模型。（一体励起はスピン系では定義されず、その他の模型は非対角グリーン関数に未対応のため、
+   これらの場合はプログラムが終了します。）
+
+.. raw:: latex
+
+   \newpage

--- a/doc/ja/source/filespecification/expertmode_ja/index_expertmode_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/index_expertmode_ja.rst
@@ -106,6 +106,12 @@
    * - :doc:`PairExcitation <PairExcitation_file_ja>`
      - スペクトル
      - 動的グリーン関数用のペア励起演算子
+   * - :doc:`SingleExcitationBra <SingleExcitationBra_file_ja>`
+     - オプション
+     - 非対角グリーン関数用のブラ側一粒子励起演算子
+   * - :doc:`PairExcitationBra <PairExcitationBra_file_ja>`
+     - オプション
+     - 非対角グリーン関数用のブラ側ペア励起演算子
    * - :doc:`SpectrumVec <SpectrumVec_File_ja>`
      - スペクトル
      - スペクトル計算用入力ベクトル
@@ -181,6 +187,8 @@
 
    SingleExcitation_file_ja
    PairExcitation_file_ja
+   SingleExcitationBra_file_ja
+   PairExcitationBra_file_ja
    SpectrumVec_File_ja
    OneBodyTE_File_ja
    TwoBodyTE_File_ja

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(HPhi PRIVATE
   CalcSpectrumByTPQ.c CalcSpectrumByFullDiag.c
   SingleEx.c SingleExHubbard.c
   PairEx.c PairExHubbard.c PairExSpin.c PairExSpinless.c
+  ExcitationSectorShift.c
 )
 
 # Time evolution

--- a/src/CalcSpectrum.c
+++ b/src/CalcSpectrum.c
@@ -22,6 +22,7 @@
 #include "CalcTime.h"
 #include "SingleEx.h"
 #include "PairEx.h"
+#include "ExcitationSectorShift.h"
 #include "wrapperMPI.h"
 #include "FileIO.h"
 #include "./common/setmemory.h"
@@ -98,6 +99,7 @@ int CalcSpectrum(
     int iFlagListModified = FALSE;
     FILE *fp;
     double dnorm = 0.0;
+    double complex *v0_Bra = NULL; //!< bra excited state B|phi> for off-diagonal spectrum (NULL = diagonal)
 
     //ToDo: Nomega should be given as a parameter
     int Nomega;
@@ -136,12 +138,48 @@ int CalcSpectrum(
     fprintf(stderr, "Error: Any excitation operators are not defined.\n");
     exitMPI(-1);
   }
-  /* TODO(off-diagonal step 8/9): the bra excitation is not yet wired into the
-     BiCG projection, so accepting it here would silently return the diagonal
-     G_AA. Hard-reject until the off-diagonal call and its guards are added. */
+  /* Off-diagonal (bra) excitation input validation. All checks are bra-gated:
+     with no *Bra input this block is skipped and the diagonal path is unchanged. */
   if (X->Bind.Def.NSingleExcitationOperatorBra > 0 || X->Bind.Def.NPairExcitationOperatorBra > 0) {
-    fprintf(stderr, "Error: SingleExcitationBra/PairExcitationBra (off-diagonal spectrum) is not yet supported in this build.\n");
-    exitMPI(-1);
+    int ketSingle = (X->Bind.Def.NSingleExcitationOperator > 0);
+    int ketPair   = (X->Bind.Def.NPairExcitationOperator > 0);
+    int braSingle = (X->Bind.Def.NSingleExcitationOperatorBra > 0);
+    int braPair   = (X->Bind.Def.NPairExcitationOperatorBra > 0);
+    int isGeneralSpin = X->Bind.Def.iFlgGeneralSpin;
+    int iCalcModel = X->Bind.Def.iCalcModel;
+    SectorShift ketShift, braShift;
+    if (X->Bind.Def.iCalcType != CG) {
+      fprintf(stderr, "Error: off-diagonal (bra) spectrum requires method=\"CG\".\n");
+      exitMPI(-1);
+    }
+    if (braSingle && braPair) {
+      fprintf(stderr, "Error: SingleExcitationBra and PairExcitationBra cannot be used together.\n");
+      exitMPI(-1);
+    }
+    if (ketSingle != braSingle || ketPair != braPair) {
+      fprintf(stderr, "Error: ket and bra excitation operators must be the same type (both single or both pair).\n");
+      exitMPI(-1);
+    }
+    if (ketSingle) {
+      ketShift = GetExcitationOperatorSetShift(iCalcModel, isGeneralSpin, FALSE,
+                   X->Bind.Def.SingleExcitationOperator, X->Bind.Def.NSingleExcitationOperator);
+      braShift = GetExcitationOperatorSetShift(iCalcModel, isGeneralSpin, FALSE,
+                   X->Bind.Def.SingleExcitationOperatorBra, X->Bind.Def.NSingleExcitationOperatorBra);
+    } else {
+      ketShift = GetExcitationOperatorSetShift(iCalcModel, isGeneralSpin, TRUE,
+                   X->Bind.Def.PairExcitationOperator, X->Bind.Def.NPairExcitationOperator);
+      braShift = GetExcitationOperatorSetShift(iCalcModel, isGeneralSpin, TRUE,
+                   X->Bind.Def.PairExcitationOperatorBra, X->Bind.Def.NPairExcitationOperatorBra);
+    }
+    if (ketShift.valid == FALSE || braShift.valid == FALSE) {
+      fprintf(stderr, "Error: off-diagonal spectrum is not supported for this model, or an excitation operator set mixes inconsistent sector shifts.\n");
+      exitMPI(-1);
+    }
+    if (ketShift.dNe != braShift.dNe || ketShift.dNup != braShift.dNup ||
+        ketShift.dNdown != braShift.dNdown || ketShift.dTotal2Sz != braShift.dTotal2Sz) {
+      fprintf(stderr, "Error: ket and bra excitation operators map to different Hilbert sectors (sector mismatch).\n");
+      exitMPI(-1);
+    }
   }
   //Make New Lists
   if (MakeExcitedList(&(X->Bind), &iFlagListModified) == FALSE) {
@@ -225,6 +263,17 @@ int CalcSpectrum(
       v1[i] = v0[i] / dnorm;
     }
 
+    //Build the bra excited state B|phi> (un-normalized) for off-diagonal spectrum.
+    if (X->Bind.Def.NSingleExcitationOperatorBra > 0 || X->Bind.Def.NPairExcitationOperatorBra > 0) {
+      ExcitationOperatorSet braSet = {
+        X->Bind.Def.NSingleExcitationOperatorBra, X->Bind.Def.SingleExcitationOperatorBra,
+        X->Bind.Def.ParaSingleExcitationOperatorBra, X->Bind.Def.NPairExcitationOperatorBra,
+        X->Bind.Def.PairExcitationOperatorBra, X->Bind.Def.ParaPairExcitationOperatorBra};
+      v0_Bra = cd_1d_allocate(X->Bind.Check.idim_max + 1);
+      for (i = 0; i <= X->Bind.Check.idim_max; i++) v0_Bra[i] = 0;
+      GetExcitedState(&(X->Bind), &braSet, v0_Bra, v1Org);
+    }
+
     //Output excited vector
     if (X->Bind.Def.iOutputExVec == 1) {
       fprintf(stdoutMPI, "  Start:   Output an excited vector.\n\n");
@@ -273,7 +322,7 @@ int CalcSpectrum(
 
     case CG:
 
-      iret = CalcSpectrumByBiCG(X, v0, v0, v1, vg, Nomega, dcSpectrum, dcomega);
+      iret = CalcSpectrumByBiCG(X, v0, (v0_Bra != NULL) ? v0_Bra : v0, v1, vg, Nomega, dcSpectrum, dcomega);
 
       if (iret != TRUE) {
         //Error Message will be added.
@@ -301,6 +350,8 @@ int CalcSpectrum(
       break;
   }
   StopTimer(6200);
+
+  if (v0_Bra != NULL) free_cd_1d_allocate(v0_Bra);
 
   if (iret != TRUE) {
     fprintf(stderr, "  Error: The selected calculation type is not supported for calculating spectrum mode.\n");

--- a/src/CalcSpectrum.c
+++ b/src/CalcSpectrum.c
@@ -152,6 +152,10 @@ int CalcSpectrum(
       fprintf(stderr, "Error: off-diagonal (bra) spectrum requires method=\"CG\".\n");
       exitMPI(-1);
     }
+    if (X->Bind.Def.iFlgCalcSpec != RECALC_NOT) {
+      fprintf(stderr, "Error: off-diagonal (bra) spectrum currently requires CalcSpec=\"Normal\" (no restart/save); saved BiCG components carry no bra-operator metadata.\n");
+      exitMPI(-1);
+    }
     if (braSingle && braPair) {
       fprintf(stderr, "Error: SingleExcitationBra and PairExcitationBra cannot be used together.\n");
       exitMPI(-1);
@@ -240,7 +244,10 @@ int CalcSpectrum(
       X->Bind.Def.NSingleExcitationOperator, X->Bind.Def.SingleExcitationOperator,
       X->Bind.Def.ParaSingleExcitationOperator, X->Bind.Def.NPairExcitationOperator,
       X->Bind.Def.PairExcitationOperator, X->Bind.Def.ParaPairExcitationOperator};
-    GetExcitedState(&(X->Bind), &ketSet, v0, v1Org);
+    if (GetExcitedState(&(X->Bind), &ketSet, v0, v1Org) != TRUE) {
+      fprintf(stderr, "Error: failed to build the ket excited state A|phi>.\n");
+      exitMPI(-1);
+    }
     StopTimer(6102);
 
     //calculate norm
@@ -271,7 +278,10 @@ int CalcSpectrum(
         X->Bind.Def.PairExcitationOperatorBra, X->Bind.Def.ParaPairExcitationOperatorBra};
       v0_Bra = cd_1d_allocate(X->Bind.Check.idim_max + 1);
       for (i = 0; i <= X->Bind.Check.idim_max; i++) v0_Bra[i] = 0;
-      GetExcitedState(&(X->Bind), &braSet, v0_Bra, v1Org);
+      if (GetExcitedState(&(X->Bind), &braSet, v0_Bra, v1Org) != TRUE) {
+        fprintf(stderr, "Error: failed to build the bra excited state B|phi>.\n");
+        exitMPI(-1);
+      }
     }
 
     //Output excited vector
@@ -323,6 +333,7 @@ int CalcSpectrum(
     case CG:
 
       iret = CalcSpectrumByBiCG(X, v0, (v0_Bra != NULL) ? v0_Bra : v0, v1, vg, Nomega, dcSpectrum, dcomega);
+      if (v0_Bra != NULL) { free_cd_1d_allocate(v0_Bra); v0_Bra = NULL; }
 
       if (iret != TRUE) {
         //Error Message will be added.

--- a/src/CalcSpectrum.c
+++ b/src/CalcSpectrum.c
@@ -198,7 +198,11 @@ int CalcSpectrum(
 
     //Multiply Operator
     StartTimer(6102);
-    GetExcitedState(&(X->Bind), v0, v1Org);
+    ExcitationOperatorSet ketSet = {
+      X->Bind.Def.NSingleExcitationOperator, X->Bind.Def.SingleExcitationOperator,
+      X->Bind.Def.ParaSingleExcitationOperator, X->Bind.Def.NPairExcitationOperator,
+      X->Bind.Def.PairExcitationOperator, X->Bind.Def.ParaPairExcitationOperator};
+    GetExcitedState(&(X->Bind), &ketSet, v0, v1Org);
     StopTimer(6102);
 
     //calculate norm
@@ -322,21 +326,22 @@ int CalcSpectrum(
 int GetExcitedState
 (
  struct BindStruct *X,
+ const ExcitationOperatorSet *op,
  double complex *tmp_v0,
  double complex *tmp_v1
 ) {
-  if (X->Def.NSingleExcitationOperator > 0 && X->Def.NPairExcitationOperator > 0) {
+  if (op->NSingle > 0 && op->NPair > 0) {
     fprintf(stderr, "Error: Both single and pair excitation operators exist.\n");
     return FALSE;
   }
 
 
-  if (X->Def.NSingleExcitationOperator > 0) {
-    if (GetSingleExcitedState(X, tmp_v0, tmp_v1) != TRUE) {
+  if (op->NSingle > 0) {
+    if (GetSingleExcitedState(X, op->NSingle, op->Single, op->ParaSingle, tmp_v0, tmp_v1) != TRUE) {
       return FALSE;
     }
-  } else if (X->Def.NPairExcitationOperator > 0) {
-    if (GetPairExcitedState(X, tmp_v0, tmp_v1) != TRUE) {
+  } else if (op->NPair > 0) {
+    if (GetPairExcitedState(X, op->NPair, op->Pair, op->ParaPair, tmp_v0, tmp_v1) != TRUE) {
       return FALSE;
     }
   } else {

--- a/src/CalcSpectrum.c
+++ b/src/CalcSpectrum.c
@@ -136,6 +136,13 @@ int CalcSpectrum(
     fprintf(stderr, "Error: Any excitation operators are not defined.\n");
     exitMPI(-1);
   }
+  /* TODO(off-diagonal step 8/9): the bra excitation is not yet wired into the
+     BiCG projection, so accepting it here would silently return the diagonal
+     G_AA. Hard-reject until the off-diagonal call and its guards are added. */
+  if (X->Bind.Def.NSingleExcitationOperatorBra > 0 || X->Bind.Def.NPairExcitationOperatorBra > 0) {
+    fprintf(stderr, "Error: SingleExcitationBra/PairExcitationBra (off-diagonal spectrum) is not yet supported in this build.\n");
+    exitMPI(-1);
+  }
   //Make New Lists
   if (MakeExcitedList(&(X->Bind), &iFlagListModified) == FALSE) {
     return FALSE;

--- a/src/CalcSpectrum.c
+++ b/src/CalcSpectrum.c
@@ -175,8 +175,18 @@ int CalcSpectrum(
       braShift = GetExcitationOperatorSetShift(iCalcModel, isGeneralSpin, TRUE,
                    X->Bind.Def.PairExcitationOperatorBra, X->Bind.Def.NPairExcitationOperatorBra);
     }
-    if (ketShift.valid == FALSE || braShift.valid == FALSE) {
-      fprintf(stderr, "Error: off-diagonal spectrum is not supported for this model, or an excitation operator set mixes inconsistent sector shifts.\n");
+    if (ketShift.valid == FALSE) {
+      if (ketShift.reason == OFFDIAG_SHIFT_SET_INCONSISTENT)
+        fprintf(stderr, "Error: the ket excitation operator set mixes operators with different Hilbert-sector shifts.\n");
+      else
+        fprintf(stderr, "Error: off-diagonal spectrum is not supported for this model / ket excitation operator.\n");
+      exitMPI(-1);
+    }
+    if (braShift.valid == FALSE) {
+      if (braShift.reason == OFFDIAG_SHIFT_SET_INCONSISTENT)
+        fprintf(stderr, "Error: the bra excitation operator set mixes operators with different Hilbert-sector shifts.\n");
+      else
+        fprintf(stderr, "Error: off-diagonal spectrum is not supported for this model / bra excitation operator.\n");
       exitMPI(-1);
     }
     if (ketShift.dNe != braShift.dNe || ketShift.dNup != braShift.dNup ||
@@ -281,6 +291,9 @@ int CalcSpectrum(
       if (GetExcitedState(&(X->Bind), &braSet, v0_Bra, v1Org) != TRUE) {
         fprintf(stderr, "Error: failed to build the bra excited state B|phi>.\n");
         exitMPI(-1);
+      }
+      if (NormMPI_dc(X->Bind.Check.idim_max, v0_Bra) < pow(10.0, -15)) {
+        fprintf(stderr, "Warning: Norm of the bra excited vector B|phi> is 0; the off-diagonal spectrum will be zero.\n");
       }
     }
 

--- a/src/CalcSpectrum.c
+++ b/src/CalcSpectrum.c
@@ -262,7 +262,7 @@ int CalcSpectrum(
 
     case CG:
 
-      iret = CalcSpectrumByBiCG(X, v0, v1, vg, Nomega, dcSpectrum, dcomega);
+      iret = CalcSpectrumByBiCG(X, v0, v0, v1, vg, Nomega, dcSpectrum, dcomega);
 
       if (iret != TRUE) {
         //Error Message will be added.

--- a/src/CalcSpectrumByBiCG.c
+++ b/src/CalcSpectrumByBiCG.c
@@ -207,7 +207,8 @@ void InitShadowRes(
  */
 int CalcSpectrumByBiCG(
   struct EDMainCalStruct *X,//!<[inout]
-  double complex *vrhs,//!<[in] [CheckList::idim_max] Right hand side vector, excited state.
+  double complex *vrhs,//!<[in] [CheckList::idim_max] Right hand side vector, excited (ket) state A|phi>.
+  double complex *vlhs_Bra,//!<[in] [CheckList::idim_max] Left (bra) state B|phi> used for the projection <B phi|r>. Pass vrhs for the diagonal G_AA.
   double complex *v2,//!<[inout] [CheckList::idim_max] Work space for residual vector @f${\bf r}@f$
   double complex *v4,//!<[inout] [CheckList::idim_max] Work space for shadow residual vector @f${\bf {\tilde r}}@f$
   int Nomega,//!<[in] Number of Frequencies
@@ -310,7 +311,7 @@ int CalcSpectrumByBiCG(
     iret = mltply(&X->Bind, v14, v4);
     if (iret == -1) return FALSE;
 
-    res_proj = VecProdMPI(X->Bind.Check.idim_max, vrhs, v2);
+    res_proj = VecProdMPI(X->Bind.Check.idim_max, vlhs_Bra, v2);
     /**
     <li>Update projected result vector dcSpectrum.</li>
     */

--- a/src/ExcitationSectorShift.c
+++ b/src/ExcitationSectorShift.c
@@ -35,7 +35,7 @@
 #include "ExcitationSectorShift.h"
 
 SectorShift GetExcitationSectorShift(int iCalcModel, int isGeneralSpin, int isPair, const int *op) {
-  SectorShift s = {0, 0, 0, 0, TRUE};
+  SectorShift s = {0, 0, 0, 0, TRUE, OFFDIAG_SHIFT_OK};
 
   if (isPair == FALSE) {
     const int spin = op[1];                /* 0 = up, 1 = down */
@@ -107,12 +107,15 @@ SectorShift GetExcitationSectorShift(int iCalcModel, int isGeneralSpin, int isPa
       break;
     }
   }
+  /* A single operator row can only be invalid because the model/operator is
+     not in the allow-list (set-internal inconsistency needs >= 2 rows). */
+  s.reason = (s.valid == TRUE) ? OFFDIAG_SHIFT_OK : OFFDIAG_SHIFT_MODEL_NOT_ALLOWED;
   return s;
 }
 
 SectorShift GetExcitationOperatorSetShift(int iCalcModel, int isGeneralSpin, int isPair,
                                           int **op, int nOp) {
-  SectorShift acc = {0, 0, 0, 0, FALSE};
+  SectorShift acc = {0, 0, 0, 0, FALSE, OFFDIAG_SHIFT_MODEL_NOT_ALLOWED};
   int i;
 
   if (nOp <= 0) return acc; /* empty set: valid=FALSE */
@@ -121,6 +124,7 @@ SectorShift GetExcitationOperatorSetShift(int iCalcModel, int isGeneralSpin, int
     SectorShift cur = GetExcitationSectorShift(iCalcModel, isGeneralSpin, isPair, op[i]);
     if (cur.valid == FALSE) {
       acc.valid = FALSE;
+      acc.reason = cur.reason; /* model/operator not allowed */
       return acc;
     }
     if (i == 0) {
@@ -128,6 +132,7 @@ SectorShift GetExcitationOperatorSetShift(int iCalcModel, int isGeneralSpin, int
     } else if (acc.dNe != cur.dNe || acc.dNup != cur.dNup ||
                acc.dNdown != cur.dNdown || acc.dTotal2Sz != cur.dTotal2Sz) {
       acc.valid = FALSE; /* rows disagree on sector shift */
+      acc.reason = OFFDIAG_SHIFT_SET_INCONSISTENT;
       return acc;
     }
   }

--- a/src/ExcitationSectorShift.c
+++ b/src/ExcitationSectorShift.c
@@ -1,0 +1,135 @@
+/* HPhi  -  Quantum Lattice Model Simulator */
+/* Copyright (C) 2015 Takahiro Misawa, Kazuyoshi Yoshimi, Mitsuaki Kawamura, Youhei Yamaji, Synge Todo, Naoki Kawashima */
+
+/* This program is free software: you can redistribute it and/or modify */
+/* it under the terms of the GNU General Public License as published by */
+/* the Free Software Foundation, either version 3 of the License, or */
+/* (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the */
+/* GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License */
+/* along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+/**@file
+ * @brief Sector-shift truth table for off-diagonal dynamical Green functions.
+ *
+ * The shift returned here mirrors the *net* sector change applied by
+ * MakeExcitedList() (src/CalcSpectrum.c). Note that MakeExcitedList's second
+ * switch runs only when iFlgListModifed==TRUE, so several GC/NConserved
+ * branches inside it are dead code. The net behavior is:
+ *   - single: HubbardGC -> none; Spin/SpinGC -> N/A;
+ *             Hubbard/Kondo/KondoGC/tJ/tJGC/(Hubbard|tJ)NConserved -> shift.
+ *   - pair:   all GC (incl. KondoGC/tJGC) + NConserved -> none;
+ *             Hubbard/Kondo/tJ -> off-diagonal-spin shift; Spin -> shift.
+ *
+ * v1 off-diagonal allow-list = {Hubbard, Spin, SpinGC}. Models outside the
+ * allow-list return valid=FALSE here (the allow-list guard rejects them); their
+ * exact shift is encoded together with a dedicated test when a model is
+ * promoted into the allow-list.
+ */
+#include "Common.h"
+#include "ExcitationSectorShift.h"
+
+SectorShift GetExcitationSectorShift(int iCalcModel, int isGeneralSpin, int isPair, const int *op) {
+  SectorShift s = {0, 0, 0, 0, TRUE};
+
+  if (isPair == FALSE) {
+    const int spin = op[1];                /* 0 = up, 1 = down */
+    const int isCreation = (op[2] == 1);   /* type==1 -> cis (creation), else ajt (annihilation) */
+    switch (iCalcModel) {
+    case Hubbard: /* v1 allow-list (CalcSpectrum.c:537-562; spin 0 == up) */
+      if (isCreation) {
+        s.dNe = +1;
+        if (spin == 0) s.dNup = +1; else s.dNdown = +1;
+      } else {
+        s.dNe = -1;
+        if (spin == 0) s.dNup = -1; else s.dNdown = -1;
+      }
+      break;
+    case Spin:
+    case SpinGC: /* single excitation N/A for spin (CalcSpectrum.c:563-565, SingleEx.c:54) */
+      s.valid = FALSE;
+      break;
+    case Kondo:
+    case KondoGC:
+    case tJ:
+    case tJGC:
+    case HubbardGC:
+    case HubbardNConserved:
+    case tJNConserved:
+    case KondoNConserved:
+      /* deferred: not in v1 allow-list (rejected upstream by the allow-list guard) */
+      s.valid = FALSE;
+      break;
+    default:
+      s.valid = FALSE;
+      break;
+    }
+  } else {
+    const int spin1 = op[1];
+    const int spin2 = op[3];
+    switch (iCalcModel) {
+    case Hubbard: /* v1 allow-list (CalcSpectrum.c:576-590; spin 0 == up) */
+      if (spin1 != spin2) {
+        if (spin1 == 0) { s.dNup = +1; s.dNdown = -1; }
+        else            { s.dNup = -1; s.dNdown = +1; }
+      }
+      break;
+    case SpinGC: /* v1 allow-list: full grand-canonical space, no shift */
+      break;
+    case Spin: /* v1 allow-list; NOTE: spin convention is opposite to Hubbard (CalcSpectrum.c:591-606) */
+      if (spin1 != spin2) {
+        if (isGeneralSpin == FALSE) {
+          if (spin1 == 0) { s.dNup = -1; s.dNdown = +1; }  /* CalcSpectrum.c:594 //down */
+          else            { s.dNup = +1; s.dNdown = -1; }  /* CalcSpectrum.c:597 //up   */
+        } else {
+          s.dTotal2Sz = 2 * (spin1 - spin2);               /* CalcSpectrum.c:603 */
+        }
+      }
+      break;
+    case Kondo:
+    case KondoGC:
+    case tJ:
+    case tJGC:
+    case HubbardGC:
+    case HubbardNConserved:
+    case tJNConserved:
+    case KondoNConserved:
+      /* deferred: not in v1 allow-list (rejected upstream by the allow-list guard) */
+      s.valid = FALSE;
+      break;
+    default:
+      s.valid = FALSE;
+      break;
+    }
+  }
+  return s;
+}
+
+SectorShift GetExcitationOperatorSetShift(int iCalcModel, int isGeneralSpin, int isPair,
+                                          int **op, int nOp) {
+  SectorShift acc = {0, 0, 0, 0, FALSE};
+  int i;
+
+  if (nOp <= 0) return acc; /* empty set: valid=FALSE */
+
+  for (i = 0; i < nOp; i++) {
+    SectorShift cur = GetExcitationSectorShift(iCalcModel, isGeneralSpin, isPair, op[i]);
+    if (cur.valid == FALSE) {
+      acc.valid = FALSE;
+      return acc;
+    }
+    if (i == 0) {
+      acc = cur;
+    } else if (acc.dNe != cur.dNe || acc.dNup != cur.dNup ||
+               acc.dNdown != cur.dNdown || acc.dTotal2Sz != cur.dTotal2Sz) {
+      acc.valid = FALSE; /* rows disagree on sector shift */
+      return acc;
+    }
+  }
+  return acc; /* valid=TRUE; shift is common to all rows */
+}

--- a/src/PairEx.c
+++ b/src/PairEx.c
@@ -47,6 +47,9 @@
 int GetPairExcitedState
 (
  struct BindStruct *X,
+ unsigned int NPairExcitationOperator,
+ int **PairExcitationOperator,
+ double complex *ParaPairExcitationOperator,
  double complex *tmp_v0,
  double complex *tmp_v1
  )
@@ -82,23 +85,23 @@ int GetPairExcitedState
   case tJGC:
   case Kondo:
   case KondoGC:
-      iret=GetPairExcitedStateHubbard(X, X->Def.NPairExcitationOperator,
-                                      X->Def.PairExcitationOperator,
-                                      X->Def.ParaPairExcitationOperator,
+      iret=GetPairExcitedStateHubbard(X, NPairExcitationOperator,
+                                      PairExcitationOperator,
+                                      ParaPairExcitationOperator,
                                       tmp_v0, tmp_v1);
     break;
 
     case Spin: // for the Sz-conserved spin system
-      iret =GetPairExcitedStateSpin(X, X->Def.NPairExcitationOperator,
-                                    X->Def.PairExcitationOperator,
-                                    X->Def.ParaPairExcitationOperator,
+      iret =GetPairExcitedStateSpin(X, NPairExcitationOperator,
+                                    PairExcitationOperator,
+                                    ParaPairExcitationOperator,
                                     tmp_v0, tmp_v1);
       break;
 
     case SpinGC:
-      iret=GetPairExcitedStateSpinGC(X, X->Def.NPairExcitationOperator,
-                                     X->Def.PairExcitationOperator,
-                                     X->Def.ParaPairExcitationOperator,
+      iret=GetPairExcitedStateSpinGC(X, NPairExcitationOperator,
+                                     PairExcitationOperator,
+                                     ParaPairExcitationOperator,
                                      tmp_v0, tmp_v1);
       break;
 

--- a/src/PairEx.c
+++ b/src/PairEx.c
@@ -89,11 +89,17 @@ int GetPairExcitedState
     break;
 
     case Spin: // for the Sz-conserved spin system
-      iret =GetPairExcitedStateSpin(X, tmp_v0, tmp_v1);
+      iret =GetPairExcitedStateSpin(X, X->Def.NPairExcitationOperator,
+                                    X->Def.PairExcitationOperator,
+                                    X->Def.ParaPairExcitationOperator,
+                                    tmp_v0, tmp_v1);
       break;
 
     case SpinGC:
-      iret=GetPairExcitedStateSpinGC(X,tmp_v0, tmp_v1);
+      iret=GetPairExcitedStateSpinGC(X, X->Def.NPairExcitationOperator,
+                                     X->Def.PairExcitationOperator,
+                                     X->Def.ParaPairExcitationOperator,
+                                     tmp_v0, tmp_v1);
       break;
 
     case SpinlessFermion:

--- a/src/PairEx.c
+++ b/src/PairEx.c
@@ -82,7 +82,10 @@ int GetPairExcitedState
   case tJGC:
   case Kondo:
   case KondoGC:
-      iret=GetPairExcitedStateHubbard(X, tmp_v0, tmp_v1);
+      iret=GetPairExcitedStateHubbard(X, X->Def.NPairExcitationOperator,
+                                      X->Def.PairExcitationOperator,
+                                      X->Def.ParaPairExcitationOperator,
+                                      tmp_v0, tmp_v1);
     break;
 
     case Spin: // for the Sz-conserved spin system

--- a/src/PairExHubbard.c
+++ b/src/PairExHubbard.c
@@ -136,6 +136,9 @@ int GetPairExcitedStateHubbardGC(
 /// \version 1.2
 int GetPairExcitedStateHubbard(
         struct BindStruct *X,/**< [inout] define list to get and put information of calculation*/
+        unsigned int NPairExcitationOperator,/**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator,/**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator,/**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 ){
@@ -170,12 +173,12 @@ int GetPairExcitedStateHubbard(
     tmp_v1bufOrg= cd_1d_allocate(idim_maxMPI + 1);
 #endif // MPI
 
-    for(i=0;i<X->Def.NPairExcitationOperator;i++){
-        org_isite1 = X->Def.PairExcitationOperator[i][0]+1;
-        org_isite2 = X->Def.PairExcitationOperator[i][2]+1;
-        org_sigma1 = X->Def.PairExcitationOperator[i][1];
-        org_sigma2 = X->Def.PairExcitationOperator[i][3];
-        tmp_trans = X->Def.ParaPairExcitationOperator[i];
+    for(i=0;i<NPairExcitationOperator;i++){
+        org_isite1 = PairExcitationOperator[i][0]+1;
+        org_isite2 = PairExcitationOperator[i][2]+1;
+        org_sigma1 = PairExcitationOperator[i][1];
+        org_sigma2 = PairExcitationOperator[i][3];
+        tmp_trans = ParaPairExcitationOperator[i];
         ibitsite1 = X->Def.OrgTpow[2*org_isite1-2+org_sigma1] ;
         ibitsite2 = X->Def.OrgTpow[2*org_isite2-2+org_sigma2] ;
         general_hopp_GetInfo(X, org_isite1, org_isite2, org_sigma1, org_sigma2);
@@ -215,7 +218,7 @@ int GetPairExcitedStateHubbard(
                 if(org_isite1==org_isite2 && org_sigma1==org_sigma2){//diagonal
                     is = X->Def.Tpow[2 * org_isite1 - 2 + org_sigma1];
                     ibit = (unsigned long int) myrank & is;
-                    if( X->Def.PairExcitationOperator[i][4]==0) {
+                    if( PairExcitationOperator[i][4]==0) {
                         if (ibit != is) {
 #pragma omp parallel for default(none) shared(tmp_v0, tmp_v1)	\
   firstprivate(i_max, tmp_trans) private(j)
@@ -248,7 +251,7 @@ int GetPairExcitedStateHubbard(
                 }
                 if(org_isite1==org_isite2 && org_sigma1==org_sigma2){
                     is = X->Def.Tpow[2 * org_isite1 - 2 + org_sigma1];
-                    if( X->Def.PairExcitationOperator[i][4]==0) {
+                    if( PairExcitationOperator[i][4]==0) {
 #pragma omp parallel for default(none) shared(list_1, tmp_v0, tmp_v1) firstprivate(i_max, is, tmp_trans) private(num1, ibit)
                         for (j = 1; j <= i_max; j++) {
                             ibit = list_1[j] & is;

--- a/src/PairExSpin.c
+++ b/src/PairExSpin.c
@@ -34,6 +34,9 @@
 /// \version 1.2
 int GetPairExcitedStateSpinGC(
         struct BindStruct *X,/**< [in,out] define list to get and put information of calculation*/
+        unsigned int NPairExcitationOperator,/**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator,/**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator,/**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -41,10 +44,12 @@ int GetPairExcitedStateSpinGC(
 
     int iret=0;
     if (X->Def.iFlgGeneralSpin == FALSE) {
-        iret=GetPairExcitedStateHalfSpinGC(X, tmp_v0, tmp_v1);
+        iret=GetPairExcitedStateHalfSpinGC(X, NPairExcitationOperator, PairExcitationOperator,
+                                           ParaPairExcitationOperator, tmp_v0, tmp_v1);
     }
     else{
-        iret=GetPairExcitedStateGeneralSpinGC(X, tmp_v0, tmp_v1);
+        iret=GetPairExcitedStateGeneralSpinGC(X, NPairExcitationOperator, PairExcitationOperator,
+                                              ParaPairExcitationOperator, tmp_v0, tmp_v1);
     }
     return iret;
 }
@@ -61,6 +66,9 @@ int GetPairExcitedStateSpinGC(
 /// \version 1.2
 int GetPairExcitedStateHalfSpinGC(
         struct BindStruct *X,/**< [in,out] define list to get and put information of calculation*/
+        unsigned int NPairExcitationOperator,/**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator,/**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator,/**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -75,16 +83,16 @@ int GetPairExcitedStateHalfSpinGC(
     int tmp_sgn;
     i_max = X->Check.idim_maxOrg;
 
-    for(i=0;i<X->Def.NPairExcitationOperator;i++){
-        org_isite1 = X->Def.PairExcitationOperator[i][0]+1;
-        org_isite2 = X->Def.PairExcitationOperator[i][2]+1;
-        org_sigma1 = X->Def.PairExcitationOperator[i][1];
-        org_sigma2 = X->Def.PairExcitationOperator[i][3];
-        tmp_trans = X->Def.ParaPairExcitationOperator[i];
+    for(i=0;i<NPairExcitationOperator;i++){
+        org_isite1 = PairExcitationOperator[i][0]+1;
+        org_isite2 = PairExcitationOperator[i][2]+1;
+        org_sigma1 = PairExcitationOperator[i][1];
+        org_sigma2 = PairExcitationOperator[i][3];
+        tmp_trans = ParaPairExcitationOperator[i];
         if(org_isite1 == org_isite2){
             if(org_isite1 > X->Def.Nsite){
                 if(org_sigma1==org_sigma2){  // longitudinal magnetic field
-                    if(X->Def.PairExcitationOperator[i][4]==0) {
+                    if(PairExcitationOperator[i][4]==0) {
                         child_GC_AisCis_spin_MPIdouble(org_isite1 - 1, org_sigma1, -tmp_trans, X, tmp_v0, tmp_v1);
                     }
                     else{
@@ -98,7 +106,7 @@ int GetPairExcitedStateHalfSpinGC(
             }else{
                 isite1 = X->Def.Tpow[org_isite1-1];
                 if(org_sigma1==org_sigma2) {
-                    if (X->Def.PairExcitationOperator[i][4] == 0) {
+                    if (PairExcitationOperator[i][4] == 0) {
                         // longitudinal magnetic field
 #pragma omp parallel for default(none) private(j, tmp_sgn) firstprivate(i_max, isite1, org_sigma1, X,tmp_trans) shared(tmp_v0, tmp_v1)
                         for (j = 1; j <= i_max; j++) {
@@ -143,6 +151,9 @@ int GetPairExcitedStateHalfSpinGC(
 /// \version 1.2
 int GetPairExcitedStateGeneralSpinGC(
         struct BindStruct *X,/**< [in,out] define list to get and put information of calculation*/
+        unsigned int NPairExcitationOperator,/**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator,/**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator,/**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -156,16 +167,16 @@ int GetPairExcitedStateGeneralSpinGC(
     long int i_max;
     i_max = X->Check.idim_maxOrg;
 
-    for(i=0;i<X->Def.NPairExcitationOperator;i++){
-        org_isite1 = X->Def.PairExcitationOperator[i][0]+1;
-        org_isite2 = X->Def.PairExcitationOperator[i][2]+1;
-        org_sigma1 = X->Def.PairExcitationOperator[i][1];
-        org_sigma2 = X->Def.PairExcitationOperator[i][3];
-        tmp_trans = X->Def.ParaPairExcitationOperator[i];
+    for(i=0;i<NPairExcitationOperator;i++){
+        org_isite1 = PairExcitationOperator[i][0]+1;
+        org_isite2 = PairExcitationOperator[i][2]+1;
+        org_sigma1 = PairExcitationOperator[i][1];
+        org_sigma2 = PairExcitationOperator[i][3];
+        tmp_trans = ParaPairExcitationOperator[i];
         if(org_isite1 == org_isite2){
             if(org_isite1 > X->Def.Nsite){
                 if(org_sigma1==org_sigma2){
-                    if(X->Def.PairExcitationOperator[i][4]==0) {
+                    if(PairExcitationOperator[i][4]==0) {
                         // longitudinal magnetic field
                         child_GC_AisCis_GeneralSpin_MPIdouble(org_isite1 - 1, org_sigma1, -tmp_trans, X, tmp_v0, tmp_v1);
                     }
@@ -179,7 +190,7 @@ int GetPairExcitedStateGeneralSpinGC(
             }
             else{//org_isite1 <= X->Def.Nsite
                 if(org_sigma1==org_sigma2){
-                    if(X->Def.PairExcitationOperator[i][4]==0) {
+                    if(PairExcitationOperator[i][4]==0) {
                         // longitudinal magnetic field
 #pragma omp parallel for default(none) private(j, num1) firstprivate(i_max, org_isite1, org_sigma1, X, tmp_trans) shared(tmp_v0, tmp_v1)
                         for (j = 1; j <= i_max; j++) {
@@ -225,16 +236,21 @@ int GetPairExcitedStateGeneralSpinGC(
 /// \version 1.2
 int GetPairExcitedStateSpin(
         struct BindStruct *X,/**< [in,out] define list to get and put information of calculation*/
+        unsigned int NPairExcitationOperator,/**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator,/**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator,/**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
 ){
     int iret=0;
     if (X->Def.iFlgGeneralSpin == FALSE) {
-        iret=GetPairExcitedStateHalfSpin(X, tmp_v0, tmp_v1);
+        iret=GetPairExcitedStateHalfSpin(X, NPairExcitationOperator, PairExcitationOperator,
+                                         ParaPairExcitationOperator, tmp_v0, tmp_v1);
     }
     else{
-        iret=GetPairExcitedStateGeneralSpin(X, tmp_v0, tmp_v1);
+        iret=GetPairExcitedStateGeneralSpin(X, NPairExcitationOperator, PairExcitationOperator,
+                                            ParaPairExcitationOperator, tmp_v0, tmp_v1);
     }
     return iret;
 }
@@ -250,6 +266,9 @@ int GetPairExcitedStateSpin(
 /// \version 1.2
 int GetPairExcitedStateHalfSpin(
         struct BindStruct *X,/**< [in,out] define list to get and put information of calculation*/
+        unsigned int NPairExcitationOperator,/**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator,/**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator,/**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -275,18 +294,18 @@ int GetPairExcitedStateHalfSpin(
     tmp_v1bufOrg=cd_1d_allocate(idim_maxMPI + 1);
 #endif // MPI
 
-    for (i = 0; i < X->Def.NPairExcitationOperator; i++) {
-        org_isite1 = X->Def.PairExcitationOperator[i][0] + 1;
-        org_isite2 = X->Def.PairExcitationOperator[i][2] + 1;
-        org_sigma1 = X->Def.PairExcitationOperator[i][1];
-        org_sigma2 = X->Def.PairExcitationOperator[i][3];
-        tmp_trans = X->Def.ParaPairExcitationOperator[i];
+    for (i = 0; i < NPairExcitationOperator; i++) {
+        org_isite1 = PairExcitationOperator[i][0] + 1;
+        org_isite2 = PairExcitationOperator[i][2] + 1;
+        org_sigma1 = PairExcitationOperator[i][1];
+        org_sigma2 = PairExcitationOperator[i][3];
+        tmp_trans = ParaPairExcitationOperator[i];
         if (org_sigma1 == org_sigma2) {
             if (org_isite1 == org_isite2) {
                 if (org_isite1 > X->Def.Nsite) {
                     is1_up = X->Def.Tpow[org_isite1 - 1];
                     ibit1 = child_SpinGC_CisAis((unsigned long int) myrank + 1, X, is1_up, org_sigma1);
-                    if (X->Def.PairExcitationOperator[i][4] == 0) {
+                    if (PairExcitationOperator[i][4] == 0) {
                         if (ibit1 == 0) {
 #pragma omp parallel for default(none) shared(tmp_v0, tmp_v1)	\
   firstprivate(i_max, tmp_trans) private(j)
@@ -303,7 +322,7 @@ int GetPairExcitedStateHalfSpin(
                 else {
                     isite1 = X->Def.Tpow[org_isite1 - 1];
                     if (org_isite1 == org_isite2 && org_sigma1 == org_sigma2 &&
-                        X->Def.PairExcitationOperator[i][4] == 0) {
+                        PairExcitationOperator[i][4] == 0) {
 #pragma omp parallel for default(none) private(j) firstprivate(i_max, isite1, org_sigma1, X, tmp_trans) shared(tmp_v0, tmp_v1)
                         for (j = 1; j <= i_max; j++) {
                             tmp_v0[j] += (1.0 - child_Spin_CisAis(j, X, isite1, org_sigma1)) * tmp_v1[j] * (-tmp_trans);
@@ -352,6 +371,9 @@ int GetPairExcitedStateHalfSpin(
 /// \version 1.2
 int GetPairExcitedStateGeneralSpin(
         struct BindStruct *X,/**< [in,out] define list to get and put information of calculation*/
+        unsigned int NPairExcitationOperator,/**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator,/**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator,/**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -374,19 +396,19 @@ int GetPairExcitedStateGeneralSpin(
     tmp_v1bufOrg = cd_1d_allocate(idim_maxMPI + 1);
 #endif // MPI
 
-    for(i=0;i<X->Def.NPairExcitationOperator;i++) {
-        org_isite1 = X->Def.PairExcitationOperator[i][0] + 1;
-        org_isite2 = X->Def.PairExcitationOperator[i][2] + 1;
-        org_sigma1 = X->Def.PairExcitationOperator[i][1];
-        org_sigma2 = X->Def.PairExcitationOperator[i][3];
-        tmp_trans = X->Def.ParaPairExcitationOperator[i];
+    for(i=0;i<NPairExcitationOperator;i++) {
+        org_isite1 = PairExcitationOperator[i][0] + 1;
+        org_isite2 = PairExcitationOperator[i][2] + 1;
+        org_sigma1 = PairExcitationOperator[i][1];
+        org_sigma2 = PairExcitationOperator[i][3];
+        tmp_trans = ParaPairExcitationOperator[i];
         if (org_isite1 == org_isite2) {
             if (org_isite1 > X->Def.Nsite) {
                 if (org_sigma1 == org_sigma2) {
                     // longitudinal magnetic field
                     num1 = BitCheckGeneral((unsigned long int) myrank,
                                            org_isite1, org_sigma1, X->Def.SiteToBit, X->Def.Tpow);
-                    if (X->Def.PairExcitationOperator[i][4] == 0) {
+                    if (PairExcitationOperator[i][4] == 0) {
                         if (num1 == 0) {
 #pragma omp parallel for default(none) private(j) firstprivate(i_max, tmp_trans) shared(tmp_v0, tmp_v1)
                             for (j = 1; j <= i_max; j++) {
@@ -410,7 +432,7 @@ int GetPairExcitedStateGeneralSpin(
             } else {//org_isite1 <= X->Def.Nsite
                 if (org_sigma1 == org_sigma2) {
                     // longitudinal magnetic field
-                    if (X->Def.PairExcitationOperator[i][4] == 0) {
+                    if (PairExcitationOperator[i][4] == 0) {
 #pragma omp parallel for default(none) private(j, num1) firstprivate(i_max, org_isite1, org_sigma1, X, tmp_trans) shared(tmp_v0, tmp_v1, list_1)
                         for (j = 1; j <= i_max; j++) {
                             num1 = BitCheckGeneral(list_1[j], org_isite1, org_sigma1, X->Def.SiteToBit, X->Def.Tpow);

--- a/src/SingleEx.c
+++ b/src/SingleEx.c
@@ -29,12 +29,19 @@ Target System: Hubbard, Kondo
 */
 int GetSingleExcitedState(
   struct BindStruct *X,//!<define list to get and put information of calcuation
+  unsigned int NSingleExcitationOperator,//!<[in] number of single excitation operators
+  int **SingleExcitationOperator,//!<[in] [n][3] = {site, spin, type}
+  double complex *ParaSingleExcitationOperator,//!<[in] coefficient of each operator
   double complex *tmp_v0,//!<[out] Result v0 = H v1
   double complex *tmp_v1//!<[in] v0 = H v1
 ) {
   int iret = 0;
   //tmp_v0
-  if (X->Def.NSingleExcitationOperator == 0) return TRUE;
+  /* NOTE: the GC leaf below is not operator-set parametrized and reads X->Def,
+     so the passed set must equal X->Def for that model. This holds for the
+     diagonal ket path; the bra path only reaches the parametrized Hubbard leaf
+     (Spin/SpinGC single excitation is rejected). */
+  if (NSingleExcitationOperator == 0) return TRUE;
 
   switch (X->Def.iCalcModel) {
   case HubbardGC:
@@ -46,9 +53,9 @@ int GetSingleExcitedState(
   case KondoGC:
   case tJ:
   case tJGC:
-    iret = GetSingleExcitedStateHubbard(X, X->Def.NSingleExcitationOperator,
-                                        X->Def.SingleExcitationOperator,
-                                        X->Def.ParaSingleExcitationOperator,
+    iret = GetSingleExcitedStateHubbard(X, NSingleExcitationOperator,
+                                        SingleExcitationOperator,
+                                        ParaSingleExcitationOperator,
                                         tmp_v0, tmp_v1);
     break;
 

--- a/src/SingleEx.c
+++ b/src/SingleEx.c
@@ -46,7 +46,10 @@ int GetSingleExcitedState(
   case KondoGC:
   case tJ:
   case tJGC:
-    iret = GetSingleExcitedStateHubbard(X, tmp_v0, tmp_v1);
+    iret = GetSingleExcitedStateHubbard(X, X->Def.NSingleExcitationOperator,
+                                        X->Def.SingleExcitationOperator,
+                                        X->Def.ParaSingleExcitationOperator,
+                                        tmp_v0, tmp_v1);
     break;
 
   case Spin:

--- a/src/SingleExHubbard.c
+++ b/src/SingleExHubbard.c
@@ -33,6 +33,9 @@
 */
 int GetSingleExcitedStateHubbard(
   struct BindStruct *X,//!<define list to get and put information of calculation
+  unsigned int NSingleExcitationOperator,//!<[in] number of single excitation operators
+  int **SingleExcitationOperator,//!<[in] [n][3] = {site, spin, type}
+  double complex *ParaSingleExcitationOperator,//!<[in] coefficient of each operator
   double complex *tmp_v0,//!<[out] Result v0 = H v1
   double complex *tmp_v1//!<[in] v0 = H v1
 ) {
@@ -44,7 +47,7 @@ int GetSingleExcitedStateHubbard(
   double complex tmpphi;
   long unsigned int tmp_off = 0;
   //tmp_v0
-  if (X->Def.NSingleExcitationOperator == 0) {
+  if (NSingleExcitationOperator == 0) {
     return TRUE;
   }
   double complex *tmp_v1bufOrg;
@@ -55,11 +58,11 @@ int GetSingleExcitedStateHubbard(
 #endif // MPI
 
   idim_max = X->Check.idim_maxOrg;
-  for (i = 0; i < X->Def.NSingleExcitationOperator; i++) {
-    org_isite = X->Def.SingleExcitationOperator[i][0];
-    ispin = X->Def.SingleExcitationOperator[i][1];
-    itype = X->Def.SingleExcitationOperator[i][2];
-    tmpphi = X->Def.ParaSingleExcitationOperator[i];
+  for (i = 0; i < NSingleExcitationOperator; i++) {
+    org_isite = SingleExcitationOperator[i][0];
+    ispin = SingleExcitationOperator[i][1];
+    itype = SingleExcitationOperator[i][2];
+    tmpphi = ParaSingleExcitationOperator[i];
     is1_spin = X->Def.Tpow[2 * org_isite + ispin];
     if (itype == 1) {
       if (org_isite >= X->Def.Nsite) {

--- a/src/check.c
+++ b/src/check.c
@@ -351,12 +351,16 @@ int check(struct BindStruct *X){
         case tJGC:
         case Spin:
         case SpinlessFermion:
-          X->Check.max_mem = (6 * X->Def.k_exct + 2) * X->Check.idim_max * 16.0 / (pow(10, 9));
+          X->Check.max_mem = (6 * X->Def.k_exct + 2
+            + ((X->Def.NSingleExcitationOperatorBra > 0 || X->Def.NPairExcitationOperatorBra > 0) ? 1.0 : 0.0))
+            * X->Check.idim_max * 16.0 / (pow(10, 9));
           break;
         case HubbardGC:
         case SpinGC:
         case SpinlessFermionGC:
-          X->Check.max_mem = (6 * X->Def.k_exct + 1.5) * X->Check.idim_max * 16.0 / (pow(10, 9));
+          X->Check.max_mem = (6 * X->Def.k_exct + 1.5
+            + ((X->Def.NSingleExcitationOperatorBra > 0 || X->Def.NPairExcitationOperatorBra > 0) ? 1.0 : 0.0))
+            * X->Check.idim_max * 16.0 / (pow(10, 9));
           break;
       }
       break;

--- a/src/include/CalcSpectrum.h
+++ b/src/include/CalcSpectrum.h
@@ -20,8 +20,21 @@ int CalcSpectrum(
                  struct EDMainCalStruct *X
 );
 
+/** @brief A set of excitation operators (ket A or bra B) to apply to |phi>.
+    Lets GetExcitedState build either A|phi> (ket / X->Def fields) or B|phi>
+    (bra / X->Def *Bra fields) without mutating DefineList. */
+typedef struct {
+  unsigned int NSingle;       /**< number of single excitation operators */
+  int **Single;               /**< [NSingle][3] = {site, spin, type} */
+  double complex *ParaSingle; /**< [NSingle] coefficients */
+  unsigned int NPair;         /**< number of pair excitation operators */
+  int **Pair;                 /**< [NPair][5] = {site1, spin1, site2, spin2, type} */
+  double complex *ParaPair;   /**< [NPair] coefficients */
+} ExcitationOperatorSet;
+
 int GetExcitedState(
                 struct BindStruct *X,
+                const ExcitationOperatorSet *op,
                 double complex *tmp_v0,
                 double complex *tmp_v1
 );

--- a/src/include/CalcSpectrumByBiCG.h
+++ b/src/include/CalcSpectrumByBiCG.h
@@ -19,6 +19,7 @@
 int CalcSpectrumByBiCG(
   struct EDMainCalStruct *X,
   double complex *vrhs,
+  double complex *vlhs_Bra,
   double complex *v2,
   double complex *v4,
   int Nomega,

--- a/src/include/ExcitationSectorShift.h
+++ b/src/include/ExcitationSectorShift.h
@@ -22,12 +22,20 @@
  *        sector. @c valid is FALSE when the (model, operator) excitation is not
  *        supported in the current (v1) off-diagonal allow-list.
  */
+/** @brief Why a SectorShift is invalid (for off-diagonal guard diagnostics). */
+typedef enum {
+  OFFDIAG_SHIFT_OK = 0,            /**< valid shift */
+  OFFDIAG_SHIFT_MODEL_NOT_ALLOWED, /**< model/operator not in the off-diagonal allow-list */
+  OFFDIAG_SHIFT_SET_INCONSISTENT   /**< rows in the operator set induce different shifts */
+} SectorShiftReason;
+
 typedef struct {
   int dNe;
   int dNup;
   int dNdown;
   int dTotal2Sz;
   int valid;
+  SectorShiftReason reason;
 } SectorShift;
 
 /**

--- a/src/include/ExcitationSectorShift.h
+++ b/src/include/ExcitationSectorShift.h
@@ -1,0 +1,46 @@
+/* HPhi  -  Quantum Lattice Model Simulator */
+/* Copyright (C) 2015 Takahiro Misawa, Kazuyoshi Yoshimi, Mitsuaki Kawamura, Youhei Yamaji, Synge Todo, Naoki Kawashima */
+
+/* This program is free software: you can redistribute it and/or modify */
+/* it under the terms of the GNU General Public License as published by */
+/* the Free Software Foundation, either version 3 of the License, or */
+/* (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the */
+/* GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License */
+/* along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+#pragma once
+
+/**
+ * @brief Sector shift (dNe, dNup, dNdown, dTotal2Sz) induced by an excitation
+ *        operator, used to guard off-diagonal dynamical Green-function input so
+ *        that the ket A|phi> and bra B|phi> land in the same excited Hilbert
+ *        sector. @c valid is FALSE when the (model, operator) excitation is not
+ *        supported in the current (v1) off-diagonal allow-list.
+ */
+typedef struct {
+  int dNe;
+  int dNup;
+  int dNdown;
+  int dTotal2Sz;
+  int valid;
+} SectorShift;
+
+/**
+ * @brief Net sector shift of a single excitation operator row.
+ * @param op single = {site, spin(0=up/1=down), type(1=creation 'cis', else annihilation 'ajt')}.
+ *           pair   = {site1, spin1, site2, spin2, type}.
+ * The table mirrors the *net* behavior of MakeExcitedList() in CalcSpectrum.c.
+ */
+SectorShift GetExcitationSectorShift(int iCalcModel, int isGeneralSpin, int isPair, const int *op);
+
+/**
+ * @brief Validate that every operator row in a set induces the same valid shift.
+ *        Returns valid=FALSE if any row is unsupported or rows disagree.
+ */
+SectorShift GetExcitationOperatorSetShift(int iCalcModel, int isGeneralSpin, int isPair,
+                                          int **op, int nOp);

--- a/src/include/PairEx.h
+++ b/src/include/PairEx.h
@@ -19,6 +19,9 @@
 int GetPairExcitedState
 (
  struct BindStruct *X,
+ unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+ int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+ double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
  double complex *tmp_v0, /**< [out] Result v0 = H v1*/
  double complex *tmp_v1 /**< [in] v0 = H v1*/
  );

--- a/src/include/PairExHubbard.h
+++ b/src/include/PairExHubbard.h
@@ -25,6 +25,9 @@ int GetPairExcitedStateHubbardGC(
 
 int GetPairExcitedStateHubbard(
         struct BindStruct *X,
+        unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 );

--- a/src/include/PairExSpin.h
+++ b/src/include/PairExSpin.h
@@ -18,6 +18,9 @@
 
 int GetPairExcitedStateSpinGC(
         struct BindStruct *X,
+        unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -25,6 +28,9 @@ int GetPairExcitedStateSpinGC(
 
 int GetPairExcitedStateHalfSpinGC(
         struct BindStruct *X,
+        unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -33,6 +39,9 @@ int GetPairExcitedStateHalfSpinGC(
 
 int GetPairExcitedStateGeneralSpinGC(
         struct BindStruct *X,
+        unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -40,12 +49,18 @@ int GetPairExcitedStateGeneralSpinGC(
 
 int GetPairExcitedStateSpin(
         struct BindStruct *X,
+        unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 );
 
 int GetPairExcitedStateHalfSpin(
         struct BindStruct *X,
+        unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 
@@ -54,6 +69,9 @@ int GetPairExcitedStateHalfSpin(
 
 int GetPairExcitedStateGeneralSpin(
         struct BindStruct *X,
+        unsigned int NPairExcitationOperator, /**< [in] number of pair excitation operators*/
+        int **PairExcitationOperator, /**< [in] [n][5] = {site1, spin1, site2, spin2, type}*/
+        double complex *ParaPairExcitationOperator, /**< [in] coefficient of each operator*/
         double complex *tmp_v0, /**< [out] Result v0 = H v1*/
         double complex *tmp_v1 /**< [in] v0 = H v1*/
 

--- a/src/include/SingleEx.h
+++ b/src/include/SingleEx.h
@@ -20,6 +20,9 @@
 int GetSingleExcitedState
 (
  struct BindStruct *X,
+ unsigned int NSingleExcitationOperator, /**< [in] number of single excitation operators*/
+ int **SingleExcitationOperator, /**< [in] [n][3] = {site, spin, type}*/
+ double complex *ParaSingleExcitationOperator, /**< [in] coefficient of each operator*/
  double complex *tmp_v0, /**< [out] Result v0 = H v1*/
   double complex *tmp_v1 /**< [in] v0 = H v1*/
 );

--- a/src/include/SingleExHubbard.h
+++ b/src/include/SingleExHubbard.h
@@ -19,6 +19,9 @@
 int GetSingleExcitedStateHubbard
 (
  struct BindStruct *X,
+ unsigned int NSingleExcitationOperator, /**< [in] number of single excitation operators*/
+ int **SingleExcitationOperator, /**< [in] [n][3] = {site, spin, type}*/
+ double complex *ParaSingleExcitationOperator, /**< [in] coefficient of each operator*/
  double complex *tmp_v0, /**< [out] Result v0 = H v1*/
   double complex *tmp_v1 /**< [in] v0 = H v1*/
 );

--- a/src/include/readdef.h
+++ b/src/include/readdef.h
@@ -55,6 +55,8 @@
 #define KWFourBodyG 22
 #define KWSixBodyG 23
 #define KWInvTemp 24
+#define KWSingleExcitationBra 25
+#define KWPairExcitationBra 26
 
 int CheckSite(
           const int iListToSite,

--- a/src/include/struct.h
+++ b/src/include/struct.h
@@ -207,6 +207,18 @@ struct DefineList {
   unsigned int NPairExcitationOperator;/**<@brief Number of pair excitaion operator for spectrum.*/
   double complex *ParaPairExcitationOperator;/**<@brief [DefineList::NPairExcitationOperator]
                            Coefficient of pair excitaion operator for spectrum. malloc in setmem_def().*/
+
+  int **SingleExcitationOperatorBra;/**<@brief [DefineList::NSingleExcitationOperatorBra][3]
+                                    Bra-side single excitation operator for off-diagonal spectrum. malloc in setmem_def().*/
+  unsigned int NSingleExcitationOperatorBra;/**<@brief Number of bra-side single excitation operators.*/
+  double complex *ParaSingleExcitationOperatorBra;/**<@brief [DefineList::NSingleExcitationOperatorBra]
+              Coefficient of bra-side single excitation operator. malloc in setmem_def().*/
+
+  int **PairExcitationOperatorBra;/**<@brief [DefineList::NPairExcitationOperatorBra][5]
+                                  Bra-side pair excitation operator for off-diagonal spectrum. malloc in setmem_def().*/
+  unsigned int NPairExcitationOperatorBra;/**<@brief Number of bra-side pair excitation operators.*/
+  double complex *ParaPairExcitationOperatorBra;/**<@brief [DefineList::NPairExcitationOperatorBra]
+                           Coefficient of bra-side pair excitation operator. malloc in setmem_def().*/
   
   int iCalcType;/**<@brief Switch for calculation type. 0:Lanczos, 1:TPQCalc, 2:FullDiag.*/
   int iCalcEigenVec;/**<@brief Switch for method to calculate eigenvectors. 

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -68,7 +68,9 @@ static char cKWListOfFileNameList[][D_CharTmpReadDef]={
   "ThreeBodyG",
   "FourBodyG",
   "SixBodyG",
-  "InvTemp"
+  "InvTemp",
+  "SingleExcitationBra",
+  "PairExcitationBra"
 };
 
 int D_iKWNumDef = sizeof(cKWListOfFileNameList)/sizeof(cKWListOfFileNameList[0]);
@@ -844,6 +846,20 @@ int ReadDefFileNInt(
       fgetsMPI(ctmp, sizeof(ctmp)/sizeof(char), fp);
       fgetsMPI(ctmp2, 256, fp);
       sscanf(ctmp2,"%s %d\n", ctmp, &(X->NPairExcitationOperator));
+      break;
+
+    case KWSingleExcitationBra:
+      /* Read singleexcitationbra.def-----------------------------------*/
+      fgetsMPI(ctmp, sizeof(ctmp)/sizeof(char), fp);
+      fgetsMPI(ctmp2, 256, fp);
+      sscanf(ctmp2,"%s %d\n", ctmp, &(X->NSingleExcitationOperatorBra));
+      break;
+
+    case KWPairExcitationBra:
+      /* Read pairexcitationbra.def-------------------------------------*/
+      fgetsMPI(ctmp, sizeof(ctmp)/sizeof(char), fp);
+      fgetsMPI(ctmp2, 256, fp);
+      sscanf(ctmp2,"%s %d\n", ctmp, &(X->NPairExcitationOperatorBra));
       break;
 
     default:
@@ -2129,6 +2145,85 @@ int ReadDefFileIdxPara(
       }
       break;
 
+    case KWSingleExcitationBra:
+      /*singleexcitationbra.def-------------------------------------*/
+      if(X->NSingleExcitationOperatorBra>0) {
+        if(X->iCalcModel == Spin || X->iCalcModel == SpinGC) {
+          fprintf(stderr, "SingleExcitationBra is not allowed for spin system.\n");
+          fclose(fp);
+          return ReadDefFileError(defname);
+        }
+        while (fgetsMPI(ctmp2, 256, fp) != NULL) {
+          sscanf(ctmp2, "%d %d %d %lf %lf\n",
+                 &isite1,
+                 &isigma1,
+                 &itype,
+                 &dvalue_re,
+                 &dvalue_im
+                 );
+
+          if (CheckSite(isite1, X->Nsite) != 0) {
+            fclose(fp);
+            return ReadDefFileError(defname);
+          }
+
+          X->SingleExcitationOperatorBra[idx][0] = isite1;
+          X->SingleExcitationOperatorBra[idx][1] = isigma1;
+          X->SingleExcitationOperatorBra[idx][2] = itype;
+          X->ParaSingleExcitationOperatorBra[idx] = dvalue_re + I * dvalue_im;
+          idx++;
+        }
+        if (idx != X->NSingleExcitationOperatorBra) {
+          fclose(fp);
+          return ReadDefFileError(defname);
+        }
+      }
+      break;
+
+    case KWPairExcitationBra:
+      /*pairexcitationbra.def-------------------------------------*/
+      if(X->NPairExcitationOperatorBra>0) {
+        while (fgetsMPI(ctmp2, 256, fp) != NULL) {
+          sscanf(ctmp2, "%d %d %d %d %d %lf %lf\n",
+                 &isite1,
+                 &isigma1,
+                 &isite2,
+                 &isigma2,
+                 &itype,
+                 &dvalue_re,
+                 &dvalue_im
+                 );
+          if (CheckPairSite(isite1, isite2, X->Nsite) != 0) {
+            fclose(fp);
+            return ReadDefFileError(defname);
+          }
+
+          if(itype==1){
+            X->PairExcitationOperatorBra[idx][0] = isite1;
+            X->PairExcitationOperatorBra[idx][1] = isigma1;
+            X->PairExcitationOperatorBra[idx][2] = isite2;
+            X->PairExcitationOperatorBra[idx][3] = isigma2;
+            X->PairExcitationOperatorBra[idx][4] = itype;
+            X->ParaPairExcitationOperatorBra[idx] = dvalue_re + I * dvalue_im;
+          }
+          else{
+            X->PairExcitationOperatorBra[idx][0] = isite2;
+            X->PairExcitationOperatorBra[idx][1] = isigma2;
+            X->PairExcitationOperatorBra[idx][2] = isite1;
+            X->PairExcitationOperatorBra[idx][3] = isigma1;
+            X->PairExcitationOperatorBra[idx][4] = itype;
+            X->ParaPairExcitationOperatorBra[idx] = -(dvalue_re + I * dvalue_im);
+          }
+
+          idx++;
+        }
+        if (idx != X->NPairExcitationOperatorBra) {
+          fclose(fp);
+          return ReadDefFileError(defname);
+        }
+      }
+      break;
+
     default:
       break;
     }
@@ -3174,6 +3269,8 @@ void InitializeInteractionNum
   X->flag_read_invtemp=0;
   X->NSingleExcitationOperator=0;
   X->NPairExcitationOperator=0;
+  X->NSingleExcitationOperatorBra=0;
+  X->NPairExcitationOperatorBra=0;
   //[s] Time Evolution
   X->NTETimeSteps=0;
   X->NLaser=0;

--- a/src/xsetmem.c
+++ b/src/xsetmem.c
@@ -127,6 +127,11 @@ void setmem_def
   X->Def.PairExcitationOperator = i_2d_allocate(X->Def.NPairExcitationOperator, 5);
   X->Def.ParaPairExcitationOperator = cd_1d_allocate(X->Def.NPairExcitationOperator);
 
+  X->Def.SingleExcitationOperatorBra = i_2d_allocate(X->Def.NSingleExcitationOperatorBra, 3);
+  X->Def.ParaSingleExcitationOperatorBra = cd_1d_allocate(X->Def.NSingleExcitationOperatorBra);
+  X->Def.PairExcitationOperatorBra = i_2d_allocate(X->Def.NPairExcitationOperatorBra, 5);
+  X->Def.ParaPairExcitationOperatorBra = cd_1d_allocate(X->Def.NPairExcitationOperatorBra);
+
   X->Def.ParaLaser = d_1d_allocate(X->Def.NLaser);
 
   xBoost->list_6spin_star = i_2d_allocate(xBoost->R0 * xBoost->num_pivot, 7);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -200,10 +200,17 @@ add_hphi_test(spectrum_kondogc_chain)
 add_hphi_test(spectrum_spingc_honey)
 add_hphi_test_with_srcdir(spectrum_spinless_chain)
 
+# Off-diagonal dynamical Green function (bra excitation)
+add_hphi_test(spectrum_hubbard_offdiag_single)
+add_hphi_test(spectrum_hubbard_offdiag_pair_density)
+
 # Spectrum test labels
 set_tests_properties(
     spectrum_hubbard_square spectrum_hubbardgc_tri
     PROPERTIES LABELS "spectrum;hubbard")
+set_tests_properties(
+    spectrum_hubbard_offdiag_single spectrum_hubbard_offdiag_pair_density
+    PROPERTIES LABELS "spectrum;hubbard;offdiag")
 set_tests_properties(
     spectrum_kondo_chain spectrum_kondogc_chain
     PROPERTIES LABELS "spectrum;kondo")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,6 +205,7 @@ add_hphi_test(spectrum_hubbard_offdiag_single)
 add_hphi_test(spectrum_hubbard_offdiag_pair_density)
 add_hphi_test(spectrum_spin_offdiag_szsz)
 add_hphi_test(spectrum_spingc_offdiag_szsz)
+add_hphi_test(spectrum_offdiag_invalid_reject)
 
 # Spectrum test labels
 set_tests_properties(
@@ -216,6 +217,9 @@ set_tests_properties(
 set_tests_properties(
     spectrum_spin_offdiag_szsz spectrum_spingc_offdiag_szsz
     PROPERTIES LABELS "spectrum;spin;offdiag")
+set_tests_properties(
+    spectrum_offdiag_invalid_reject
+    PROPERTIES LABELS "spectrum;offdiag;validation")
 set_tests_properties(
     spectrum_kondo_chain spectrum_kondogc_chain
     PROPERTIES LABELS "spectrum;kondo")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -203,6 +203,8 @@ add_hphi_test_with_srcdir(spectrum_spinless_chain)
 # Off-diagonal dynamical Green function (bra excitation)
 add_hphi_test(spectrum_hubbard_offdiag_single)
 add_hphi_test(spectrum_hubbard_offdiag_pair_density)
+add_hphi_test(spectrum_spin_offdiag_szsz)
+add_hphi_test(spectrum_spingc_offdiag_szsz)
 
 # Spectrum test labels
 set_tests_properties(
@@ -211,6 +213,9 @@ set_tests_properties(
 set_tests_properties(
     spectrum_hubbard_offdiag_single spectrum_hubbard_offdiag_pair_density
     PROPERTIES LABELS "spectrum;hubbard;offdiag")
+set_tests_properties(
+    spectrum_spin_offdiag_szsz spectrum_spingc_offdiag_szsz
+    PROPERTIES LABELS "spectrum;spin;offdiag")
 set_tests_properties(
     spectrum_kondo_chain spectrum_kondogc_chain
     PROPERTIES LABELS "spectrum;kondo")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -220,6 +220,23 @@ set_tests_properties(
 set_tests_properties(
     spectrum_offdiag_invalid_reject
     PROPERTIES LABELS "spectrum;offdiag;validation")
+
+# Unit test: off-diagonal excitation sector-shift truth table
+add_executable(unittest_excitation_sector_shift
+    ${CMAKE_SOURCE_DIR}/test/unittest_excitation_sector_shift.c
+    ${CMAKE_SOURCE_DIR}/src/ExcitationSectorShift.c)
+target_include_directories(unittest_excitation_sector_shift
+    PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
+target_compile_definitions(unittest_excitation_sector_shift PRIVATE DSFMT_MEXP=19937)
+add_test(NAME unittest_excitation_sector_shift
+    COMMAND unittest_excitation_sector_shift)
+set_tests_properties(unittest_excitation_sector_shift
+    PROPERTIES LABELS "unit;offdiag")
+
+# MPI consistency for the off-diagonal spectrum (4-site Hubbard needs np=4)
+add_hphi_mpi_test(spectrum_hubbard_offdiag_single_mpi exact:4)
+set_tests_properties(spectrum_hubbard_offdiag_single_mpi
+    PROPERTIES LABELS "spectrum;hubbard;offdiag;mpi")
 set_tests_properties(
     spectrum_kondo_chain spectrum_kondogc_chain
     PROPERTIES LABELS "spectrum;kondo")

--- a/test/spectrum_hubbard_offdiag_pair_density.sh
+++ b/test/spectrum_hubbard_offdiag_pair_density.sh
@@ -117,6 +117,10 @@ EOF
 paste output/zvo_DynamicalGreen.dat reference.dat > paste1.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste1.dat`
 
-test "${diff}" = "0.000000"
+echo "spectrum_hubbard_offdiag_pair_density: accumulated L1 diff vs reference = ${diff}"
+# Reference values were generated with a different BLAS (Accelerate on macOS);
+# allow a small cross-platform tolerance on the accumulated L1 difference.
+# A genuine regression shifts the spectrum by O(0.1) or more, far above this.
+awk -v d="${diff}" 'BEGIN { exit (d < 1.0e-3) ? 0 : 1 }'
 
 exit $?

--- a/test/spectrum_hubbard_offdiag_pair_density.sh
+++ b/test/spectrum_hubbard_offdiag_pair_density.sh
@@ -1,0 +1,122 @@
+#!/bin/sh -e
+
+# Off-diagonal density-density dynamical Green function
+#   G_BA(z) = <gs| n_{1,up} (1/(z-H)) n_{0,up} |gs>
+# on a 1D Hubbard 4-site cluster (t=1, U=4, half filling, 2Sz=0), method=CG (BiCG).
+# ket A = n_{0,up} (PairExcitation), bra B = n_{1,up} (PairExcitationBra).
+# The reference values were cross-checked against exact diagonalization (~1e-6).
+# Serial test (MPI consistency is covered separately).
+
+HPHI=../../src/HPhi
+
+mkdir -p spectrum_hubbard_offdiag_pair_density/
+cd spectrum_hubbard_offdiag_pair_density
+
+#
+# Ground state (standard mode; StdFace writes the lattice .def files and the eigenvector)
+#
+cat > stan_gs.in <<EOF
+model = "Hubbard"
+method = "CG"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+nelec = 4
+2Sz = 0
+EigenVecIO = "out"
+EOF
+
+${HPHI} -s stan_gs.in
+
+#
+# Off-diagonal density-density spectrum (expert mode)
+#
+cat > calcmod_cg.def <<EOF
+CalcType   3
+CalcModel   0
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   1
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Ncond          4
+Lanczos_max    2000
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -2.1027484834620633
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+
+cat > pairexcitation.def <<EOF
+=============================================
+NPairExcitation 1
+=============================================
+=============== Pair Excitation =============
+=============================================
+0 0 0 0 1         1.000000000000000         0.000000000000000
+EOF
+
+cat > pairexcitationbra.def <<EOF
+=============================================
+NPairExcitationBra 1
+=============================================
+=============== Pair Excitation Bra =========
+=============================================
+1 0 1 0 1         1.000000000000000         0.000000000000000
+EOF
+
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombIntra  coulombintra.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  PairExcitation  pairexcitation.def
+  PairExcitationBra  pairexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+
+${HPHI} -e namelist_cg.def
+
+cat > reference.dat <<EOF
+0.0000000000 0.0000000000 0.3775198728 -2.3744943609
+0.1000000000 0.0000000000 1.7520780671 -0.9972366790
+0.2000000000 0.0000000000 1.6189779535 0.1362815906
+0.3000000000 0.0000000000 0.7113192440 0.9748842355
+0.4000000000 0.0000000000 -0.0181002508 0.4441586632
+EOF
+
+paste output/zvo_DynamicalGreen.dat reference.dat > paste1.dat
+diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste1.dat`
+
+test "${diff}" = "0.000000"
+
+exit $?

--- a/test/spectrum_hubbard_offdiag_single.sh
+++ b/test/spectrum_hubbard_offdiag_single.sh
@@ -1,0 +1,123 @@
+#!/bin/sh -e
+
+# Off-diagonal dynamical Green function
+#   G_BA(z) = <gs| c_{0,up}^dagger (1/(z-H)) c_{1,up} |gs>
+# on a 1D Hubbard 4-site cluster (t=1, U=4, half filling, 2Sz=0), method=CG (BiCG).
+# ket A = c_{1,up} (SingleExcitation), bra B = c_{0,up} (SingleExcitationBra).
+# The reference values reproduce exact diagonalization (new_spectrum validation).
+# Serial test (MPI consistency is covered separately).
+
+HPHI=../../src/HPhi
+
+mkdir -p spectrum_hubbard_offdiag_single/
+cd spectrum_hubbard_offdiag_single
+
+#
+# Ground state (standard mode; StdFace writes the lattice .def files and the eigenvector)
+#
+cat > stan_gs.in <<EOF
+model = "Hubbard"
+method = "CG"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+nelec = 4
+2Sz = 0
+EigenVecIO = "out"
+EOF
+
+${HPHI} -s stan_gs.in
+
+#
+# Off-diagonal spectrum (expert mode: reuses the StdFace lattice files,
+# adds the ket/bra single-excitation operators)
+#
+cat > calcmod_cg.def <<EOF
+CalcType   3
+CalcModel   0
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   1
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Ncond          4
+Lanczos_max    2000
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -2.1027484834620633
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+
+cat > singleexcitation.def <<EOF
+=============================================
+NSingleExcitation 1
+=============================================
+======== Single Excitation ==================
+=============================================
+1 0 0         1.000000000000000         0.000000000000000
+EOF
+
+cat > singleexcitationbra.def <<EOF
+=============================================
+NSingleExcitationBra 1
+=============================================
+======== Single Excitation Bra ==============
+=============================================
+0 0 0         1.000000000000000         0.000000000000000
+EOF
+
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombIntra  coulombintra.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  SingleExcitation  singleexcitation.def
+  SingleExcitationBra  singleexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+
+${HPHI} -e namelist_cg.def
+
+cat > reference.dat <<EOF
+0.0000000000 0.0000000000 -0.3354182045 -0.0537129306
+0.1000000000 0.0000000000 -0.3952267119 -0.0749316242
+0.2000000000 0.0000000000 -0.4790334010 -0.1113242043
+0.3000000000 0.0000000000 -0.6027761001 -0.1810475321
+0.4000000000 0.0000000000 -0.7942785902 -0.3376755873
+EOF
+
+paste output/zvo_DynamicalGreen.dat reference.dat > paste1.dat
+diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste1.dat`
+
+test "${diff}" = "0.000000"
+
+exit $?

--- a/test/spectrum_hubbard_offdiag_single.sh
+++ b/test/spectrum_hubbard_offdiag_single.sh
@@ -118,6 +118,10 @@ EOF
 paste output/zvo_DynamicalGreen.dat reference.dat > paste1.dat
 diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste1.dat`
 
-test "${diff}" = "0.000000"
+echo "spectrum_hubbard_offdiag_single: accumulated L1 diff vs reference = ${diff}"
+# Reference values were generated with a different BLAS (Accelerate on macOS);
+# allow a small cross-platform tolerance on the accumulated L1 difference.
+# A genuine regression shifts the spectrum by O(0.1) or more, far above this.
+awk -v d="${diff}" 'BEGIN { exit (d < 1.0e-3) ? 0 : 1 }'
 
 exit $?

--- a/test/spectrum_hubbard_offdiag_single_mpi.sh
+++ b/test/spectrum_hubbard_offdiag_single_mpi.sh
@@ -1,0 +1,114 @@
+#!/bin/sh -e
+
+# MPI consistency for the off-diagonal dynamical Green function:
+# the same G_BA = <gs| c_{0up}^dag (z-H)^-1 c_{1up} |gs> on a 4-site Hubbard
+# chain (t=1, U=4) must reproduce the serial/exact result when run under MPI.
+# A 4-site Hubbard requires the MPI process count to be a power of 4, so this
+# test is registered to run only at np = 4 (skipped otherwise via the precheck).
+# MPI introduces ~1e-7 BiCG-convergence differences, so a small tolerance is used.
+
+if [ -z "${MPIRUN}" ]; then
+    MPIRUN=""
+fi
+
+mkdir -p spectrum_hubbard_offdiag_single_mpi/
+cd spectrum_hubbard_offdiag_single_mpi
+
+cat > stan_gs.in <<EOF
+model = "Hubbard"
+method = "CG"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+nelec = 4
+2Sz = 0
+EigenVecIO = "out"
+EOF
+${MPIRUN} ../../src/HPhi -s stan_gs.in
+
+cat > calcmod_cg.def <<EOF
+CalcType   3
+CalcModel   0
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   1
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Ncond          4
+Lanczos_max    2000
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -2.1027484834620633
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+cat > singleexcitation.def <<EOF
+=============================================
+NSingleExcitation 1
+=============================================
+======== Single Excitation ==================
+=============================================
+1 0 0         1.000000000000000         0.000000000000000
+EOF
+cat > singleexcitationbra.def <<EOF
+=============================================
+NSingleExcitationBra 1
+=============================================
+======== Single Excitation Bra ==============
+=============================================
+0 0 0         1.000000000000000         0.000000000000000
+EOF
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombIntra  coulombintra.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  SingleExcitation  singleexcitation.def
+  SingleExcitationBra  singleexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+${MPIRUN} ../../src/HPhi -e namelist_cg.def
+
+# Serial / exact reference (validated against exact diagonalization).
+cat > reference.dat <<EOF
+0.0000000000 0.0000000000 -0.3354182045 -0.0537129306
+0.1000000000 0.0000000000 -0.3952267119 -0.0749316242
+0.2000000000 0.0000000000 -0.4790334010 -0.1113242043
+0.3000000000 0.0000000000 -0.6027761001 -0.1810475321
+0.4000000000 0.0000000000 -0.7942785902 -0.3376755873
+EOF
+paste output/zvo_DynamicalGreen.dat reference.dat > paste1.dat
+diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%e", diff}' paste1.dat`
+echo "MPI-vs-serial L2 diff = ${diff}"
+
+ok=`awk "BEGIN{print (${diff} < 1.0e-5) ? 1 : 0}"`
+test "${ok}" = "1"
+
+exit $?

--- a/test/spectrum_offdiag_invalid_reject.sh
+++ b/test/spectrum_offdiag_invalid_reject.sh
@@ -1,0 +1,165 @@
+#!/bin/sh -e
+
+# Negative tests for the off-diagonal (bra) dynamical-Green guards.
+# A 4-site Hubbard chain ground state is computed once; then several invalid
+# bra-excitation inputs are fed to the spectrum run, each of which MUST be
+# rejected (HPhi exits non-zero). The test fails if any invalid case is accepted.
+
+HPHI=../../src/HPhi
+
+mkdir -p spectrum_offdiag_invalid_reject/
+cd spectrum_offdiag_invalid_reject
+
+#
+# Ground state + base lattice files
+#
+cat > stan_gs.in <<EOF
+model = "Hubbard"
+method = "CG"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+nelec = 4
+2Sz = 0
+EigenVecIO = "out"
+EOF
+${HPHI} -s stan_gs.in
+
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Ncond          4
+Lanczos_max    100
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         2
+OmegaOrg       -2.1027484834620633
+OmegaMin       0.0
+OmegaMax       0.2
+OmegaIm        0.1
+EOF
+
+# Excitation operator building blocks
+single_ket() {  # c_{1up} annihilation
+  printf '%s\n' '=====' 'NSingleExcitation 1' '=====' '=====' '=====' \
+    '1 0 0  1.0 0.0' > singleexcitation.def
+}
+pair_ket() {    # n_{0up}
+  printf '%s\n' '=====' 'NPairExcitation 1' '=====' '=====' '=====' \
+    '0 0 0 0 1  1.0 0.0' > pairexcitation.def
+}
+calcmod() {     # $1 = CalcType, $2 = CalcSpec
+  cat > calcmod_cg.def <<EOF
+CalcType   $1
+CalcModel   0
+ReStart   0
+CalcSpec   $2
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   1
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+}
+nl() {  # build namelist with the given excitation keyword lines (passed as args)
+  {
+    echo '         ModPara  SpectrumModpara'
+    echo '         LocSpin  locspn.def'
+    echo '           Trans  trans.def'
+    echo '    CoulombIntra  coulombintra.def'
+    echo '        OneBodyG  greenone.def'
+    echo '        TwoBodyG  greentwo.def'
+    echo '         CalcMod  calcmod_cg.def'
+    for line in "$@"; do echo "  $line"; done
+    echo '     SpectrumVec  zvo_eigenvec_0'
+  } > namelist_cg.def
+}
+
+fail=0
+expect_reject() {  # $1 = case name, $2 = expected guard-message substring
+  name="$1"
+  pat="$2"
+  if ${HPHI} -e namelist_cg.def > "reject_${name}.log" 2>&1; then
+    echo "FAIL: invalid case '${name}' was ACCEPTED (should be rejected)"
+    cat "reject_${name}.log"
+    fail=1
+  elif ! grep -q "${pat}" "reject_${name}.log"; then
+    echo "FAIL: '${name}' rejected, but not by the expected guard ('${pat}')"
+    cat "reject_${name}.log"
+    fail=1
+  else
+    echo "OK: '${name}' rejected by the expected guard"
+  fi
+}
+
+#
+# 1. bra requires method=CG  (CalcType = Lanczos)
+#
+single_ket
+printf '%s\n' '=====' 'NSingleExcitationBra 1' '=====' '=====' '=====' \
+  '0 0 0  1.0 0.0' > singleexcitationbra.def
+calcmod 0 1
+nl 'SingleExcitation  singleexcitation.def' 'SingleExcitationBra  singleexcitationbra.def'
+expect_reject "calctype_not_cg" "requires method"
+
+#
+# 2. bra requires CalcSpec = Normal  (CalcSpec = Restart)
+#
+calcmod 3 4
+nl 'SingleExcitation  singleexcitation.def' 'SingleExcitationBra  singleexcitationbra.def'
+expect_reject "calcspec_not_normal" "requires CalcSpec"
+
+#
+# 3. ket/bra excitation type mismatch  (ket single, bra pair)
+#
+calcmod 3 1
+pair_ket  # not used by ket here, but present
+printf '%s\n' '=====' 'NPairExcitationBra 1' '=====' '=====' '=====' \
+  '1 0 1 0 1  1.0 0.0' > pairexcitationbra.def
+nl 'SingleExcitation  singleexcitation.def' 'PairExcitationBra  pairexcitationbra.def'
+expect_reject "type_mismatch" "must be the same type"
+
+#
+# 4. both SingleExcitationBra and PairExcitationBra specified
+#
+nl 'SingleExcitation  singleexcitation.def' \
+   'SingleExcitationBra  singleexcitationbra.def' \
+   'PairExcitationBra  pairexcitationbra.def'
+expect_reject "both_bra_types" "cannot be used together"
+
+#
+# 5. ket/bra map to different Hilbert sectors
+#    (ket c_{1up} annihilation, bra c_{0up} creation -> dNe = -1 vs +1)
+#
+printf '%s\n' '=====' 'NSingleExcitationBra 1' '=====' '=====' '=====' \
+  '0 0 1  1.0 0.0' > singleexcitationbra.def
+nl 'SingleExcitation  singleexcitation.def' 'SingleExcitationBra  singleexcitationbra.def'
+expect_reject "sector_mismatch" "different Hilbert sectors"
+
+#
+# 6. bra operator set mixes inconsistent sector shifts
+#    (annihilation + creation in one bra file)
+#
+printf '%s\n' '=====' 'NSingleExcitationBra 2' '=====' '=====' '=====' \
+  '0 0 0  1.0 0.0' '0 0 1  1.0 0.0' > singleexcitationbra.def
+nl 'SingleExcitation  singleexcitation.def' 'SingleExcitationBra  singleexcitationbra.def'
+expect_reject "set_inconsistent" "mixes operators with different"
+
+test "${fail}" = "0"
+exit $?

--- a/test/spectrum_spin_offdiag_szsz.sh
+++ b/test/spectrum_spin_offdiag_szsz.sh
@@ -1,0 +1,196 @@
+#!/bin/sh -e
+
+# Off-diagonal dynamical spin structure factor (Sz-Sz cross term)
+#   G(z) = <gs| Sz_1 (1/(z-H)) Sz_0 |gs>
+# on a Heisenberg ring (chain, PBC), H = J sum S_i.S_j, J=1, 2Sz=0, method=CG.
+# Covers the canonical Spin leaves:
+#   - S=1/2 : GetPairExcitedStateHalfSpin
+#   - S=1   : GetPairExcitedStateGeneralSpin
+# References were cross-checked against exact diagonalization (~1e-8).
+
+HPHI=../../src/HPhi
+
+mkdir -p spectrum_spin_offdiag_szsz/
+cd spectrum_spin_offdiag_szsz
+
+#
+# --- S = 1/2 (HalfSpin leaf) ---
+#
+cat > stan_gs.in <<EOF
+model = "Spin"
+method = "CG"
+lattice = "chain"
+L = 4
+J = 1.0
+2Sz = 0
+EigenVecIO = "out"
+EOF
+${HPHI} -s stan_gs.in
+
+cat > calcmod_cg.def <<EOF
+CalcType   3
+CalcModel   1
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   1
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Lanczos_max    2000
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -2.0
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+cat > pairexcitation.def <<EOF
+=============================================
+NPairExcitation 2
+=============================================
+=============== Pair Excitation =============
+=============================================
+0 0 0 0 1        -0.500000000000000         0.000000000000000
+0 1 0 1 1         0.500000000000000         0.000000000000000
+EOF
+cat > pairexcitationbra.def <<EOF
+=============================================
+NPairExcitationBra 2
+=============================================
+=============== Pair Excitation Bra =========
+=============================================
+1 0 1 0 1        -0.500000000000000         0.000000000000000
+1 1 1 1 1         0.500000000000000         0.000000000000000
+EOF
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombInter  coulombinter.def
+            Hund  hund.def
+        Exchange  exchange.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  PairExcitation  pairexcitation.def
+  PairExcitationBra  pairexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+${HPHI} -e namelist_cg.def
+cat > reference.dat <<EOF
+0.0000000000 0.0000000000 0.1650165022 0.0165016502
+0.1000000000 0.0000000000 0.1829268299 0.0203252033
+0.2000000000 0.0000000000 0.2051282058 0.0256410257
+0.3000000000 0.0000000000 0.2333333341 0.0333333334
+0.4000000000 0.0000000000 0.2702702712 0.0450450452
+EOF
+paste output/zvo_DynamicalGreen.dat reference.dat > paste1.dat
+diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste1.dat`
+
+#
+# --- S = 1 (GeneralSpin leaf) ---
+#
+cat > stan_gs.in <<EOF
+model = "Spin"
+method = "CG"
+lattice = "chain"
+L = 4
+2S = 2
+J = 1.0
+2Sz = 0
+EigenVecIO = "out"
+EOF
+${HPHI} -s stan_gs.in
+
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Lanczos_max    2000
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -6.0
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+cat > pairexcitation.def <<EOF
+=============================================
+NPairExcitation 3
+=============================================
+=============== Pair Excitation =============
+=============================================
+0 0 0 0 1        -1.000000000000000         0.000000000000000
+0 1 0 1 1         0.000000000000000         0.000000000000000
+0 2 0 2 1         1.000000000000000         0.000000000000000
+EOF
+cat > pairexcitationbra.def <<EOF
+=============================================
+NPairExcitationBra 3
+=============================================
+=============== Pair Excitation Bra =========
+=============================================
+1 0 1 0 1        -1.000000000000000         0.000000000000000
+1 1 1 1 1         0.000000000000000         0.000000000000000
+1 2 1 2 1         1.000000000000000         0.000000000000000
+EOF
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+        InterAll  interall.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  PairExcitation  pairexcitation.def
+  PairExcitationBra  pairexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+${HPHI} -e namelist_cg.def
+cat > reference.dat <<EOF
+0.0000000000 0.0000000000 0.4950495119 0.0495049512
+0.1000000000 0.0000000000 0.5487804948 0.0609756105
+0.2000000000 0.0000000000 0.6153846224 0.0769230777
+0.3000000000 0.0000000000 0.7000000069 0.1000000009
+0.4000000000 0.0000000000 0.8108108175 0.1351351360
+EOF
+paste output/zvo_DynamicalGreen.dat reference.dat > paste2.dat
+diff=`awk 'BEGIN{diff='${diff}'} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste2.dat`
+
+test "${diff}" = "0.000000"
+
+exit $?

--- a/test/spectrum_spin_offdiag_szsz.sh
+++ b/test/spectrum_spin_offdiag_szsz.sh
@@ -191,6 +191,10 @@ EOF
 paste output/zvo_DynamicalGreen.dat reference.dat > paste2.dat
 diff=`awk 'BEGIN{diff='${diff}'} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste2.dat`
 
-test "${diff}" = "0.000000"
+echo "spectrum_spin_offdiag_szsz: accumulated L1 diff vs reference = ${diff}"
+# Reference values were generated with a different BLAS (Accelerate on macOS);
+# allow a small cross-platform tolerance on the accumulated L1 difference.
+# A genuine regression shifts the spectrum by O(0.1) or more, far above this.
+awk -v d="${diff}" 'BEGIN { exit (d < 1.0e-3) ? 0 : 1 }'
 
 exit $?

--- a/test/spectrum_spingc_offdiag_szsz.sh
+++ b/test/spectrum_spingc_offdiag_szsz.sh
@@ -1,0 +1,194 @@
+#!/bin/sh -e
+
+# Off-diagonal dynamical spin structure factor (Sz-Sz cross term) in the
+# grand-canonical spin ensemble:  G(z) = <gs| Sz_1 (1/(z-H)) Sz_0 |gs>
+# Heisenberg ring (chain, PBC), H = J sum S_i.S_j, J=1, method=CG.
+# Covers the SpinGC leaves:
+#   - S=1/2 : GetPairExcitedStateHalfSpinGC
+#   - S=1   : GetPairExcitedStateGeneralSpinGC
+# References were cross-checked against exact diagonalization (~1e-8).
+
+HPHI=../../src/HPhi
+
+mkdir -p spectrum_spingc_offdiag_szsz/
+cd spectrum_spingc_offdiag_szsz
+
+#
+# --- S = 1/2 (HalfSpinGC leaf) ---
+#
+cat > stan_gs.in <<EOF
+model = "SpinGC"
+method = "CG"
+lattice = "chain"
+L = 4
+J = 1.0
+EigenVecIO = "out"
+EOF
+${HPHI} -s stan_gs.in
+
+cat > calcmod_cg.def <<EOF
+CalcType   3
+CalcModel   4
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   1
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Lanczos_max    2000
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -2.0
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+cat > pairexcitation.def <<EOF
+=============================================
+NPairExcitation 2
+=============================================
+=============== Pair Excitation =============
+=============================================
+0 0 0 0 1        -0.500000000000000         0.000000000000000
+0 1 0 1 1         0.500000000000000         0.000000000000000
+EOF
+cat > pairexcitationbra.def <<EOF
+=============================================
+NPairExcitationBra 2
+=============================================
+=============== Pair Excitation Bra =========
+=============================================
+1 0 1 0 1        -0.500000000000000         0.000000000000000
+1 1 1 1 1         0.500000000000000         0.000000000000000
+EOF
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombInter  coulombinter.def
+            Hund  hund.def
+        Exchange  exchange.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  PairExcitation  pairexcitation.def
+  PairExcitationBra  pairexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+${HPHI} -e namelist_cg.def
+cat > reference.dat <<EOF
+0.0000000000 0.0000000000 0.1650164998 0.0165016500
+0.1000000000 0.0000000000 0.1829268272 0.0203252030
+0.2000000000 0.0000000000 0.2051282028 0.0256410254
+0.3000000000 0.0000000000 0.2333333308 0.0333333330
+0.4000000000 0.0000000000 0.2702702673 0.0450450446
+EOF
+paste output/zvo_DynamicalGreen.dat reference.dat > paste1.dat
+diff=`awk 'BEGIN{diff=0.0} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste1.dat`
+
+#
+# --- S = 1 (GeneralSpinGC leaf) ---
+#
+cat > stan_gs.in <<EOF
+model = "SpinGC"
+method = "CG"
+lattice = "chain"
+L = 4
+2S = 2
+J = 1.0
+EigenVecIO = "out"
+EOF
+${HPHI} -s stan_gs.in
+
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Lanczos_max    2000
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -6.0
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+cat > pairexcitation.def <<EOF
+=============================================
+NPairExcitation 3
+=============================================
+=============== Pair Excitation =============
+=============================================
+0 0 0 0 1        -1.000000000000000         0.000000000000000
+0 1 0 1 1         0.000000000000000         0.000000000000000
+0 2 0 2 1         1.000000000000000         0.000000000000000
+EOF
+cat > pairexcitationbra.def <<EOF
+=============================================
+NPairExcitationBra 3
+=============================================
+=============== Pair Excitation Bra =========
+=============================================
+1 0 1 0 1        -1.000000000000000         0.000000000000000
+1 1 1 1 1         0.000000000000000         0.000000000000000
+1 2 1 2 1         1.000000000000000         0.000000000000000
+EOF
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+        InterAll  interall.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  PairExcitation  pairexcitation.def
+  PairExcitationBra  pairexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+${HPHI} -e namelist_cg.def
+cat > reference.dat <<EOF
+0.0000000000 0.0000000000 0.4950495098 0.0495049516
+0.1000000000 0.0000000000 0.5487804932 0.0609756111
+0.2000000000 0.0000000000 0.6153846214 0.0769230786
+0.3000000000 0.0000000000 0.7000000069 0.1000000020
+0.4000000000 0.0000000000 0.8108108188 0.1351351377
+EOF
+paste output/zvo_DynamicalGreen.dat reference.dat > paste2.dat
+diff=`awk 'BEGIN{diff='${diff}'} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste2.dat`
+
+test "${diff}" = "0.000000"
+
+exit $?

--- a/test/spectrum_spingc_offdiag_szsz.sh
+++ b/test/spectrum_spingc_offdiag_szsz.sh
@@ -189,6 +189,10 @@ EOF
 paste output/zvo_DynamicalGreen.dat reference.dat > paste2.dat
 diff=`awk 'BEGIN{diff='${diff}'} {diff+=sqrt(($3-$7)*($3-$7))+sqrt(($4-$8)*($4-$8))} END{printf "%8.6f", diff}' paste2.dat`
 
-test "${diff}" = "0.000000"
+echo "spectrum_spingc_offdiag_szsz: accumulated L1 diff vs reference = ${diff}"
+# Reference values were generated with a different BLAS (Accelerate on macOS);
+# allow a small cross-platform tolerance on the accumulated L1 difference.
+# A genuine regression shifts the spectrum by O(0.1) or more, far above this.
+awk -v d="${diff}" 'BEGIN { exit (d < 1.0e-3) ? 0 : 1 }'
 
 exit $?

--- a/test/tools/README.md
+++ b/test/tools/README.md
@@ -18,12 +18,11 @@ quantity by dense diagonalization.
 
 ## Requirements / how to run
 
-Only `numpy` is required. Activate the project Python environment first:
+Only `numpy` is required. Run with any Python 3 interpreter that has it:
 
 ```sh
-pyenv activate venv312
-python test/tools/exact_diag_hubbard_offdiag.py
-python test/tools/exact_diag_spin_offdiag.py
+python3 test/tools/exact_diag_hubbard_offdiag.py
+python3 test/tools/exact_diag_spin_offdiag.py
 ```
 
 Each script prints the ground-state energy `E0` (which equals the `OmegaOrg`

--- a/test/tools/README.md
+++ b/test/tools/README.md
@@ -1,0 +1,53 @@
+# Off-diagonal dynamical Green function: reference-value validation
+
+These small exact-diagonalization (ED) scripts independently reproduce the
+reference values hard-coded in the off-diagonal dynamical Green-function
+regression tests, so the references can be re-derived and audited rather than
+trusted blindly.
+
+The tests compute `G_BA(z) = <gs| B^dagger (z-H)^-1 A |gs>` (ket excitation `A`,
+bra excitation `B`) via HPhi's shifted BiCG; these scripts compute the same
+quantity by dense diagonalization.
+
+## Scripts
+
+| script | model | validates tests |
+|---|---|---|
+| `exact_diag_hubbard_offdiag.py` | 4-site Hubbard ring (t=1, U=4, half filling) | `spectrum_hubbard_offdiag_single`, `spectrum_hubbard_offdiag_pair_density`, `spectrum_hubbard_offdiag_single_mpi` |
+| `exact_diag_spin_offdiag.py`    | 4-site Heisenberg ring (J=1), spin S=1/2 and S=1 | `spectrum_spin_offdiag_szsz`, `spectrum_spingc_offdiag_szsz` |
+
+## Requirements / how to run
+
+Only `numpy` is required. Activate the project Python environment first:
+
+```sh
+pyenv activate venv312
+python test/tools/exact_diag_hubbard_offdiag.py
+python test/tools/exact_diag_spin_offdiag.py
+```
+
+Each script prints the ground-state energy `E0` (which equals the `OmegaOrg`
+used in the test inputs) followed by `omega  Re G  Im G` for `omega = 0.0 .. 0.4`.
+Compare those columns to the `reference.dat` blocks embedded in the matching
+`test/*.sh`.
+
+## Agreement and tolerances
+
+- HPhi uses shifted BiCG with `LanczosEps = 14`, so its output matches the exact
+  ED here to about `1e-8` (single / Sz-Sz) and `1e-6` (pair-density). The serial
+  regression tests embed the HPhi output itself, so their internal `L2 diff`
+  is `0.000000`; the ED scripts are the *independent* correctness check.
+- The MPI test (`spectrum_hubbard_offdiag_single_mpi`) compares an `np=4` run to
+  the serial/exact reference with a `< 1e-5` tolerance, because MPI changes the
+  BiCG convergence path (observed `L2 diff ~ 3e-7`).
+
+## Conventions (must match HPhi)
+
+- `z = omega + OmegaOrg + i*OmegaIm`, with `OmegaOrg = E0`.
+- `numpy.vdot(B, x)` conjugates its first argument, matching HPhi's
+  `VecProdMPI(<B phi|, .)` projection, i.e. the `<B phi|` direction.
+- The bra operators are written in the `*Bra` files as `B` (not `B^dagger`); the
+  computed quantity is `<phi| B^dagger (z-H)^-1 A |phi>`.
+- `Sz_i` is the standard pair-operator representation
+  (S=1/2: `-0.5 n_{i,0} + 0.5 n_{i,1}`; S=1: `-n_{i,0} + n_{i,2}`). The overall
+  sign convention is irrelevant for the `Sz`-`Sz` correlation.

--- a/test/tools/exact_diag_hubbard_offdiag.py
+++ b/test/tools/exact_diag_hubbard_offdiag.py
@@ -28,8 +28,7 @@ with z = omega + OmegaOrg + i*OmegaIm, OmegaOrg = E0.  numpy.vdot conjugates its
 first argument, mirroring HPhi's VecProdMPI(<B phi|, .) projection.
 
 Run (requires numpy; see test/tools/README.md):
-    pyenv activate venv312
-    python test/tools/exact_diag_hubbard_offdiag.py
+    python3 test/tools/exact_diag_hubbard_offdiag.py
 
 The printed values agree with HPhi (BiCG) to ~1e-8 (single) / ~1e-6 (pair).
 """

--- a/test/tools/exact_diag_hubbard_offdiag.py
+++ b/test/tools/exact_diag_hubbard_offdiag.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# HPhi  -  Quantum Lattice Model Simulator
+# Copyright (C) 2015 Takahiro Misawa, Kazuyoshi Yoshimi, Mitsuaki Kawamura, Youhei Yamaji, Synge Todo, Naoki Kawashima
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Independent exact-diagonalization check of the off-diagonal dynamical Green
+function references used by the HPhi regression tests
+
+    test/spectrum_hubbard_offdiag_single.sh        (single excitation)
+    test/spectrum_hubbard_offdiag_pair_density.sh  (pair / density excitation)
+    test/spectrum_hubbard_offdiag_single_mpi.sh    (MPI consistency)
+
+Model: 1D Hubbard 4-site ring (t=1, U=4, PBC, Nup=Ndown=2), E0 = -2.1027484835.
+
+Convention (matches HPhi): G_BA(omega) = <gs| B^dagger (z - H)^-1 A |gs>
+with z = omega + OmegaOrg + i*OmegaIm, OmegaOrg = E0.  numpy.vdot conjugates its
+first argument, mirroring HPhi's VecProdMPI(<B phi|, .) projection.
+
+Run (requires numpy; see test/tools/README.md):
+    pyenv activate venv312
+    python test/tools/exact_diag_hubbard_offdiag.py
+
+The printed values agree with HPhi (BiCG) to ~1e-8 (single) / ~1e-6 (pair).
+"""
+import numpy as np
+import itertools
+
+L = 4
+t = 1.0
+U = 4.0
+
+
+def popcount(x):
+    return bin(x).count("1")
+
+
+def orb(site, spin):
+    # spin-orbital index: o = 2*site + spin (spin 0 = up, 1 = down)
+    return 2 * site + spin
+
+
+def fermion_sign(state, o):
+    """Sign from anticommuting c_o^(dag) past lower-index occupied orbitals."""
+    return -1 if (popcount(state & ((1 << o) - 1)) & 1) else 1
+
+
+def annihilate(state, o):
+    if not (state >> o) & 1:
+        return None, 0
+    return state & ~(1 << o), fermion_sign(state, o)
+
+
+def create(state, o):
+    if (state >> o) & 1:
+        return None, 0
+    return state | (1 << o), fermion_sign(state, o)
+
+
+def build_basis(nup, ndown):
+    up_orbs = [orb(s, 0) for s in range(L)]
+    dn_orbs = [orb(s, 1) for s in range(L)]
+    states = []
+    for ups in itertools.combinations(up_orbs, nup):
+        for dns in itertools.combinations(dn_orbs, ndown):
+            st = 0
+            for o in ups + dns:
+                st |= (1 << o)
+            states.append(st)
+    states.sort()
+    index = {st: i for i, st in enumerate(states)}
+    return states, index
+
+
+def build_H(states, index):
+    n = len(states)
+    H = np.zeros((n, n), dtype=complex)
+    bonds = [(s, (s + 1) % L) for s in range(L)]  # PBC chain
+    for i, st in enumerate(states):
+        # U n_up n_down
+        diag = 0.0
+        for s in range(L):
+            if ((st >> orb(s, 0)) & 1) and ((st >> orb(s, 1)) & 1):
+                diag += U
+        H[i, i] += diag
+        # -t hopping c^dag_{i s} c_{j s} + h.c.
+        for (a, b) in bonds:
+            for spin in (0, 1):
+                oa, ob = orb(a, spin), orb(b, spin)
+                for (o1, o2) in ((oa, ob), (ob, oa)):  # both directions
+                    s1, sgn1 = annihilate(st, o2)
+                    if s1 is None:
+                        continue
+                    s2, sgn2 = create(s1, o1)
+                    if s2 is None:
+                        continue
+                    j = index.get(s2)
+                    if j is not None:
+                        H[j, i] += -t * sgn1 * sgn2
+    return H
+
+
+def apply_single(vec, states_from, idx_to, states_to, site, spin, itype):
+    """itype==1: creation c^dag; else annihilation c. Returns vector in target basis."""
+    out = np.zeros(len(states_to), dtype=complex)
+    o = orb(site, spin)
+    for i, st in enumerate(states_from):
+        if vec[i] == 0:
+            continue
+        if itype == 1:
+            st2, sgn = create(st, o)
+        else:
+            st2, sgn = annihilate(st, o)
+        if st2 is None:
+            continue
+        j = idx_to.get(st2)
+        if j is not None:
+            out[j] += sgn * vec[i]
+    return out
+
+
+def apply_number(vec, states, site, spin):
+    """n_{site,spin} (diagonal, preserves sector)."""
+    o = orb(site, spin)
+    out = np.zeros(len(states), dtype=complex)
+    for i, st in enumerate(states):
+        if (st >> o) & 1:
+            out[i] = vec[i]
+    return out
+
+
+def main():
+    # Ground state in (Nup=2, Ndown=2)
+    states0, idx0 = build_basis(2, 2)
+    H0 = build_H(states0, idx0)
+    evals, evecs = np.linalg.eigh(H0)
+    E0 = evals[0]
+    gs = evecs[:, 0]
+    print(f"E0 = {E0:.10f}  (dim {len(states0)})")
+
+    omega_org = E0
+    eta = 0.1
+    omegas = [0.0, 0.1, 0.2, 0.3, 0.4]
+
+    def green(a_ket, b_bra, states_mid, idx_mid):
+        """G(omega) = <gs| B^dag (z-H_mid)^-1 A |gs>, z = omega + OmegaOrg + i eta."""
+        h_mid = build_H(states_mid, idx_mid)
+        out = []
+        for w in omegas:
+            z = w + omega_org + 1j * eta
+            x = np.linalg.solve(z * np.eye(len(states_mid)) - h_mid, a_ket)
+            out.append(np.vdot(b_bra, x))  # <B bra| x>
+        return out
+
+    # single: A = c_{1up} (annihilate), B = c_{0up}; mid sector (Nup=1, Ndown=2)
+    states_m, idx_m = build_basis(1, 2)
+    a_single = apply_single(gs, states0, idx_m, states_m, site=1, spin=0, itype=0)
+    b_single = apply_single(gs, states0, idx_m, states_m, site=0, spin=0, itype=0)
+    print("\n# single  G_BA = <gs| c0up^dag (z-H)^-1 c1up |gs>")
+    for w, g in zip(omegas, green(a_single, b_single, states_m, idx_m)):
+        print(f"{w:.4f}  {g.real:.10f}  {g.imag:.10f}")
+
+    # pair-density: A = n_{0up}, B = n_{1up}; same (Nup=2, Ndown=2) sector
+    a_pair = apply_number(gs, states0, site=0, spin=0)
+    b_pair = apply_number(gs, states0, site=1, spin=0)
+    print("\n# pair-density  G_BA = <gs| n1up (z-H)^-1 n0up |gs>")
+    for w, g in zip(omegas, green(a_pair, b_pair, states0, idx0)):
+        print(f"{w:.4f}  {g.real:.10f}  {g.imag:.10f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tools/exact_diag_spin_offdiag.py
+++ b/test/tools/exact_diag_spin_offdiag.py
@@ -29,8 +29,7 @@ SpinGC results coincide (the two HPhi tests exercise different leaves but expect
 the same values).  Works for any spin via twoS = 2S.
 
 Run (requires numpy; see test/tools/README.md):
-    pyenv activate venv312
-    python test/tools/exact_diag_spin_offdiag.py
+    python3 test/tools/exact_diag_spin_offdiag.py
 
 The printed values agree with HPhi (BiCG) to ~1e-8.
 """

--- a/test/tools/exact_diag_spin_offdiag.py
+++ b/test/tools/exact_diag_spin_offdiag.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# HPhi  -  Quantum Lattice Model Simulator
+# Copyright (C) 2015 Takahiro Misawa, Kazuyoshi Yoshimi, Mitsuaki Kawamura, Youhei Yamaji, Synge Todo, Naoki Kawashima
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Independent exact-diagonalization check of the off-diagonal Sz-Sz dynamical
+Green-function references used by the HPhi regression tests
+
+    test/spectrum_spin_offdiag_szsz.sh     (canonical Spin: S=1/2 + S=1)
+    test/spectrum_spingc_offdiag_szsz.sh   (SpinGC:        S=1/2 + S=1)
+
+Model: Heisenberg ring (chain, PBC), H = J sum_<ij> S_i . S_j, J=1, L=4.
+Ground-state energies: E0 = -2 (S=1/2), E0 = -6 (S=1).
+
+G_BA(omega) = <gs| Sz_1 (z - H)^-1 Sz_0 |gs>, z = omega + E0 + i*eta.
+Sz conserves total Sz and the ground state is in Sz=0, so the canonical Spin and
+SpinGC results coincide (the two HPhi tests exercise different leaves but expect
+the same values).  Works for any spin via twoS = 2S.
+
+Run (requires numpy; see test/tools/README.md):
+    pyenv activate venv312
+    python test/tools/exact_diag_spin_offdiag.py
+
+The printed values agree with HPhi (BiCG) to ~1e-8.
+"""
+import numpy as np
+
+
+def run(L, twoS, bonds, omegas, eta=0.1, J=1.0):
+    d = twoS + 1                       # local dimension (2S+1)
+    S = twoS / 2.0
+    m = np.array([S - k for k in range(d)])   # Sz eigenvalues: S, S-1, ..., -S
+    Sz = np.diag(m)
+    # S^+ raises Sz by 1, S^- lowers it: <m+-1|S^+-|m> = sqrt(S(S+1) - m(m+-1))
+    Sp = np.zeros((d, d))
+    Sm = np.zeros((d, d))
+    for k in range(d):
+        mm = m[k]
+        if k > 0:               # raise m -> m+1 (index k-1)
+            Sp[k - 1, k] = np.sqrt(S * (S + 1) - mm * (mm + 1))
+        if k < d - 1:           # lower m -> m-1 (index k+1)
+            Sm[k + 1, k] = np.sqrt(S * (S + 1) - mm * (mm - 1))
+    I = np.eye(d)
+
+    def op_at(site, M):
+        out = np.array([[1.0]])
+        for s in range(L):
+            out = np.kron(out, M if s == site else I)
+        return out
+
+    dim = d ** L
+    H = np.zeros((dim, dim))
+    for (a, b) in bonds:
+        Sza, Szb = op_at(a, Sz), op_at(b, Sz)
+        Spa, Sma = op_at(a, Sp), op_at(a, Sm)
+        Spb, Smb = op_at(b, Sp), op_at(b, Sm)
+        H += J * (Sza @ Szb + 0.5 * (Spa @ Smb + Sma @ Spb))
+
+    evals, evecs = np.linalg.eigh(H)
+    E0 = evals[0]
+    gs = evecs[:, 0]
+    A = op_at(0, Sz) @ gs       # Sz_0 |gs>
+    B = op_at(1, Sz) @ gs       # Sz_1 |gs>
+    res = []
+    for w in omegas:
+        z = w + E0 + 1j * eta
+        x = np.linalg.solve(z * np.eye(dim) - H, A)
+        res.append(np.vdot(B, x))   # <Sz_1 gs| x>
+    return E0, res
+
+
+def main():
+    L = 4
+    bonds = [(s, (s + 1) % L) for s in range(L)]  # PBC ring
+    omegas = [0.0, 0.1, 0.2, 0.3, 0.4]
+    for twoS, label in [(1, "S=1/2 (Half leaf)"), (2, "S=1 (General leaf)")]:
+        E0, g = run(L, twoS, bonds, omegas)
+        print(f"\n# Heisenberg ring L=4, {label};  E0 = {E0:.10f}")
+        for w, val in zip(omegas, g):
+            print(f"{w:.4f}  {val.real:.10f}  {val.imag:.10f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/unittest_excitation_sector_shift.c
+++ b/test/unittest_excitation_sector_shift.c
@@ -1,0 +1,106 @@
+/* Unit test for the off-diagonal excitation sector-shift truth table
+ * (GetExcitationSectorShift / GetExcitationOperatorSetShift).
+ * Returns non-zero if any case disagrees with the expected behavior. */
+#include "Common.h"
+#include "ExcitationSectorShift.h"
+#include <stdio.h>
+
+static int g_fail = 0;
+
+static void check_single(const char *name, int model, int gen, int op0, int op1, int op2,
+                         int wantValid, int dNe, int dNup, int dNdown, int dT2Sz) {
+  int op[3] = {op0, op1, op2};
+  SectorShift s = GetExcitationSectorShift(model, gen, FALSE, op);
+  int ok = (s.valid == wantValid);
+  if (wantValid == TRUE)
+    ok = ok && s.dNe == dNe && s.dNup == dNup && s.dNdown == dNdown && s.dTotal2Sz == dT2Sz;
+  printf("%-40s : %s\n", name, ok ? "OK" : "FAIL");
+  if (!ok) {
+    printf("   got valid=%d (dNe=%d dNup=%d dNdown=%d dT2Sz=%d reason=%d)\n",
+           s.valid, s.dNe, s.dNup, s.dNdown, s.dTotal2Sz, s.reason);
+    g_fail = 1;
+  }
+}
+
+static void check_pair(const char *name, int model, int gen,
+                       int s1, int sp1, int s2, int sp2, int type,
+                       int wantValid, int dNe, int dNup, int dNdown, int dT2Sz) {
+  int op[5] = {s1, sp1, s2, sp2, type};
+  SectorShift s = GetExcitationSectorShift(model, gen, TRUE, op);
+  int ok = (s.valid == wantValid);
+  if (wantValid == TRUE)
+    ok = ok && s.dNe == dNe && s.dNup == dNup && s.dNdown == dNdown && s.dTotal2Sz == dT2Sz;
+  printf("%-40s : %s\n", name, ok ? "OK" : "FAIL");
+  if (!ok) {
+    printf("   got valid=%d (dNe=%d dNup=%d dNdown=%d dT2Sz=%d reason=%d)\n",
+           s.valid, s.dNe, s.dNup, s.dNdown, s.dTotal2Sz, s.reason);
+    g_fail = 1;
+  }
+}
+
+static void check_reason(const char *name, int model, int gen, int isPair, int wantReason,
+                         int **op, int nOp) {
+  SectorShift s = GetExcitationOperatorSetShift(model, gen, isPair, op, nOp);
+  int ok = (s.valid == FALSE && s.reason == wantReason);
+  printf("%-40s : %s\n", name, ok ? "OK" : "FAIL");
+  if (!ok) {
+    printf("   got valid=%d reason=%d (want reason=%d)\n", s.valid, s.reason, wantReason);
+    g_fail = 1;
+  }
+}
+
+int main(void) {
+  /* --- Hubbard single (spin 0 = up). type 1 = creation, 0 = annihilation --- */
+  check_single("Hubbard single c_up^dag (cis)", Hubbard, 0, 0, 0, 1, TRUE, +1, +1, 0, 0);
+  check_single("Hubbard single c_up (ajt)",     Hubbard, 0, 0, 0, 0, TRUE, -1, -1, 0, 0);
+  check_single("Hubbard single c_dn^dag (cis)", Hubbard, 0, 0, 1, 1, TRUE, +1, 0, +1, 0);
+  check_single("Hubbard single c_dn (ajt)",     Hubbard, 0, 0, 1, 0, TRUE, -1, 0, -1, 0);
+
+  /* --- Hubbard pair: off-diagonal spin flips Nup/Ndown; diagonal -> no shift --- */
+  check_pair("Hubbard pair n_up (diag)",        Hubbard, 0, 0, 0, 0, 0, 1, TRUE, 0, 0, 0, 0);
+  check_pair("Hubbard pair c_up^dag c_dn",      Hubbard, 0, 0, 0, 0, 1, 1, TRUE, 0, +1, -1, 0);
+  check_pair("Hubbard pair c_dn^dag c_up",      Hubbard, 0, 0, 1, 0, 0, 1, TRUE, 0, -1, +1, 0);
+
+  /* --- SpinGC pair: full GC space, never shifts --- */
+  check_pair("SpinGC pair (diag)",  SpinGC, 0, 0, 0, 0, 0, 1, TRUE, 0, 0, 0, 0);
+  check_pair("SpinGC pair (flip)",  SpinGC, 0, 0, 0, 0, 1, 1, TRUE, 0, 0, 0, 0);
+
+  /* --- canonical Spin (half): spin convention opposite to Hubbard --- */
+  check_pair("Spin half pair flip(0->1)", Spin, 0, 0, 0, 0, 1, 1, TRUE, 0, -1, +1, 0);
+  check_pair("Spin half pair flip(1->0)", Spin, 0, 0, 1, 0, 0, 1, TRUE, 0, +1, -1, 0);
+  check_pair("Spin half pair (diag)",     Spin, 0, 0, 0, 0, 0, 1, TRUE, 0, 0, 0, 0);
+
+  /* --- general Spin: Total2Sz = 2*(spin1-spin2) --- */
+  check_pair("Spin general flip 0->2", Spin, 1, 0, 0, 0, 2, 1, TRUE, 0, 0, 0, -4);
+  check_pair("Spin general diag",      Spin, 1, 0, 1, 0, 1, 1, TRUE, 0, 0, 0, 0);
+
+  /* --- single excitation not allowed for spin --- */
+  check_single("Spin single -> invalid",   Spin,   0, 0, 0, 1, FALSE, 0, 0, 0, 0);
+  check_single("SpinGC single -> invalid", SpinGC, 0, 0, 0, 1, FALSE, 0, 0, 0, 0);
+
+  /* --- deferred (non-allow-list) models -> invalid (MODEL_NOT_ALLOWED) --- */
+  { int row[5] = {0, 0, 0, 0, 1}; int *op[1] = {row};
+    check_reason("Kondo pair    -> MODEL_NOT_ALLOWED",   Kondo,   0, TRUE, OFFDIAG_SHIFT_MODEL_NOT_ALLOWED, op, 1);
+    check_reason("KondoGC pair  -> MODEL_NOT_ALLOWED",   KondoGC, 0, TRUE, OFFDIAG_SHIFT_MODEL_NOT_ALLOWED, op, 1);
+    check_reason("tJ pair       -> MODEL_NOT_ALLOWED",   tJ,      0, TRUE, OFFDIAG_SHIFT_MODEL_NOT_ALLOWED, op, 1);
+    check_reason("tJGC pair     -> MODEL_NOT_ALLOWED",   tJGC,    0, TRUE, OFFDIAG_SHIFT_MODEL_NOT_ALLOWED, op, 1);
+    check_reason("HubbardGC pair-> MODEL_NOT_ALLOWED",   HubbardGC,0, TRUE, OFFDIAG_SHIFT_MODEL_NOT_ALLOWED, op, 1);
+  }
+
+  /* --- operator-set internal consistency --- */
+  { /* Hubbard single set: two up annihilations (same shift) -> valid */
+    int r0[3] = {0, 0, 0}, r1[3] = {1, 0, 0}; int *op[2] = {(int*)r0, (int*)r1};
+    SectorShift s = GetExcitationOperatorSetShift(Hubbard, 0, FALSE, op, 2);
+    int ok = (s.valid == TRUE && s.dNe == -1);
+    printf("%-40s : %s\n", "Hubbard single set (consistent)", ok ? "OK" : "FAIL");
+    if (!ok) { printf("   got valid=%d dNe=%d\n", s.valid, s.dNe); g_fail = 1; }
+  }
+  { /* Hubbard single set: annihilation + creation (mixed shift) -> SET_INCONSISTENT */
+    int r0[3] = {0, 0, 0}, r1[3] = {0, 0, 1}; int *op[2] = {(int*)r0, (int*)r1};
+    check_reason("Hubbard single set (inconsistent)", Hubbard, 0, FALSE,
+                 OFFDIAG_SHIFT_SET_INCONSISTENT, op, 2);
+  }
+
+  printf("\n%s\n", g_fail ? "UNIT TEST FAILED" : "UNIT TEST PASSED");
+  return g_fail;
+}


### PR DESCRIPTION
## Summary

Reimplements **off-diagonal dynamical Green's functions**

G_BA(z) = <φ| B† (z − H)⁻¹ A |φ>

on top of the current `develop`, where the left (bra, `B`) and right (ket, `A`)
excitation operators may differ. This re-derives the legacy `new_spectrum`
branch cleanly against the current `develop`, adding Hilbert-sector guards,
invalid-input rejection, and small exact-diagonalization regression tests.

Original `new_spectrum` work by **Takahiro Misawa** and **Youhei Yamaji**;
re-derived here against current `develop` (the original branch is kept as a
reference and can be removed after this lands).

## What's new

- **New bra-side inputs** `SingleExcitationBra` / `PairExcitationBra` describing
  the left excitation operator `B` (the existing `SingleExcitation` /
  `PairExcitation` keep describing the right operator `A`).
- New additive `ExcitationSectorShift.c/.h` (`GetExcitationSectorShift` /
  `GetExcitationOperatorSetShift`): a truth table for the per-model ΔN / ΔSz
  sector shift of each excitation operator set. `MakeExcitedList` is unchanged.
- Excitation helpers down to the leaf are parametrized by an operator set so a
  bra operator set different from the ket can be applied (helper-ized, no
  pointer swapping). Diagonal spectrum is byte-for-byte unchanged.
- `CalcSpectrumByBiCG` gains an explicit **left-vector** argument (defaults to
  the existing `vrhs`, i.e. diagonal behaviour).
- `CalcSpectrum.c` builds `B|φ>` and routes the off-diagonal evaluation through
  the CG/BiCG path.
- **Bra-gated guards** (only active when a bra input is given): CG method only,
  `CalcSpec = Normal` only, operator-kind match (single↔single / pair↔pair),
  ket/bra sector match (same ΔN, ΔSz), bra zero-norm warning. Distinct reason
  codes separate "model not allowed" from "operator set inconsistent". A
  defensive guard inside `CalcSpectrum()` backstops the path.
- Restart/save spectrum modes (`CalcSpec ≠ Normal`) are rejected when a bra
  input is supplied (see Scope below for the rationale).
- `check.c` memory estimate accounts for the extra bra vector.

## Scope and limitations

- **Spinless-fermion off-diagonal** is out of scope and rejected by the guard.
- **Restart/save modes (`CalcSpec ≠ Normal`) are rejected for off-diagonal
  (bra) runs**, because saved BiCG tridiagonal components record no bra-operator
  metadata; off-diagonal spectra must be computed from a fresh BiCG iteration.
  (Deferred until such metadata is added.)

## Testing

- New regression tests added to `test/` + `test/CMakeLists.txt`:
  - Hubbard off-diagonal single-particle and pair-density Green's functions
  - Spin / SpinGC off-diagonal Sz-Sz (Half and General S)
  - Off-diagonal bra-guard negative tests (method/CalcSpec/kind/sector/spinless)
  - `unittest_excitation_sector_shift` truth-table unit test
  - `spectrum_hubbard_offdiag_single_mpi` MPI (np=4) consistency test
- Reference values computed by an **independent exact diagonalization**
  (Hubbard / Heisenberg, general S) ; agreement ~1e-6–1e-8.
  The verification scripts are bundled (GPLv3) under `test/tools/`.
- Full `ctest` green across configurations: 80 serial; np=4 (including the
  off-diagonal MPI consistency test); np=16 `*_mpidouble`.
- EN / JA user manuals updated with the `SingleExcitationBra` /
  `PairExcitationBra` specification; EN PDF builds.
