### PR TITLE
Print Spinless batching stats + add batched-vs-NOBATCH equivalence tests

### DIFF
--- a/src/mltplyMPIBatched.c
+++ b/src/mltplyMPIBatched.c
@@ -270,6 +270,21 @@ int InitializeMPIBatchedTransfers_SpinlessFermionGC(
     free(origin_count);
     free(unique_origins);
 
+    // Debug output: show batching statistics (parity with the Hubbard/Spin
+    // models, which already print this; lets tests confirm the batched
+    // Spinless MPIsingle path actually fired).
+    {
+        int total_transfers = 0, gg;
+        for (gg = 0; gg < batched->num_groups; gg++) {
+            total_transfers += batched->groups[gg].num_transfers;
+        }
+        if (myrank == 0) {
+            fprintf(stdout, "  [MPI Batching] Spinless: %d MPIsingle transfers -> %d groups (%.1fx reduction)\n",
+                    total_transfers, batched->num_groups,
+                    batched->num_groups > 0 ? (double)total_transfers / batched->num_groups : 0.0);
+        }
+    }
+
     batched->is_initialized = 1;
     return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -320,10 +320,20 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_consistency_te_hubbardgc_twobody min:4)
     add_hphi_mpi_test(mpi_consistency_te_hubbard_twobody min:4)
     add_hphi_mpi_test(mpi_nobatch_equivalence min:4)
+    # batched-vs-nobatch equivalence for the paths the base test does not reach:
+    # MPIdouble (np=16), HubbardGC off-diagonal InterAll, SpinGC PairLift, Spinless.
+    add_hphi_mpi_test(mpi_nobatch_equivalence_mpidouble exact:16)
+    add_hphi_mpi_test(mpi_nobatch_equivalence_interall exact:4)
+    add_hphi_mpi_test(mpi_nobatch_equivalence_pairlift exact:4)
+    add_hphi_mpi_test_with_srcdir(mpi_nobatch_equivalence_spinless exact:4)
 
     # MPI consistency test labels
     set_tests_properties(
         mpi_nobatch_equivalence
+        mpi_nobatch_equivalence_mpidouble
+        mpi_nobatch_equivalence_interall
+        mpi_nobatch_equivalence_pairlift
+        mpi_nobatch_equivalence_spinless
         PROPERTIES LABELS "mpi;nobatch")
     set_tests_properties(
         mpi_consistency_hubbard mpi_consistency_hubbardgc mpi_consistency_te_hubbard

--- a/test/mpi_nobatch_equivalence_interall.sh
+++ b/test/mpi_nobatch_equivalence_interall.sh
@@ -1,0 +1,62 @@
+#!/bin/sh -e
+# Assert HPHI_MPI_NOBATCH=1 (per-term MPI) reproduces the batched result for the
+# HubbardGC off-diagonal InterAll path (X_child_GC_InterAll_Hubbard_MPI_batched),
+# the most complex batched routine and the one PR #216 review H-1 found a stale-
+# state bug in. No StdFace standard-mode input produces an inter-process
+# off-diagonal InterAll, so this builds the base defs with -sdry and injects an
+# explicit off-diagonal InterAll term coupling site 0 to the last site (site 3),
+# which straddles the inter-process boundary at np=4.
+if [ -z "${MPIRUN}" ]; then echo "MPIRUN not set. Skipping."; exit 0; fi
+
+mkdir -p mpi_nobatch_equivalence_interall
+cd mpi_nobatch_equivalence_interall
+
+cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+Lanczos_max = 2000
+initial_iv = 1
+EOF
+
+# Generate the standard-mode definition files (serial -sdry; np-independent).
+../../src/HPhi -sdry stan.in > log_sdry.txt 2>&1
+
+# Inject an explicit off-diagonal InterAll term + its Hermitian conjugate:
+#   c^dag_{3,up} c_{0,up} n_{0,down}   and its h.c.
+# Couples site 0 and site 3 -> inter-process at np=4 -> batched InterAll path.
+cat > interall.def <<EOF
+========================
+NInterAll 2
+========================
+========zInterAll=======
+========================
+    3 0 0 0 0 1 0 1 0.5000000000000000 0.0000000000000000
+    0 1 0 1 0 0 3 0 0.5000000000000000 0.0000000000000000
+EOF
+# Register the InterAll file in the StdFace-generated namelist.
+printf '    InterAll  interall.def\n' >> namelist.def
+
+run_side() {  # $1 = tag, $2 = HPHI_MPI_NOBATCH value (empty or 1)
+  tag="$1"; nb="$2"
+  rm -rf output
+  if [ -n "$nb" ]; then env_pfx="HPHI_MPI_NOBATCH=$nb"; else env_pfx=""; fi
+  env $env_pfx ${MPIRUN} ../../src/HPhi -e namelist.def > "log_${tag}.txt" 2>&1
+  cp output/zvo_energy.dat "energy_${tag}.dat"
+}
+
+run_side batched ""
+# Confirm the batched off-diagonal InterAll path actually fired.
+if ! grep -q "InterAll:.*MPI terms -> .* groups" log_batched.txt; then
+  echo "ERROR: batched HubbardGC InterAll path did not fire"; grep -i "InterAll" log_batched.txt || true; exit 1
+fi
+run_side nobatch 1
+
+d=$(paste energy_batched.dat energy_nobatch.dat \
+    | awk '$2 ~ /^[-+0-9.eE]+$/ && $4 ~ /^[-+0-9.eE]+$/ { x=$2-$4; if(x<0)x=-x; if(x>m)m=x } END{ printf "%.3e", m+0 }')
+echo "[interall] max |batched - nobatch| energy = ${d}"
+awk -v d="${d}" 'BEGIN{ exit (d < 1e-10) ? 0 : 1 }' || { echo "[interall] MISMATCH"; exit 1; }
+echo "HubbardGC off-diagonal InterAll: batched == no-batch within tolerance."

--- a/test/mpi_nobatch_equivalence_mpidouble.sh
+++ b/test/mpi_nobatch_equivalence_mpidouble.sh
@@ -1,0 +1,55 @@
+#!/bin/sh -e
+# Assert HPHI_MPI_NOBATCH=1 (per-term MPI) reproduces the batched result for the
+# MPIdouble transfer path (both transfer sites inter-process). This needs 16 MPI
+# ranks so that a 4-site chain puts sites 2,3 inter-process, exercising
+# X_child_general_hopp_MPIdouble_batched / X_child_GC_general_hopp_MPIdouble_batched.
+# The existing mpi_nobatch_equivalence test only reaches MPIsingle at np=4.
+if [ -z "${MPIRUN}" ]; then echo "MPIRUN not set. Skipping."; exit 0; fi
+
+mkdir -p mpi_nobatch_equivalence_mpidouble
+cd mpi_nobatch_equivalence_mpidouble
+
+run_one() {  # $1 = tag; stan.in body on stdin
+  tag="$1"
+  cat > "stan_${tag}.in"
+  rm -rf output
+  ${MPIRUN} ../../src/HPhi -s "stan_${tag}.in" > "log_${tag}_batched.txt" 2>&1
+  cp output/zvo_energy.dat "energy_${tag}_batched.dat"
+  # Confirm the batched MPIdouble path actually fired (not "No inter-process transfers").
+  if ! grep -q "MPIdouble:.*-> .* groups" "log_${tag}_batched.txt"; then
+    echo "[${tag}] ERROR: batched MPIdouble path did not fire"; grep -i "MPIdouble" "log_${tag}_batched.txt" || true; exit 1
+  fi
+  rm -rf output
+  HPHI_MPI_NOBATCH=1 ${MPIRUN} ../../src/HPhi -s "stan_${tag}.in" > "log_${tag}_nobatch.txt" 2>&1
+  cp output/zvo_energy.dat "energy_${tag}_nobatch.dat"
+  d=$(paste "energy_${tag}_batched.dat" "energy_${tag}_nobatch.dat" \
+      | awk '$2 ~ /^[-+0-9.eE]+$/ && $4 ~ /^[-+0-9.eE]+$/ { x=$2-$4; if(x<0)x=-x; if(x>m)m=x } END{ printf "%.3e", m+0 }')
+  echo "[${tag}] max |batched - nobatch| energy = ${d}"
+  awk -v d="${d}" 'BEGIN{ exit (d < 1e-10) ? 0 : 1 }' || { echo "[${tag}] MISMATCH"; exit 1; }
+}
+
+run_one hubbard <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+nelec = 4
+2Sz = 0
+Lanczos_max = 2000
+initial_iv = 1
+EOF
+
+run_one hubbardgc <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+Lanczos_max = 2000
+initial_iv = 1
+EOF
+
+echo "MPIdouble: batched == no-batch within tolerance."

--- a/test/mpi_nobatch_equivalence_pairlift.sh
+++ b/test/mpi_nobatch_equivalence_pairlift.sh
@@ -1,0 +1,61 @@
+#!/bin/sh -e
+# Assert HPHI_MPI_NOBATCH=1 (per-term MPI) reproduces the batched result for the
+# SpinGC PairLift MPIsingle path. The SpinGC batched init scans Exchange AND
+# PairLift together, but every existing SpinGC test input is pure Heisenberg
+# (zero PairLift terms), so the PairLift branch is never exercised. This injects
+# an explicit PairLift coupling site 0 to an inter-process site (site 7).
+# J is set to 0 so there are NO Exchange terms: the single inter-process
+# MPIsingle term the batched group reports then comes ONLY from the PairLift,
+# so the path-fired guard below proves the PairLift branch (not Exchange) fired.
+if [ -z "${MPIRUN}" ]; then echo "MPIRUN not set. Skipping."; exit 0; fi
+
+mkdir -p mpi_nobatch_equivalence_pairlift
+cd mpi_nobatch_equivalence_pairlift
+
+cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 8
+2S = 1
+J = 0.0
+Lanczos_max = 2000
+initial_iv = 1
+EOF
+
+# Generate the standard-mode definition files (serial -sdry).
+../../src/HPhi -sdry stan.in > log_sdry.txt 2>&1
+
+# Inject a PairLift term coupling site 0 and the inter-process site 7.
+cat > pairlift.def <<EOF
+=============================================
+NPairLift          1
+=============================================
+====== Pair-Lift term ============
+=============================================
+    0     7         0.300000000000000
+EOF
+printf '    PairLift  pairlift.def\n' >> namelist.def
+
+run_side() {  # $1 = tag, $2 = HPHI_MPI_NOBATCH value (empty or 1)
+  tag="$1"; nb="$2"
+  rm -rf output
+  if [ -n "$nb" ]; then env_pfx="HPHI_MPI_NOBATCH=$nb"; else env_pfx=""; fi
+  env $env_pfx ${MPIRUN} ../../src/HPhi -e namelist.def > "log_${tag}.txt" 2>&1
+  cp output/zvo_energy.dat "energy_${tag}.dat"
+}
+
+run_side batched ""
+# With J=0 the only inter-process MPIsingle term is the injected PairLift, so the
+# batched group must report exactly "1 MPIsingle terms" -> this proves the
+# PairLift branch fired (without the PairLift it would be "No MPIsingle terms").
+if ! grep -q "SpinGC Exchange: 1 MPIsingle terms -> 1 groups" log_batched.txt; then
+  echo "ERROR: batched SpinGC PairLift path did not fire as expected"; grep -i "SpinGC Exchange" log_batched.txt || true; exit 1
+fi
+run_side nobatch 1
+
+d=$(paste energy_batched.dat energy_nobatch.dat \
+    | awk '$2 ~ /^[-+0-9.eE]+$/ && $4 ~ /^[-+0-9.eE]+$/ { x=$2-$4; if(x<0)x=-x; if(x>m)m=x } END{ printf "%.3e", m+0 }')
+echo "[pairlift] max |batched - nobatch| energy = ${d}"
+awk -v d="${d}" 'BEGIN{ exit (d < 1e-10) ? 0 : 1 }' || { echo "[pairlift] MISMATCH"; exit 1; }
+echo "SpinGC PairLift: batched == no-batch within tolerance."

--- a/test/mpi_nobatch_equivalence_spinless.sh
+++ b/test/mpi_nobatch_equivalence_spinless.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -e
+# Assert HPHI_MPI_NOBATCH=1 (per-term MPI) reproduces the batched result for the
+# SpinlessFermion / SpinlessFermionGC transfer MPIsingle batched path. The
+# existing mpi_nobatch_equivalence test excludes the Expert-mode spinless models;
+# they are only covered serial-vs-MPI, which cannot isolate a rank-uniform
+# batched bug. This compares batched vs HPHI_MPI_NOBATCH=1 under the SAME MPIRUN
+# for both the energy and the one-body Green function.
+# $1 = CMAKE_SOURCE_DIR (for test/testSpinlessCalc.py).
+if [ -z "${MPIRUN}" ]; then echo "MPIRUN not set. Skipping."; exit 0; fi
+
+SRCDIR="$1"
+mkdir -p mpi_nobatch_equivalence_spinless
+cd mpi_nobatch_equivalence_spinless
+
+spinless_case() {  # $1 = tag, $2... = testSpinlessCalc.py args
+  tag="$1"; shift
+  python3 "${SRCDIR}/test/testSpinlessCalc.py" -p "../../src/HPhi" "$@" --onebody-offdiag > "log_${tag}_gen.txt" 2>&1
+  rm -rf output
+  ${MPIRUN} ../../src/HPhi -e namelist.def > "log_${tag}_batched.txt" 2>&1
+  # Confirm the batched Spinless MPIsingle path actually fired.
+  if ! grep -q "Spinless:.*MPIsingle transfers -> .* groups" "log_${tag}_batched.txt"; then
+    echo "[${tag}] ERROR: batched Spinless MPIsingle path did not fire"
+    grep -i "MPI Batching\|MPI batching" "log_${tag}_batched.txt" || true; exit 1
+  fi
+  cp output/zvo_energy.dat "energy_${tag}_batched.dat"
+  cp output/zvo_cisajs.dat "cisajs_${tag}_batched.dat"
+  rm -rf output
+  HPHI_MPI_NOBATCH=1 ${MPIRUN} ../../src/HPhi -e namelist.def > "log_${tag}_nobatch.txt" 2>&1
+  cp output/zvo_energy.dat "energy_${tag}_nobatch.dat"
+  cp output/zvo_cisajs.dat "cisajs_${tag}_nobatch.dat"
+  de=$(paste "energy_${tag}_batched.dat" "energy_${tag}_nobatch.dat" \
+       | awk '$2 ~ /^[-+0-9.eE]+$/ && $4 ~ /^[-+0-9.eE]+$/ { x=$2-$4; if(x<0)x=-x; if(x>m)m=x } END{ printf "%.3e", m+0 }')
+  dg=$(paste "cisajs_${tag}_batched.dat" "cisajs_${tag}_nobatch.dat" \
+       | awk '{ dre=$5-$11; dim=$6-$12; d=sqrt(dre*dre+dim*dim); if(d>m)m=d } END{ printf "%.3e", m+0 }')
+  echo "[${tag}] max |batched - nobatch| : energy = ${de} , onebody-Green = ${dg}"
+  awk -v de="${de}" -v dg="${dg}" 'BEGIN{ exit (de < 1e-10 && dg < 1e-10) ? 0 : 1 }' \
+    || { echo "[${tag}] MISMATCH"; exit 1; }
+}
+
+spinless_case spinless    -m SpinlessFermion   -s 8
+spinless_case spinless_gc -m SpinlessFermionGC -s 8 -V 0.5
+
+echo "SpinlessFermion(GC): batched == no-batch within tolerance (energy + one-body Green)."


### PR DESCRIPTION
PR #216's batched MPI scheme is default-ON. The only existing batched-vs-non- batched test (mpi_nobatch_equivalence) covers transfer MPIsingle for Hubbard/HubbardGC/Spin/SpinGC at np=4 (ground-state energy). Several other default-on batched paths have no batched-vs-non-batched coverage:

- transfer MPIdouble (Hubbard/HubbardGC) -- only tested vs a hardcoded ref
- HubbardGC off-diagonal InterAll -- the path PR #216 review H-1 found a bug in
- SpinGC PairLift MPIsingle -- never triggered (all SpinGC inputs are pure Heisenberg, with zero PairLift terms)
- SpinlessFermion(GC) transfer MPIsingle -- only serial-vs-MPI, which cannot isolate a rank-uniform batched bug

Add four tests that run the same input with the default (batched) path and with HPHI_MPI_NOBATCH=1 (per-term) under the same MPIRUN, asserting the energy (and, for spinless, the one-body Green function) agree to < 1e-10. Each test also asserts the intended batched path actually fired (via the "[MPI Batching] ... -> N groups" stdout marker), so it fails loudly if a future change stops exercising the batched code instead of silently passing.

To give the spinless test the same path-fired guard, also emit the batching statistics line for SpinlessFermion(GC) from
InitializeMPIBatchedTransfers_SpinlessFermionGC, matching the existing HubbardGC/Hubbard/Spin prints (the spinless path was the only batched model that printed nothing). This is an additive stdout diagnostic; it does not change any computation.

np gating: MPIdouble needs exact:16 (a 4-site chain puts both transfer sites inter-process); the others use exact:4. Spinful Hubbard requires nproc to be a power of 4, so exact gating keeps the tests off the np=2/8/3/9 CI ranks where they would abort.