### PR TITLE
Fix SpinlessFermion CalcHS=0 enumeration and reject diagonal spinless TE

### DIFF
--- a/src/diagonalcalc.c
+++ b/src/diagonalcalc.c
@@ -218,12 +218,27 @@ int diagonalcalcForTE
   long unsigned int A_spin, B_spin;
   double tmp_V;
 
+  /* The diagonal time-evolution handlers (SetDiagonalTE{Transfer,Chemi,InterAll})
+     do not implement SpinlessFermion / SpinlessFermionGC. A diagonal TE term on a
+     spinless model would otherwise be silently dropped, giving wrong dynamics, so
+     reject it here with a clear message. Spinless TE with only off-diagonal terms
+     has no diagonal TE term at this step and is unaffected. */
+  if ((X->Def.iCalcModel == SpinlessFermion || X->Def.iCalcModel == SpinlessFermionGC)
+      && (X->Def.NTETransferDiagonal[_istep] > 0 || X->Def.NTEInterAllDiagonal[_istep] > 0)) {
+    fprintf(stdoutMPI,
+            "Error: time evolution with diagonal one-body / two-body terms is not "
+            "supported for SpinlessFermion / SpinlessFermionGC.\n");
+    exitMPI(-1);
+  }
+
   if (X->Def.NTETransferDiagonal[_istep] > 0) {
     for (i = 0; i < X->Def.NTETransferDiagonal[_istep]; i++) {
       isite1 = X->Def.TETransferDiagonal[_istep][i][0] + 1;
       A_spin = X->Def.TETransferDiagonal[_istep][i][1];
       tmp_V = -X->Def.ParaTETransferDiagonal[_istep][i];
-      SetDiagonalTETransfer(isite1, tmp_V, A_spin, X, tmp_v0, tmp_v1);
+      if (SetDiagonalTETransfer(isite1, tmp_V, A_spin, X, tmp_v0, tmp_v1) != 0) {
+        return -1;
+      }
     }
   }
   else if (X->Def.NTEInterAllDiagonal[_istep] >0) {

--- a/src/sz.c
+++ b/src/sz.c
@@ -2242,6 +2242,7 @@ void calculate_jb_Spin_Old(struct BindStruct *X, long unsigned int *list_jb, lon
     int num_up,all_up;
     long int **comb;
     comb = li_2d_allocate(X->Def.Nsite+1,X->Def.Nsite+1);
+    jb   = 0;
     for(ib=0;ib<X->Check.sdim;ib++){
         list_jb[ib] = jb;
         i           = ib*ihfbit;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,7 @@ add_hphi_test(lanczos_tjgc_dimension)
 add_hphi_test(lanczos_tjgc_exchange)
 add_hphi_test_with_srcdir(lanczos_spinless)
 add_hphi_test_with_srcdir(lanczos_spinless_GC)
+add_hphi_test_with_srcdir(lanczos_spinless_calchs0)
 add_hphi_test_with_srcdir(spinless_onebody_sigma_validation)
 add_hphi_test_with_srcdir(spinless_onebody_offdiag_compare)
 add_hphi_test(lanczos_hubbard_square_restart)
@@ -101,7 +102,7 @@ set_tests_properties(
     lanczos_tjgc_dimension lanczos_tjgc_exchange
     PROPERTIES LABELS "lanczos;tjgc")
 set_tests_properties(
-    lanczos_spinless lanczos_spinless_GC
+    lanczos_spinless lanczos_spinless_GC lanczos_spinless_calchs0
     PROPERTIES LABELS "lanczos;spinless")
 set_tests_properties(
     spinless_onebody_sigma_validation
@@ -229,6 +230,7 @@ add_hphi_test_with_srcdir(te_hubbard_chain_interall)
 add_hphi_test_with_srcdir(te_hubbard_chain_interall_diagonal)
 add_hphi_test_with_srcdir(te_spin_chain_interall)
 add_hphi_test_with_srcdir(te_kondo_chain_interall)
+add_hphi_test_with_srcdir(te_spinless_diagonal_reject)
 
 # Time evolution test labels
 set_tests_properties(
@@ -242,6 +244,9 @@ set_tests_properties(
 set_tests_properties(
     te_kondo_chain_interall
     PROPERTIES LABELS "te;kondo")
+set_tests_properties(
+    te_spinless_diagonal_reject
+    PROPERTIES LABELS "te;spinless;validation")
 
 #
 # mTPQ

--- a/test/lanczos_spinless_calchs0.sh
+++ b/test/lanczos_spinless_calchs0.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -e
+# Regression test for the calculate_jb_Spin_Old uninitialized-jb bug.
+# CalcHS=0 routes Spin / SpinlessFermion basis construction through
+# calculate_jb_Spin_Old(), which declared `jb` without initializing it before
+# `list_jb[ib] = jb` (the sibling calculate_jb_Spin_Hacker sets jb=0). The
+# garbage offset corrupted the sz-list, giving heap corruption / a crash in
+# Lanczos. This asserts CalcHS=0 reproduces the default (CalcHS=1) ground-state
+# energy for an 8-site SpinlessFermion chain.
+# $1 = CMAKE_SOURCE_DIR (for test/testSpinlessCalc.py).
+
+SRCDIR="$1"
+HPHI=../../src/HPhi
+
+mkdir -p lanczos_spinless_calchs0
+cd lanczos_spinless_calchs0
+
+# Generate an 8-site, 3-particle SpinlessFermion input (default CalcHS=1).
+python3 "${SRCDIR}/test/testSpinlessCalc.py" -p "${HPHI}" -m SpinlessFermion -s 8 -n 3 > gen.log 2>&1
+
+rm -rf output
+${HPHI} -e namelist.def > log_calchs1.txt 2>&1
+e1=$(awk 'NR==1{print $2}' output/zvo_energy.dat)
+
+# Same input, basis built via the CalcHS=0 (calculate_jb_Spin_Old) path.
+echo "CalcHS         0" >> modpara.def
+rm -rf output
+${HPHI} -e namelist.def > log_calchs0.txt 2>&1
+e0=$(awk 'NR==1{print $2}' output/zvo_energy.dat)
+
+echo "E(CalcHS=1)=${e1}  E(CalcHS=0)=${e0}"
+awk -v a="${e1}" -v b="${e0}" 'BEGIN{
+    if (b == "") { print "CalcHS=0 produced no ground-state energy"; exit 1 }
+    d = a - b; if (d < 0) d = -d
+    printf "max |E(CalcHS=0) - E(CalcHS=1)| = %.3e\n", d
+    exit (d < 1e-10) ? 0 : 1
+}' || { echo "MISMATCH"; exit 1; }
+echo "SpinlessFermion CalcHS=0 == CalcHS=1: OK"

--- a/test/te_spinless_diagonal_reject.sh
+++ b/test/te_spinless_diagonal_reject.sh
@@ -1,0 +1,126 @@
+#!/bin/sh -e
+# SpinlessFermion TimeEvolution does not implement diagonal TE one-body/two-body
+# handlers. A diagonal TEOneBody term must be rejected with a clear message,
+# while an off-diagonal-only TEOneBody run must still be accepted.
+# $1 = CMAKE_SOURCE_DIR (for test/testSpinlessCalc.py).
+
+SRCDIR="$1"
+HPHI=../../../src/HPhi
+TE_STEPS=10
+EXPECTED_MSG="time evolution with diagonal one-body / two-body terms is not supported for SpinlessFermion / SpinlessFermionGC"
+
+mkdir -p te_spinless_diagonal_reject
+cd te_spinless_diagonal_reject
+
+prepare_spinless_case() {
+  case_dir="$1"
+  model="$2"
+
+  rm -rf "${case_dir}"
+  mkdir -p "${case_dir}"
+  (
+    cd "${case_dir}"
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true -m "${model}" -s 8 > gen.log 2>&1
+    printf '     SpectrumVec  zvo_eigenvec_0\n' >> namelist.def
+
+    sed -e 's/^OutputEigenVec.*/OutputEigenVec   1/' calcmod.def > _t && mv _t calcmod.def
+    "${HPHI}" -e namelist.def > gs.log 2>&1
+
+    sed -e 's/^CalcType.*/CalcType   4/' \
+        -e 's/^InputEigenVec.*/InputEigenVec   1/' \
+        -e 's/^OutputEigenVec.*/OutputEigenVec   0/' \
+        calcmod.def > _t && mv _t calcmod.def
+    sed -e "s/^Lanczos_max.*/Lanczos_max    ${TE_STEPS}/" modpara.def > _t && mv _t modpara.def
+    printf 'ExpandCoef     10\n' >> modpara.def
+  )
+}
+
+write_diagonal_teonebody() {
+  case_dir="$1"
+  (
+    cd "${case_dir}"
+    cat > teonebody.def <<EOF
+========================
+NTimeSteps    ${TE_STEPS}
+========================
+=========  OneBody Time Evolution  ==========
+========================
+EOF
+    i=0
+    while [ "${i}" -lt "${TE_STEPS}" ]; do
+      printf '0.%02d  1\n' "${i}" >> teonebody.def
+      printf '%s\n' '0  0  0  0  0.2  0.0' >> teonebody.def
+      i=$((i + 1))
+    done
+    printf '       TEOneBody  teonebody.def\n' >> namelist.def
+  )
+}
+
+write_offdiag_teonebody() {
+  case_dir="$1"
+  (
+    cd "${case_dir}"
+    cat > teonebody.def <<EOF
+========================
+NTimeSteps    ${TE_STEPS}
+========================
+=========  OneBody Time Evolution  ==========
+========================
+EOF
+    i=0
+    while [ "${i}" -lt "${TE_STEPS}" ]; do
+      printf '0.%02d  2\n' "${i}" >> teonebody.def
+      printf '%s\n' '0  0  1  0  0.2  0.0' >> teonebody.def
+      printf '%s\n' '1  0  0  0  0.2  0.0' >> teonebody.def
+      i=$((i + 1))
+    done
+    printf '       TEOneBody  teonebody.def\n' >> namelist.def
+  )
+}
+
+run_expect_reject() {
+  name="$1"
+  model="$2"
+
+  prepare_spinless_case "${name}" "${model}"
+  write_diagonal_teonebody "${name}"
+  (
+    cd "${name}"
+    set +e
+    "${HPHI}" -e namelist.def > te.log 2>&1
+    rc=$?
+    set -e
+
+    if [ "${rc}" = "0" ]; then
+      echo "[${name}] ERROR: diagonal Spinless TE run succeeded but was expected to fail" >&2
+      exit 1
+    fi
+    if ! grep -q "${EXPECTED_MSG}" te.log; then
+      echo "[${name}] ERROR: expected Spinless TE diagonal reject message not found" >&2
+      tail -40 te.log >&2
+      exit 1
+    fi
+  )
+}
+
+run_expect_accept() {
+  name="$1"
+  model="$2"
+
+  prepare_spinless_case "${name}" "${model}"
+  write_offdiag_teonebody "${name}"
+  (
+    cd "${name}"
+    if ! "${HPHI}" -e namelist.def > te.log 2>&1; then
+      echo "[${name}] ERROR: off-diagonal-only Spinless TE run failed" >&2
+      tail -40 te.log >&2
+      exit 1
+    fi
+  )
+}
+
+run_expect_reject spinless_diagonal SpinlessFermion
+run_expect_reject spinless_gc_diagonal SpinlessFermionGC
+run_expect_accept spinless_offdiag SpinlessFermion
+
+echo "SpinlessFermion(GC) diagonal TEOneBody reject and off-diagonal TEOneBody accept: OK"


### PR DESCRIPTION
Two independent SpinlessFermion bugs from PR #216 follow-up:

* calculate_jb_Spin_Old() used `jb` uninitialized before `list_jb[ib] = jb`. CalcHS=0 routes both Spin and SpinlessFermion basis construction through this function, so the garbage offset corrupted the sz-list and aborted Lanczos. Initialize jb=0, matching the sibling enumerators.

* diagonalcalcForTE() called the diagonal TE handlers (SetDiagonalTE{Transfer,Chemi,InterAll}), none of which implement SpinlessFermion/GC, and ignored their -1 return, so a diagonal TEOneBody/TETwoBody term on a spinless model was silently dropped, giving wrong dynamics. Reject it up front with a clear message via exitMPI(), since mltply.c ignores diagonalcalcForTE's return value. Off-diagonal-only spinless TE is unaffected. Also propagate SetDiagonalTETransfer's return for symmetry with the InterAll/Chemi branches.

Regression tests (both verified red without the fix, green with it):
* lanczos_spinless_calchs0: CalcHS=0 reproduces the CalcHS=1 ground-state energy for an 8-site SpinlessFermion chain.
* te_spinless_diagonal_reject: diagonal TEOneBody on SpinlessFermion(GC) is rejected with the expected message; off-diagonal-only TE still runs.