### PR TITLE
Fix modulo-by-zero in TE/TPQ progress printout for small Lanczos_max

### DIFF
--- a/src/CalcByCanonicalTPQ.c
+++ b/src/CalcByCanonicalTPQ.c
@@ -273,12 +273,14 @@ int CalcByCanonicalTPQ(
             } 
             //printf("num_lines = %d  %d %d \n",num_lines,X->Bind.Def.istep,X->Bind.Def.Lanczos_max);
         }
+        int progress_interval = (X->Bind.Def.Lanczos_max - step_iO) / 10;
+        if (progress_interval < 1) progress_interval = 1;  /* avoid % 0 for small (Lanczos_max - step_iO) */
         for (step_i = X->Bind.Def.istep; step_i<X->Bind.Def.Lanczos_max; step_i++){
             if (flag_read_invtemp == 1){
                 X->Bind.Def.Param.ExpandCoef = read_nmax[step_i-1];
                 delta_tau                    = read_invtemp[step_i]-read_invtemp[step_i-1];
             }
-            if(step_i %((X->Bind.Def.Lanczos_max-step_iO)/10)==0){
+            if(step_i % progress_interval == 0){
                 fprintf(stdoutMPI, cLogTPQStep, step_i, X->Bind.Def.Lanczos_max);
             }
             X->Bind.Def.istep=step_i;

--- a/src/CalcByTEM.c
+++ b/src/CalcByTEM.c
@@ -177,6 +177,8 @@ int CalcByTEM(
 
   int iInterAllOffDiagonal_org = X->Bind.Def.NInterAll_OffDiagonal;
   int iTransfer_org = X->Bind.Def.EDNTransfer;
+  int progress_interval = X->Bind.Def.Lanczos_max / 10;
+  if (progress_interval < 1) progress_interval = 1;  /* avoid % 0 when Lanczos_max < 10 */
   for (step_i = step_initial; step_i < X->Bind.Def.Lanczos_max; step_i++) {
     X->Bind.Def.istep = step_i;
 
@@ -184,7 +186,7 @@ int CalcByTEM(
     X->Bind.Def.EDNTransfer = iTransfer_org;
     X->Bind.Def.NInterAll_OffDiagonal = iInterAllOffDiagonal_org;
 
-    if (step_i % (X->Bind.Def.Lanczos_max / 10) == 0) {
+    if (step_i % progress_interval == 0) {
       fprintf(stdoutMPI, cLogTEStep, step_i, X->Bind.Def.Lanczos_max);
     }
 

--- a/src/CalcByTPQ.c
+++ b/src/CalcByTPQ.c
@@ -257,9 +257,11 @@ int CalcByTPQ(
       step_iO=0;
     }
 
+    int progress_interval = (X->Bind.Def.Lanczos_max - step_iO) / 10;
+    if (progress_interval < 1) progress_interval = 1;  /* avoid % 0 for small (Lanczos_max - step_iO) */
     for (step_i = X->Bind.Def.istep; step_i<X->Bind.Def.Lanczos_max; step_i++){
       X->Bind.Def.istep=step_i;
-      if(step_i %((X->Bind.Def.Lanczos_max-step_iO)/10)==0){
+      if(step_i % progress_interval == 0){
         fprintf(stdoutMPI, cLogTPQStep, step_i, X->Bind.Def.Lanczos_max);
       }
       X->Bind.Def.istep=step_i;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -229,6 +229,7 @@ add_hphi_test_with_srcdir(te_hubbard_chain_interall)
 add_hphi_test_with_srcdir(te_hubbard_chain_interall_diagonal)
 add_hphi_test_with_srcdir(te_spin_chain_interall)
 add_hphi_test_with_srcdir(te_kondo_chain_interall)
+add_hphi_test_with_srcdir(te_small_lanczos_max)
 
 # Time evolution test labels
 set_tests_properties(
@@ -242,16 +243,23 @@ set_tests_properties(
 set_tests_properties(
     te_kondo_chain_interall
     PROPERTIES LABELS "te;kondo")
+set_tests_properties(
+    te_small_lanczos_max
+    PROPERTIES LABELS "te;validation")
 
 #
 # mTPQ
 #
 add_hphi_test_with_srcdir(tpq_spin_kagome)
 add_hphi_test_with_srcdir(tpq_spin_kagome_randomsphere)
+add_hphi_test(tpq_small_lanczos_max)
 
 set_tests_properties(
     tpq_spin_kagome tpq_spin_kagome_randomsphere
     PROPERTIES LABELS "tpq;spin")
+set_tests_properties(
+    tpq_small_lanczos_max
+    PROPERTIES LABELS "tpq;validation")
 
 #
 # cTPQ

--- a/test/te_small_lanczos_max.sh
+++ b/test/te_small_lanczos_max.sh
@@ -1,0 +1,38 @@
+#!/bin/sh -e
+# Regression test for the modulo-by-zero (% 0) UB in CalcByTEM.c.
+#
+# The TE progress printout used `step_i % (Lanczos_max / 10)`. For
+# Lanczos_max < 10 the divisor is 0, so the modulo is undefined behavior:
+# on x86 it raises SIGFPE and aborts the run. (On arm64 integer % 0 happens
+# not to trap, so this crash guard is effective on the x86 CI jobs.) The fix
+# clamps the print interval to >= 1. This runs a TE with Lanczos_max=5 and
+# asserts the run completes instead of crashing.
+# $1 = CMAKE_SOURCE_DIR (for test/testTECalc.py).
+
+# If MPIRUN is unset, run in serial mode.
+if [ -z "${MPIRUN}" ]; then
+    MPIRUN=""
+fi
+
+SRCDIR="$1"
+HPHI=../../src/HPhi
+
+mkdir -p te_small_lanczos_max
+cd te_small_lanczos_max
+
+# Generate a working Hubbard TE setup (also produces the input eigenvector).
+python3 "${SRCDIR}/test/testTECalc.py" -p "${HPHI}" -mpi "${MPIRUN}" > gen.log 2>&1
+
+# Re-run the time-evolution step with a small Lanczos_max (< 10) that makes
+# the buggy `Lanczos_max / 10` divisor zero. Edit the ModPara file that
+# namelist2.def actually references (testTECalc.py leaves it as modpara.def).
+MODPARA=$(awk '$1=="ModPara"{print $2}' namelist2.def)
+sed -e 's/^Lanczos_max.*/Lanczos_max    5/' "${MODPARA}" > _t && mv _t "${MODPARA}"
+
+if ! ${MPIRUN} "${HPHI}" -e namelist2.def > te_small.log 2>&1; then
+    echo "ERROR: TE with Lanczos_max=5 failed (modulo-by-zero regression?)" >&2
+    tail -40 te_small.log >&2
+    exit 1
+fi
+
+echo "TE Lanczos_max=5 (<10) completes without modulo-by-zero: OK"

--- a/test/tpq_small_lanczos_max.sh
+++ b/test/tpq_small_lanczos_max.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+# Regression test for the modulo-by-zero (% 0) UB in CalcByTPQ.c.
+#
+# The mTPQ progress printout used `step_i % ((Lanczos_max - step_iO) / 10)`.
+# When (Lanczos_max - step_iO) < 10 the divisor is 0, so the modulo is
+# undefined behavior: on x86 it raises SIGFPE and aborts the run. (On arm64
+# integer % 0 happens not to trap, so this crash guard is effective on the
+# x86 CI jobs.) The fix clamps the print interval to >= 1. This runs mTPQ with
+# lanczos_max=5 and asserts the run completes instead of crashing.
+
+# If MPIRUN is unset, run in serial mode.
+if [ -z "${MPIRUN}" ]; then
+    MPIRUN=""
+fi
+
+mkdir -p tpq_small_lanczos_max
+cd tpq_small_lanczos_max
+
+# L = 8 (not 4): the baseline CI runs this at mpisize=16, and the MPI site
+# partition for the Spin model needs enough sites for nproc=2^k=16. L=4 aborts
+# with "The number of PROCESS should be 2-exponent ...".
+cat > stan.in <<EOF
+L = 8
+model = "Spin"
+method = "TPQ"
+lattice = "chain"
+J = 1.0
+2Sz = 0
+lanczos_max = 5
+LargeValue = 5
+NumAve = 1
+EOF
+
+if ! ${MPIRUN} ../../src/HPhi -s stan.in > tpq_small.log 2>&1; then
+    echo "ERROR: mTPQ with lanczos_max=5 failed (modulo-by-zero regression?)" >&2
+    tail -40 tpq_small.log >&2
+    exit 1
+fi
+
+echo "mTPQ lanczos_max=5 (<10) completes without modulo-by-zero: OK"


### PR DESCRIPTION
CalcByTEM, CalcByTPQ and CalcByCanonicalTPQ print progress every ~10% of the run via `step_i % (Lanczos_max / 10)` (TEM) or `step_i % ((Lanczos_max - step_iO) / 10)` (TPQ/cTPQ). When the divisor is < 10 the integer division yields 0, making the modulo a division by zero: undefined behavior that raises SIGFPE and aborts on x86. (The existing TE regression tests were pinned to Lanczos_max >= 10 to dodge this.) Compute the print interval once before the loop and clamp it to >= 1; behavior for Lanczos_max >= 10 is unchanged.

Regression tests (verified under UBSan: red with "division by zero" at CalcByTEM.c:187 / CalcByTPQ.c:262 without the fix, green with it; on x86 the unfixed runs SIGFPE):
* te_small_lanczos_max: TE with Lanczos_max=5 completes instead of crashing.
* tpq_small_lanczos_max: mTPQ with lanczos_max=5 completes instead of crashing.