### PR TITLE
Document default MPI batching behavior

### DIFF
--- a/doc/en/source/technical/MPI_en.rst
+++ b/doc/en/source/technical/MPI_en.rst
@@ -88,6 +88,11 @@ The batched communication is implemented for:
 * Hubbard models (MPIsingle, MPIdouble; InterAll for HubbardGC only)
 * Spin models (Exchange MPIsingle; SpinGC also batches PairLift)
 
+In MPI builds, batched communication is enabled by default. No input-file
+option is required. The optimization changes the communication/apply path for
+supported inter-process terms, but it is designed to reproduce the same
+numerical result as the conventional per-term MPI path.
+
 .. note::
 
    **Limitation in Time-Evolution (TimeEvolution) mode**
@@ -112,7 +117,8 @@ Disabling batched communication
 Set the environment variable ``HPHI_MPI_NOBATCH=1`` to disable MPI
 communication batching globally and fall back to the original per-term MPI
 exchanges. This is intended for debugging and for verifying that the batched
-optimization reproduces the unbatched result::
+optimization reproduces the unbatched result. It can also be used to compare
+performance with the conventional path on a particular machine and input::
 
    export HPHI_MPI_NOBATCH=1
    mpirun -np 4 ./HPhi -e namelist.def

--- a/doc/ja/source/technical/MPI_ja.rst
+++ b/doc/ja/source/technical/MPI_ja.rst
@@ -88,6 +88,10 @@ MPI通信オーバーヘッドを削減するため、:math:`{\mathcal H}\Phi` �
 * Hubbardモデル（MPIsingle、MPIdouble；InterAllはHubbardGCのみ）
 * Spinモデル（Exchange MPIsingle；SpinGCはPairLiftも一括処理）
 
+MPIビルドでは、バッチ通信はデフォルトで有効です。入力ファイルでの指定は不要です。
+この最適化は、対応しているプロセス間項の通信・適用経路を変更しますが、
+従来の項ごとのMPI通信経路と同じ数値結果を再現するよう設計されています。
+
 .. note::
 
    **時間発展（TimeEvolution）モードでのバッチ通信の制限**
@@ -108,7 +112,8 @@ MPI通信オーバーヘッドを削減するため、:math:`{\mathcal H}\Phi` �
 
 環境変数 ``HPHI_MPI_NOBATCH=1`` を設定すると、MPI通信のバッチ処理を全体で無効化し、
 バッチ化前の項ごとのMPI通信にフォールバックします。デバッグや、バッチ最適化が
-非バッチ時と同一の結果を再現することの検証に使用します::
+非バッチ時と同一の結果を再現することの検証に使用します。また、特定の計算機・入力で
+従来経路との性能比較を行う場合にも使用できます::
 
    export HPHI_MPI_NOBATCH=1
    mpirun -np 4 ./HPhi -e namelist.def
@@ -118,7 +123,7 @@ MPI通信オーバーヘッドを削減するため、:math:`{\mathcal H}\Phi` �
 常に全プロセスで一致します。
 
 SpinlessFermionのoff-diagonal two-body Green関数
------------------------------------------------
+--------------------------------------------------------
 
 SpinlessFermionにおける
 :math:`\langle c^\dagger_i c_j c^\dagger_k c_l \rangle`


### PR DESCRIPTION
## Summary

This PR clarifies the user manual description of MPI communication batching.

- State that MPI batching is enabled by default in MPI builds
- Clarify that no input-file option is required
- Clarify that `HPHI_MPI_NOBATCH=1` is the switch for falling back to the conventional per-term MPI path
- Mention that `HPHI_MPI_NOBATCH=1` is useful for debugging, reproducibility checks, and machine/input-specific performance comparison
- Apply the same update to both English and Japanese manuals

No source-code behavior is changed.

## Related

- Follow-up documentation for the MPI batching work introduced in #216
- Benchmark/context discussion: #225

## Verification

- `git diff --check`
- `make -C doc/en html SPHINXOPTS=-q`
- `make -C doc/ja html SPHINXOPTS=-q`
- `make -C doc/en latexpdf`
- `make -C doc/ja latexpdf`

Both English and Japanese PDFs were generated successfully.