### PR TITLE
Fix HubbardGC batched InterAll dropping origin==myrank terms

### DIFF
--- a/src/include/mltplyMPIBatched.h
+++ b/src/include/mltplyMPIBatched.h
@@ -339,6 +339,30 @@ int InitializeMPIBatchedInterAll_HubbardGC(
 );
 
 /**
+ * @brief Compute the MPI communication partner (origin) of an off-diagonal
+ *        InterAll term, using the same logic as the HubbardGC batched
+ *        initializer. Exposed so the per-term dispatch can tell which terms
+ *        the batched groups actually cover.
+ *
+ * @return 0 if an inter-process contribution exists (origin/is_hermite set);
+ *        -1 if all four sites are local (no MPI needed);
+ *        -2 if the term does not contribute (no valid occupancy path).
+ *         Note: a return of 0 with *origin == myrank denotes a contributing
+ *         term whose partner is the local rank (e.g. an inter-process number
+ *         operator); the batched groups deliberately exclude these, so they
+ *         must be applied via the per-term path.
+ */
+int ComputeInterAllOrigin(
+    int org_isite1, int org_ispin1,
+    int org_isite2, int org_ispin2,
+    int org_isite3, int org_ispin3,
+    int org_isite4, int org_ispin4,
+    struct BindStruct *X,
+    unsigned long int *origin,
+    int *is_hermite
+);
+
+/**
  * @brief Free memory allocated for batched InterAll
  *
  * @param batched Pointer to MPIBatchedInterAll to finalize

--- a/src/mltplyHubbard.c
+++ b/src/mltplyHubbard.c
@@ -584,8 +584,26 @@ int mltplyHubbardGC(
     {
 #ifdef MPI
       if (use_batching) {
-        // Inter-PE terms are handled by batched processing above
-        continue;
+        // Inter-PE terms are normally handled by the batched groups above.
+        // But the batched initializer drops terms whose communication partner
+        // is the local rank (origin==myrank) -- e.g. an off-diagonal InterAll
+        // whose inter-process factor is a number operator, which leaves the
+        // rank bit unchanged. Those terms still contribute and would otherwise
+        // be lost (skipped both here and in batching), silently corrupting H.
+        // Recompute the partner with the same routine the batched initializer
+        // uses, and only skip terms the batched groups actually cover
+        // (origin != myrank). Self-partner / non-contributing terms fall
+        // through to the per-term path below, whose child_GC_*_Hubbard_MPI
+        // routines apply the myrank==origin branch locally.
+        unsigned long int origin_chk;
+        int is_hermite_chk;
+        int ret_chk = ComputeInterAllOrigin(
+            isite1 - 1, sigma1, isite2 - 1, sigma2,
+            isite3 - 1, sigma3, isite4 - 1, sigma4,
+            X, &origin_chk, &is_hermite_chk);
+        if (ret_chk == 0 && (int)origin_chk != myrank) {
+          continue;
+        }
       }
       // Non-batched per-term MPI path (original develop behavior)
       StartTimer(221);

--- a/src/mltplyMPIBatched.c
+++ b/src/mltplyMPIBatched.c
@@ -1369,7 +1369,7 @@ double complex X_child_GC_general_hopp_MPIdouble_batched(
  *
  * This is similar to CheckBit_InterAllPE but simplified for origin computation.
  */
-static int ComputeInterAllOrigin(
+int ComputeInterAllOrigin(
     int org_isite1, int org_ispin1,
     int org_isite2, int org_ispin2,
     int org_isite3, int org_ispin3,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -370,6 +370,7 @@ if(MPI_FOUND)
     # MPIdouble (np=16), HubbardGC off-diagonal InterAll, SpinGC PairLift, Spinless.
     add_hphi_mpi_test(mpi_nobatch_equivalence_mpidouble exact:16)
     add_hphi_mpi_test(mpi_nobatch_equivalence_interall exact:4)
+    add_hphi_mpi_test(mpi_nobatch_equivalence_interall_selfterm exact:4)
     add_hphi_mpi_test(mpi_nobatch_equivalence_pairlift exact:4)
     add_hphi_mpi_test_with_srcdir(mpi_nobatch_equivalence_spinless exact:4)
 
@@ -378,6 +379,7 @@ if(MPI_FOUND)
         mpi_nobatch_equivalence
         mpi_nobatch_equivalence_mpidouble
         mpi_nobatch_equivalence_interall
+        mpi_nobatch_equivalence_interall_selfterm
         mpi_nobatch_equivalence_pairlift
         mpi_nobatch_equivalence_spinless
         PROPERTIES LABELS "mpi;nobatch")

--- a/test/mpi_nobatch_equivalence_interall_selfterm.sh
+++ b/test/mpi_nobatch_equivalence_interall_selfterm.sh
@@ -42,9 +42,14 @@ EOF
 # operator n_3. Each pair is the term and its Hermitian conjugate (operator
 # order reversed). Encoding: i1 s1 i2 s2 i3 s3 i4 s4 = c^dag_{i1,s1} c_{i2,s2}
 # c^dag_{i3,s3} c_{i4,s4}.
+# The first four pairs put the number operator LAST (c^dag_i c_j n_k ->
+# child_GC_CisAjtCkuAku_Hubbard_MPI); the last pair puts it FIRST
+# (n_k c^dag_i c_j -> child_GC_CisAisCjtAku_Hubbard_MPI, which delegates to the
+# former), so both off-diagonal dispatch targets that route origin==myrank
+# terms are exercised.
 cat > interall.def <<EOF
 ========================
-NInterAll 8
+NInterAll 10
 ========================
 ========zInterAll=======
 ========================
@@ -56,6 +61,8 @@ NInterAll 8
     3 0 3 0 1 1 0 1 1.0000000000000000 0.0000000000000000
     0 0 2 0 3 1 3 1 1.0000000000000000 0.0000000000000000
     3 1 3 1 2 0 0 0 1.0000000000000000 0.0000000000000000
+    3 0 3 0 0 0 2 0 1.0000000000000000 0.0000000000000000
+    2 0 0 0 3 0 3 0 1.0000000000000000 0.0000000000000000
 EOF
 # Register the InterAll file in the StdFace-generated namelist.
 printf '    InterAll  interall.def\n' >> namelist.def

--- a/test/mpi_nobatch_equivalence_interall_selfterm.sh
+++ b/test/mpi_nobatch_equivalence_interall_selfterm.sh
@@ -1,0 +1,78 @@
+#!/bin/sh -e
+# Assert HPHI_MPI_NOBATCH=1 (per-term MPI) reproduces the batched result for
+# HubbardGC off-diagonal InterAll terms whose inter-process factor is a NUMBER
+# operator, i.e. terms whose communication partner is the local rank
+# (origin==myrank).
+#
+# This is the complement of mpi_nobatch_equivalence_interall.sh, which only
+# injects c^dag_{3,up} c_{0,up} n_{0,down} -- there the inter-process operator
+# (c^dag on site 3) flips the rank bit, so origin!=myrank and the term is
+# correctly batched. The batched initializer DROPS terms with origin==myrank
+# (mltplyMPIBatched.c), and mltplyHubbardGC used to `continue` past every
+# inter-PE term under batching, so a term like c^dag_{0,up} c_{1,up} n_{3,up}
+# (local hop modulated by an inter-process density) was applied by NEITHER
+# path -- silently corrupting H with no warning. See
+# docs/2026-06-15-v3.6-prerelease-review.md finding H-1.
+#
+# The terms below all have site 3 (inter-process at np=4) appearing only as a
+# number operator, so every one maps to origin==myrank. With the bug, batched
+# mode drops them all and reports the no-InterAll energy; the per-term path
+# keeps them. The fix lets origin==myrank terms fall through to the per-term
+# path, restoring batched == NOBATCH.
+if [ -z "${MPIRUN}" ]; then echo "MPIRUN not set. Skipping."; exit 0; fi
+
+mkdir -p mpi_nobatch_equivalence_interall_selfterm
+cd mpi_nobatch_equivalence_interall_selfterm
+
+cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+Lanczos_max = 2000
+initial_iv = 1
+EOF
+
+# Generate the standard-mode definition files (serial -sdry; np-independent).
+../../src/HPhi -sdry stan.in > log_sdry.txt 2>&1
+
+# Off-diagonal InterAll terms whose inter-process factor (site 3) is a number
+# operator n_3. Each pair is the term and its Hermitian conjugate (operator
+# order reversed). Encoding: i1 s1 i2 s2 i3 s3 i4 s4 = c^dag_{i1,s1} c_{i2,s2}
+# c^dag_{i3,s3} c_{i4,s4}.
+cat > interall.def <<EOF
+========================
+NInterAll 8
+========================
+========zInterAll=======
+========================
+    0 0 1 0 3 0 3 0 1.0000000000000000 0.0000000000000000
+    3 0 3 0 1 0 0 0 1.0000000000000000 0.0000000000000000
+    1 0 2 0 3 0 3 0 1.0000000000000000 0.0000000000000000
+    3 0 3 0 2 0 1 0 1.0000000000000000 0.0000000000000000
+    0 1 1 1 3 0 3 0 1.0000000000000000 0.0000000000000000
+    3 0 3 0 1 1 0 1 1.0000000000000000 0.0000000000000000
+    0 0 2 0 3 1 3 1 1.0000000000000000 0.0000000000000000
+    3 1 3 1 2 0 0 0 1.0000000000000000 0.0000000000000000
+EOF
+# Register the InterAll file in the StdFace-generated namelist.
+printf '    InterAll  interall.def\n' >> namelist.def
+
+run_side() {  # $1 = tag, $2 = HPHI_MPI_NOBATCH value (empty or 1)
+  tag="$1"; nb="$2"
+  rm -rf output
+  if [ -n "$nb" ]; then env_pfx="HPHI_MPI_NOBATCH=$nb"; else env_pfx=""; fi
+  env $env_pfx ${MPIRUN} ../../src/HPhi -e namelist.def > "log_${tag}.txt" 2>&1
+  cp output/zvo_energy.dat "energy_${tag}.dat"
+}
+
+run_side batched ""
+run_side nobatch 1
+
+d=$(paste energy_batched.dat energy_nobatch.dat \
+    | awk '$2 ~ /^[-+0-9.eE]+$/ && $4 ~ /^[-+0-9.eE]+$/ { x=$2-$4; if(x<0)x=-x; if(x>m)m=x } END{ printf "%.3e", m+0 }')
+echo "[interall-selfterm] max |batched - nobatch| energy = ${d}"
+awk -v d="${d}" 'BEGIN{ exit (d < 1e-10) ? 0 : 1 }' || { echo "[interall-selfterm] MISMATCH (origin==myrank InterAll terms dropped under batching)"; exit 1; }
+echo "HubbardGC origin==myrank InterAll (inter-PE number operator): batched == no-batch within tolerance."


### PR DESCRIPTION
## Summary

This fixes a HubbardGC MPI batching bug where inter-PE `InterAll` terms with `origin == myrank` were skipped by both paths.

`mltplyHubbardGC` previously delegated all inter-PE `InterAll` terms to the batched path when batching was enabled. However, the batched initialization intentionally drops `origin == myrank` terms. As a result, those terms disappeared from the Hamiltonian without an error.

The dispatch now uses the same origin classification as the batched path and only skips terms that batching actually handles. Terms with `origin == myrank` fall through to the per-term path and are applied locally.

## Changes

- Expose and reuse `ComputeInterAllOrigin`.
- Avoid delegating `origin == myrank` inter-PE `InterAll` terms to batching.
- Add regression coverage for HubbardGC batched/no-batch equivalence, including self-term InterAll ordering.

## Tests

- `MPIRUN="mpirun -np 4" ctest --test-dir build -V -R "^mpi_nobatch_equivalence_interall(_selfterm)?$"`

Observed max differences:

- `mpi_nobatch_equivalence_interall`: `1.332e-15`
- `mpi_nobatch_equivalence_interall_selfterm`: `4.441e-16`
