### PR TITLE
Fix Spin CalcHS=-1 basis enumeration count

### DIFF
--- a/src/include/sz.h
+++ b/src/include/sz.h
@@ -166,7 +166,7 @@ int Read_sz(
 /*[s] func. for refactoring */
 int count_localized_spins(struct BindStruct *X);
 void calculate_jb_GeneralSpin(struct BindStruct *X, long unsigned int *list_jb, long int *list_2_1_Sz,long int *list_2_2_Sz, long unsigned int ihfbit,long unsigned int ilftdim,unsigned int N);
-void calculate_jb_Spin_m1(struct BindStruct *X, long unsigned int *list_jb, long unsigned int *list_1_, long unsigned int *list_2_1,long unsigned int *list_2_2,\
+long unsigned int calculate_jb_Spin_m1(struct BindStruct *X, long unsigned int *list_jb, long unsigned int *list_1_, long unsigned int *list_2_1,long unsigned int *list_2_2,\
 long unsigned int ihfbit,long unsigned int irght,long unsigned int ilft,long unsigned int ibpatn, unsigned int N);
 void calculate_jb_Spin_Old(struct BindStruct *X, long unsigned int *list_jb, long unsigned int ihfbit,unsigned int N);
 void calculate_jb_Spin_Hacker(struct BindStruct *X, long unsigned int *list_jb, long unsigned int ihfbit,unsigned int N);

--- a/src/sz.c
+++ b/src/sz.c
@@ -526,7 +526,7 @@ int sz(
                       if(X->Def.iFlgGeneralSpin==FALSE){
                           hacker = X->Def.read_hacker;
                           if(hacker        ==  -1){
-                              calculate_jb_Spin_m1(X,list_jb,list_1_,list_2_1_,list_2_2_,ihfbit,irght,ilft,ibpatn, N);
+                              icnt = calculate_jb_Spin_m1(X,list_jb,list_1_,list_2_1_,list_2_2_,ihfbit,irght,ilft,ibpatn, N);
                           }else if(hacker  ==  1){
                               calculate_jb_Spin_Hacker(X,list_jb,ihfbit,N);
                               TimeKeeper(X, cFileNameSzTimeKeep, cOMPSzMid, "a");
@@ -2171,7 +2171,7 @@ void calculate_jb_GeneralSpin(struct BindStruct *X, long unsigned int *list_jb, 
     free_lui_1d_allocate(HilbertNumToSz);
 }
 
-void calculate_jb_Spin_m1(struct BindStruct *X, long unsigned int *list_jb, long unsigned int *list_1_, long unsigned int *list_2_1_,long unsigned int *list_2_2_,\
+long unsigned int calculate_jb_Spin_m1(struct BindStruct *X, long unsigned int *list_jb, long unsigned int *list_1_, long unsigned int *list_2_1_,long unsigned int *list_2_2_,\
 long unsigned int ihfbit,long unsigned int irght,long unsigned int ilft,long unsigned int ibpatn, unsigned int N){
     long unsigned int ia,ja,ib,jb,div_up,i,j,tmp_1;
     long unsigned int tmp_pow,tmp_i,tmp_j,icnt,max_tmp_i;
@@ -2211,8 +2211,8 @@ long unsigned int ihfbit,long unsigned int irght,long unsigned int ilft,long uns
         tmp_i         = tmp_j;
         icnt         += 1;
     }
-    icnt = icnt-1;
     // old version + hacker's delight
+    return icnt-1;
 }
 
 void calculate_jb_Spin_Hacker(struct BindStruct *X, long unsigned int *list_jb, long unsigned int ihfbit,unsigned int N){

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ add_hphi_test(lanczos_hubbard_chain_polarized_calchs2)
 add_hphi_test(calchs2_unsupported_reject)
 add_hphi_test(lanczos_kondo_chain)
 add_hphi_test(lanczos_spin_kagome)
+add_hphi_test(lanczos_spin_calchs_minus1)
 add_hphi_test(lanczos_spin_ladder_DM)
 add_hphi_test(lanczos_genspin_ladder)
 add_hphi_test(lanczos_hubbardgc_tri)
@@ -92,6 +93,7 @@ set_tests_properties(
     PROPERTIES LABELS "lanczos;kondo")
 set_tests_properties(
     lanczos_spin_kagome lanczos_spin_ladder_DM
+    lanczos_spin_calchs_minus1
     lanczos_spingc_honey lanczos_spingc_hcor
     lanczos_spin_kagome_restart
     PROPERTIES LABELS "lanczos;spin")

--- a/test/lanczos_spin_calchs_minus1.sh
+++ b/test/lanczos_spin_calchs_minus1.sh
@@ -1,0 +1,62 @@
+#!/bin/sh -e
+
+testname="lanczos_spin_calchs_minus1"
+
+mkdir -p "${testname}"
+cd "${testname}"
+hphi="$(pwd)/../../src/HPhi"
+
+fail() {
+  echo "FAILED (${testname}): $1"
+  exit 1
+}
+
+run_case() {
+  dir="$1"
+  calc_hs_line="$2"
+
+  rm -rf "${dir}"
+  mkdir -p "${dir}"
+  cd "${dir}"
+
+  cat > stan.in <<EOF
+L = 4
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+J = 1.0
+2Sz = 0
+initial_iv = 1
+Lanczos_max = 100
+LanczosEps = 12
+outputmode = "None"
+EOF
+
+  "${hphi}" -sdry stan.in > stdface.log 2>&1 || { cat stdface.log; fail "${dir}: input generation failed"; }
+  if [ -n "${calc_hs_line}" ]; then
+    printf "%s\n" "${calc_hs_line}" >> modpara.def
+  fi
+
+  "${hphi}" -e namelist.def > run.log 2>&1 || { cat run.log; fail "${dir}: HPhi failed"; }
+  grep -q "Error: in sz" run.log && { cat run.log; fail "${dir}: Error in sz"; }
+  [ -s output/zvo_energy.dat ] || { cat run.log; fail "${dir}: missing zvo_energy.dat"; }
+  awk 'NR==1{print $2}' output/zvo_energy.dat > energy.txt
+
+  cd ..
+}
+
+run_case calchs1 ""
+run_case calchs_minus1 "CalcHS         -1"
+
+e1=$(cat calchs1/energy.txt)
+em1=$(cat calchs_minus1/energy.txt)
+
+echo "E(CalcHS=1)=${e1}  E(CalcHS=-1)=${em1}"
+awk -v a="${e1}" -v b="${em1}" 'BEGIN{
+  if (a == "" || b == "") { print "missing energy"; exit 1 }
+  d = a - b; if (d < 0) d = -d
+  printf "max |E(CalcHS=-1) - E(CalcHS=1)| = %.3e\n", d
+  exit (d < 1e-10) ? 0 : 1
+}' || { echo "MISMATCH"; exit 1; }
+
+echo "Spin CalcHS=-1 == CalcHS=1: OK"


### PR DESCRIPTION
## Summary

This PR fixes a Spin/SpinlessFermion canonical `CalcHS=-1` regression where `calculate_jb_Spin_m1()` filled the basis lists but did not return the final basis count to the caller.

As a result, `sz()` kept a stale `icnt` value and could abort with a basis-size mismatch for inputs that previously worked.

## Changes

- Change `calculate_jb_Spin_m1()` from `void` to `long unsigned int`.
- Return `icnt - 1` as the computed basis count.
- Assign the returned count in the `CalcHS=-1` path.
- Add a regression test comparing `CalcHS=1` and `CalcHS=-1` energies for a small Spin chain.

## Tests

- `cmake -S . -B ../tmp/hphi-m1-build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build ../tmp/hphi-m1-build -j4`
- `ctest --test-dir ../tmp/hphi-m1-build -V -R "^(lanczos_spin_calchs_minus1|calchs2_unsupported_reject|lanczos_spinless_calchs0)$"`