### PR TITLE
Add validation guards for ThreeBodyG and internal CalcModel values

### DIFF
--- a/src/ErrorMessage.c
+++ b/src/ErrorMessage.c
@@ -47,7 +47,7 @@ char *cErrOutputHam="Error in %s\n OutputHam: \n 0: not output Hamiltonian,\n 1:
 char *cErrOutputHamForFullDiag="Error in %s\n OutputHam is only defined for FullDiag mode, CalcType=2.\n";
 char *cErrInputHam="Error in %s\n InputHam: \n 0: not input Hamiltonian,\n 1: input Hamiltonian.\n";
 char *cErrInputOutputHam="Error in %s\n OutputHam=1 and InputHam=1.\n";
-char *cErrCalcModel="Error in %s\n CalcModel: \n 0: Hubbard, 1: Spin, 2: Kondo, 3: HubbardGC, 4: SpinGC, 5: KondoGC, 9: tJ, 10: tJGC.\n";
+char *cErrCalcModel="Error in %s\n CalcModel: \n 0: Hubbard, 1: Spin, 2: Kondo, 3: HubbardGC, 4: SpinGC, 5: KondoGC, 7: SpinlessFermion, 8: SpinlessFermionGC, 9: tJ, 10: tJGC.\n";
 char *cErrFiniteTemp="Error in %s\n FlgFiniteTemperature: Finite Temperature, 1: Zero Temperature.\n";
 char *cErrSetIniVec="Error in %s\n InitialVecType: \n 0: complex type,\n 1: real type.\n";
 char *cErrRestart="Error in %s\n Restart: \n 0: not restart (default).\n 1: output a restart vector.\n 2: input a restart vector and output a new restart vector.\n 3: input a restart vector.\n";

--- a/src/expec_cisajscktaltdc.c
+++ b/src/expec_cisajscktaltdc.c
@@ -178,6 +178,12 @@ int expec_cisajscktaltdc
     sprintf(sdt_4,cFileName6BGreen_FullDiag, X->Def.CDataFileHead, X->Phys.eigen_num);
     break;
   }
+  if(X->Def.iCalcModel == Spin &&
+     (X->Def.NTBody>0 || X->Def.NFBody>0 || X->Def.NSBody>0)){
+    fprintf(stdoutMPI,
+            "Error: ThreeBodyG/FourBodyG/SixBodyG for canonical Spin is not supported. Use SpinGC or remove the N-body Green function request.\n");
+    return -1;
+  }
   if(X->Def.NCisAjtCkuAlvDC>0){
     // If the number of two-body interactions is zero, the file name is not used.
     if(childfopenMPI(sdt, "w", &fp)!=0){

--- a/src/include/DefCommon.h
+++ b/src/include/DefCommon.h
@@ -27,7 +27,7 @@
 #define cTPQ 5 /*!< CalcType is canonical TPQ*/
 
 /*!< CalcModel */
-#define NUM_CALCMODEL     12 /*!< Number of model types defined by CalcModel in calcmodfile. Note: HubbardNConserved is not explicitly defined in calcmod file and thus not counted. SpinlessFermion and SpinlessFermionGC are not yet supported*/
+#define NUM_CALCMODEL     12 /*!< Number of model values accepted from CalcModel. Number-conserved variants are internal and selected from conserved quantities. */
 #define Hubbard           0  /*!< CalcModel is Hubbard model.*/
 #define Spin              1  /*!< CalcModel is Spin system.*/
 #define Kondo             2  /*!< CalcModel is Kondo model.*/
@@ -35,7 +35,7 @@
 #define SpinGC            4  /*!< CalcModel is GrandCanonical Spin system.*/
 #define KondoGC           5  /*!< CalcModel is GrandCanonical Kondo model.*/
 #define HubbardNConserved 6  /*!< CalcModel is Hubbard model under particle number conserved. This symmetry is automatically introduced by not defining 2Sz in a modpara file.*/
-#define SpinlessFermion   7  /*!< CalcModel is GrandCanonical Spinless fermion model.*/
+#define SpinlessFermion   7  /*!< CalcModel is canonical Spinless fermion model.*/
 #define SpinlessFermionGC 8  /*!< CalcModel is GrandCanonical Spinless fermionGC model.*/
 #define tJ                9  /*!< CalcModel is Canonical      tJ model.*/
 #define tJGC              10 /*!< CalcModel is GrandCanonical tJ model.*/

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -335,6 +335,15 @@ int ReadcalcmodFile(
     fprintf(stdoutMPI,cErrCalcModel, defname);
     return (-1);
   }
+  if(X->iCalcModel == HubbardNConserved ||
+     X->iCalcModel == tJNConserved ||
+     X->iCalcModel == KondoNConserved){
+    fprintf(stdoutMPI,
+            "Error in %s\n CalcModel %d is reserved for internal use. "
+            "Specify the base model and let HPhi choose the number-conserved variant from the conserved quantities.\n",
+            defname, X->iCalcModel);
+    return (-1);
+  }
   if(ValidateValue(X->iCalcType, 0, NUM_CALCTYPE-1)){
     fprintf(stdoutMPI, cErrCalcType, defname);
     return (-1);
@@ -1647,15 +1656,24 @@ int ReadDefFileIdxPara(
                  &isite6,
                  &isigma6
                  );
-          /*
+          if(CheckQuadSite(isite1, isite2, isite3, isite4, X->Nsite) !=0 ||
+             CheckPairSite(isite5, isite6, X->Nsite) !=0){
+            fclose(fp);
+            return ReadDefFileError(defname);
+          }
+
           if(X->iCalcModel == Spin || X->iCalcModel == SpinGC){
             if(CheckFormatForSpinInt(isite1, isite2, isite3, isite4)!=0){
-                exitMPI(-1);
-              //X->NCisAjtCkuAlvDC--;
-              //continue;
+              fclose(fp);
+              return ReadDefFileError(defname);
+            }
+            if(isite5 != isite6){
+              fprintf(stdoutMPI,
+                      "Error: ThreeBodyG for Spin/SpinGC requires the 5th and 6th operators to be on the same site.\n");
+              fclose(fp);
+              return ReadDefFileError(defname);
             }
           }
-          */
 
           X->TBody[idx][0]  = isite1;
           X->TBody[idx][1]  = isigma1;
@@ -1670,12 +1688,6 @@ int ReadDefFileIdxPara(
           X->TBody[idx][10] = isite6;
           X->TBody[idx][11] = isigma6;
 
-          /*
-          if(CheckQuadSite(isite1, isite2, isite3, isite4,X->Nsite) !=0){
-            fclose(fp);
-            return ReadDefFileError(defname);
-          }
-          */
           idx++;
         }
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,7 @@ add_hphi_test(lanczos_hubbard_square_calchs2)
 add_hphi_test(lanczos_hubbard_square_ncond_calchs2)
 add_hphi_test(lanczos_hubbard_chain_polarized_calchs2)
 add_hphi_test(calchs2_unsupported_reject)
+add_hphi_test(threebody_calcmodel_validation)
 add_hphi_test(lanczos_kondo_chain)
 add_hphi_test(lanczos_spin_kagome)
 add_hphi_test(lanczos_spin_ladder_DM)
@@ -86,6 +87,9 @@ set_tests_properties(
 set_tests_properties(
     calchs2_unsupported_reject
     PROPERTIES LABELS "lanczos;hubbard;validation")
+set_tests_properties(
+    threebody_calcmodel_validation
+    PROPERTIES LABELS "lanczos;spin;validation")
 set_tests_properties(
     lanczos_kondo_chain lanczos_kondogc_chain
     lanczos_kondo_chain_restart

--- a/test/threebody_calcmodel_validation.sh
+++ b/test/threebody_calcmodel_validation.sh
@@ -1,0 +1,145 @@
+#!/bin/sh -e
+
+testname="threebody_calcmodel_validation"
+
+mkdir -p "${testname}"
+cd "${testname}"
+hphi="$(pwd)/../../src/HPhi"
+
+expect_reject() {
+  name="$1"
+  expected_msg="$2"
+  shift 2
+
+  rm -rf "${name}"
+  mkdir -p "${name}"
+  (
+    cd "${name}"
+    "$@"
+
+    set +e
+    "${hphi}" -e namelist.def > run.log 2>&1
+    rc=$?
+    set -e
+
+    if [ "${rc}" = "0" ]; then
+      echo "[${name}] ERROR: run succeeded but was expected to fail" >&2
+      exit 1
+    fi
+    if ! grep -q "${expected_msg}" run.log; then
+      echo "[${name}] ERROR: expected error message '${expected_msg}' not found" >&2
+      tail -40 run.log >&2
+      exit 1
+    fi
+  )
+}
+
+prepare_spingc_bad_threebody() {
+  cat > stan.in <<EOF
+L = 4
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+J = 1.0
+h = 0.1
+2S = 1
+outputmode = "None"
+EOF
+  "${hphi}" -sdry stan.in > gen.log 2>&1
+  cat > green3.def <<EOF
+===================
+num       1
+===================
+===================
+===================
+0 0 0 1 1 1 1 0 2 0 3 0
+EOF
+  printf "ThreeBodyG  green3.def\n" >> namelist.def
+}
+
+prepare_spin_threebody() {
+  cat > stan.in <<EOF
+L = 4
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+J = 1.0
+2Sz = 0
+outputmode = "None"
+EOF
+  "${hphi}" -sdry stan.in > gen.log 2>&1
+  cat > green3.def <<EOF
+===================
+num       1
+===================
+===================
+===================
+0 0 0 1 1 1 1 0 2 0 2 0
+EOF
+  printf "ThreeBodyG  green3.def\n" >> namelist.def
+}
+
+prepare_internal_calcmodel() {
+  cat > namelist.def <<EOF
+CalcMod   calcmod.def
+ModPara   modpara.def
+LocSpin   locspn.def
+Trans     trans.def
+InterAll  interall.def
+OneBodyG  greenone.def
+TwoBodyG  greentwo.def
+EOF
+  cat > calcmod.def <<EOF
+CalcType        0
+CalcModel       11
+ReStart         0
+CalcSpec        0
+CalcEigenVec    0
+InitialVecType  0
+InputEigenVec   0
+OutputEigenVec  0
+InputHam        0
+OutputHam       0
+EOF
+  cat > modpara.def <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+Ncond          2
+Lanczos_max    5
+initial_iv     1
+exct           1
+LanczosEps     10
+LanczosTarget  2
+LargeValue     4.5
+NumAve         1
+ExpecInterval  20
+EOF
+  cat > locspn.def <<EOF
+================================
+NlocalSpin     0
+================================
+========i_1LocSpn_0IteElc ======
+================================
+0 0
+1 0
+2 0
+3 0
+EOF
+  printf "========================\nNTransfer      0\n========================\n========i_j_s_tijs======\n========================\n" > trans.def
+  printf "======================\nNInterAll      0\n======================\n========zInterAll=====\n======================\n" > interall.def
+  printf "===========\nNCisAjs          0\n===========\n===========\n===========\n" > greenone.def
+  printf "===========\nNCisAjsCktAlt          0\n===========\n===========\n===========\n" > greentwo.def
+}
+
+expect_reject spingc_threebody_site_mismatch "requires the 5th and 6th operators to be on the same site" prepare_spingc_bad_threebody
+expect_reject spin_threebody_unsupported "canonical Spin is not supported" prepare_spin_threebody
+expect_reject internal_tjn_calcmodel "reserved for internal use" prepare_internal_calcmodel
+
+echo "ThreeBodyG and internal CalcModel validation rejects invalid inputs: OK"


### PR DESCRIPTION
## Summary

This PR adds input validation for several cases that previously produced silent or misleading behavior.

## Changes

- Validate `ThreeBodyG` site indices in `readdef.c`.
- For `Spin`/`SpinGC`, require the 5th and 6th `ThreeBodyG` operators to be on the same site.
- Reject canonical `Spin` with `ThreeBodyG`/`FourBodyG`/`SixBodyG` before opening empty output files.
- Reject direct user selection of reserved internal number-conserved `CalcModel` values.
- Update the public `CalcModel` error message and related comments.
- Add validation regression tests.

## Tests

- `cmake -S . -B ../tmp/hphi-m2-build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build ../tmp/hphi-m2-build -j4`
- `ctest --test-dir ../tmp/hphi-m2-build -V -R "^(threebody_calcmodel_validation|lanczos_spingc_hcor|lobcg_spingc_hcor|mpi_consistency_threebody_generalspin)$"`
- `MPIRUN="mpirun -np 3" ctest --test-dir ../tmp/hphi-m2-build -V -R "^mpi_consistency_threebody_generalspin$"`
- `ctest --test-dir ../tmp/hphi-m2-build -V -R "^(lanczos_hubbard_square_ncond_calchs2|calchs2_unsupported_reject)$"`