### PR TITLE
Harden cTPQ InvTemp input validation

### DIFF
--- a/src/CalcByCanonicalTPQ.c
+++ b/src/CalcByCanonicalTPQ.c
@@ -23,6 +23,7 @@
 #include "FileIO.h"
 #include "wrapperMPI.h"
 #include "CalcTime.h"
+#include <ctype.h>
 #ifdef MPI
     #include <mpi.h>
 #endif
@@ -70,7 +71,7 @@ int CalcByCanonicalTPQ(
     double *read_invtemp=NULL;
     int    *read_nmax=NULL,*read_physcal=NULL,*read_eigen=NULL; 
     int    flag_read_invtemp;
-    int    num_lines,read_lines;
+    int    num_lines=0, read_lines=0, invtemp_status=0;
     /*[e] for inverse temperatures*/
 
     tstruct.tstart=time(NULL);
@@ -84,30 +85,88 @@ int CalcByCanonicalTPQ(
     file_name[D_FileNameMax - 1] = '\0'; // Ensure null termination
     /*[e]Following copilot's suggestion, we use strncpy to avoid buffer overflow*/
     if (X->Bind.Def.flag_read_invtemp==1){
+        if(X->Bind.Def.iReStart==RESTART_INOUT || X->Bind.Def.iReStart==RESTART_IN){
+            fprintf(stdoutMPI,
+                    "Error: InvTemp input cannot be combined with Restart=2 or Restart=3 in cTPQ.\n");
+            return -1;
+        }
         if(myrank==0){
             num_lines      = count_file_lines(file_name); /*count lines of files*/
-            //[s] allocate
-            read_invtemp   = (double*)calloc(num_lines,sizeof(double));
-            read_nmax      = (int *)calloc(num_lines, sizeof(int));
-            read_physcal   = (int *)calloc(num_lines, sizeof(int));
-            read_eigen     = (int *)calloc(num_lines, sizeof(int));
-            //[e] allocate
-            read_lines     = func_read_invtemp(read_invtemp,read_nmax,read_physcal,read_eigen,file_name,num_lines); /*read files*/
-            //printf("DEBUG: myrank = %d: flag_read_invtemp = %d file_name = %s num_lines = %d read_lines = %d \n", 
-            //       myrank,X->Bind.Def.flag_read_invtemp, file_name, num_lines, read_lines);
+            if(num_lines <= 0){
+                fprintf(stdoutMPI,
+                        "Error: InvTemp file '%s' must contain at least one complete row.\n",
+                        file_name);
+                invtemp_status = -1;
+            }else{
+                //[s] allocate
+                read_invtemp   = (double*)calloc(num_lines,sizeof(double));
+                read_nmax      = (int *)calloc(num_lines, sizeof(int));
+                read_physcal   = (int *)calloc(num_lines, sizeof(int));
+                read_eigen     = (int *)calloc(num_lines, sizeof(int));
+                //[e] allocate
+                if(read_invtemp == NULL || read_nmax == NULL ||
+                   read_physcal == NULL || read_eigen == NULL){
+                    fprintf(stdoutMPI,
+                            "Error: failed to allocate InvTemp arrays for %d rows.\n",
+                            num_lines);
+                    invtemp_status = -1;
+                }else{
+                    read_lines = func_read_invtemp(read_invtemp,read_nmax,read_physcal,read_eigen,file_name,num_lines); /*read files*/
+                    if(read_lines < 0){
+                        fprintf(stdoutMPI,
+                                "Error: InvTemp file '%s' has an invalid row. Each non-empty row must contain exactly: beta nmax physcal eigen.\n",
+                                file_name);
+                        invtemp_status = -1;
+                    }else if(read_lines == 0){
+                        fprintf(stdoutMPI,
+                                "Error: InvTemp file '%s' must contain at least one complete row.\n",
+                                file_name);
+                        invtemp_status = -1;
+                    }else{
+                        num_lines = read_lines;
+                    }
+                }
+            }
         }
         #ifdef MPI
+            MPI_Bcast(&invtemp_status, 1, MPI_INT, 0, MPI_COMM_WORLD);
             // Broadcast the number of lines to all ranks
             MPI_Bcast(&num_lines, 1, MPI_INT, 0, MPI_COMM_WORLD);
             //printf("DEBUG: myrank = %d: flag_read_invtemp = %d file_name = %s num_lines = %d \n", 
             //       myrank,X->Bind.Def.flag_read_invtemp, file_name, num_lines);
+        #endif
 
+        if(invtemp_status != 0){
+            free(read_invtemp);
+            free(read_nmax);
+            free(read_physcal);
+            free(read_eigen);
+            return -1;
+        }
+
+        #ifdef MPI
+            int local_invtemp_status = 0;
             // Allocate memory on non-root ranks
             if (myrank != 0) {
                 read_invtemp = (double*)calloc(num_lines, sizeof(double));
                 read_nmax    = (int*)calloc(num_lines, sizeof(int));
                 read_physcal = (int*)calloc(num_lines, sizeof(int));
                 read_eigen   = (int*)calloc(num_lines, sizeof(int));
+                if(read_invtemp == NULL || read_nmax == NULL ||
+                   read_physcal == NULL || read_eigen == NULL){
+                    fprintf(stdoutMPI,
+                            "Error: failed to allocate InvTemp arrays for %d rows.\n",
+                            num_lines);
+                    local_invtemp_status = -1;
+                }
+            }
+            MPI_Allreduce(&local_invtemp_status, &invtemp_status, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+            if(invtemp_status != 0){
+                free(read_invtemp);
+                free(read_nmax);
+                free(read_physcal);
+                free(read_eigen);
+                return -1;
             }
 
             // Broadcast data arrays to all ranks
@@ -440,18 +499,48 @@ int count_file_lines(const char *file_name) {
 int func_read_invtemp(double *read_invtemp, int *read_nmax, int *read_physcal, int *read_eigen, const char *file_name, int max_lines) {
 
     FILE *file = fopen(file_name, "r");
+    char line[1024];
     if (file == NULL) {
         fprintf(stderr, "could not open file: %s\n", file_name);
         return -1;
     }
 
     int i = 0;
-    while (fscanf(file, "%lf %d %d %d", &read_invtemp[i], &read_nmax[i], &read_physcal[i], &read_eigen[i]) == 4) {
+    int line_no = 0;
+    while (fgets(line, sizeof(line), file) != NULL) {
+        double invtemp_tmp;
+        int nmax_tmp, physcal_tmp, eigen_tmp;
+        int nread = 0;
+        char *cursor = line;
+        line_no++;
+
+        while (isspace((unsigned char)*cursor)) cursor++;
+        if (*cursor == '\0') continue;
+
         if (i >= max_lines) {
             fprintf(stderr, "Error: number of lines in file exceeds expected %d\n", max_lines);
             fclose(file);
             return -2;
         }
+
+        if (sscanf(cursor, "%lf %d %d %d %n",
+                   &invtemp_tmp, &nmax_tmp, &physcal_tmp, &eigen_tmp, &nread) != 4) {
+            fprintf(stderr, "Error: invalid InvTemp row %d in file: %s\n", line_no, file_name);
+            fclose(file);
+            return -3;
+        }
+        cursor += nread;
+        while (isspace((unsigned char)*cursor)) cursor++;
+        if (*cursor != '\0') {
+            fprintf(stderr, "Error: invalid InvTemp row %d in file: %s\n", line_no, file_name);
+            fclose(file);
+            return -3;
+        }
+
+        read_invtemp[i] = invtemp_tmp;
+        read_nmax[i] = nmax_tmp;
+        read_physcal[i] = physcal_tmp;
+        read_eigen[i] = eigen_tmp;
         i++;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -306,10 +306,14 @@ set_tests_properties(
 add_hphi_test_with_srcdir(ctpq_spin_kagome)
 add_hphi_test_with_srcdir(ctpq_spin_kagome_randomsphere)
 add_hphi_test_with_srcdir(read_ctpq_spin_chain)
+add_hphi_test(ctpq_invtemp_validation)
 
 set_tests_properties(
     ctpq_spin_kagome ctpq_spin_kagome_randomsphere read_ctpq_spin_chain
     PROPERTIES LABELS "ctpq;spin")
+set_tests_properties(
+    ctpq_invtemp_validation
+    PROPERTIES LABELS "ctpq;validation")
 
 #
 # Three body for spin 1 Heisenberg chain

--- a/test/ctpq_invtemp_validation.sh
+++ b/test/ctpq_invtemp_validation.sh
@@ -1,0 +1,119 @@
+#!/bin/sh -e
+
+if [ -z "${MPIRUN}" ]; then
+  MPIRUN=""
+fi
+
+testname="ctpq_invtemp_validation"
+
+mkdir -p "${testname}"
+cd "${testname}"
+hphi="$(pwd)/../../src/HPhi"
+
+prepare_case() {
+  name="$1"
+  restart_value="$2"
+  invtemp_file="$3"
+
+  rm -rf "${name}"
+  mkdir -p "${name}"
+  (
+    cd "${name}"
+    cat > stan.in <<EOF
+L = 8
+model = "SpinGC"
+method = "TPQ"
+lattice = "chain"
+J = 1.0
+NumAve = 1
+Lanczos_max = 5
+outputmode = "None"
+EOF
+    "${hphi}" -sdry stan.in > gen.log 2>&1
+
+    cat > calcmod.def <<EOF
+CalcType   5
+CalcModel   4
+ReStart   ${restart_value}
+CalcSpec   0
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   0
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+    printf "InvTemp         %s\n" "${invtemp_file}" >> namelist.def
+  )
+}
+
+expect_reject() {
+  name="$1"
+  expected_msg="$2"
+
+  (
+    cd "${name}"
+    set +e
+    ${MPIRUN} "${hphi}" -e namelist.def > run.log 2>&1
+    rc=$?
+    set -e
+
+    if [ "${rc}" = "0" ]; then
+      echo "[${name}] ERROR: run succeeded but was expected to fail" >&2
+      exit 1
+    fi
+    if ! grep -q "${expected_msg}" run.log; then
+      echo "[${name}] ERROR: expected error message '${expected_msg}' not found" >&2
+      tail -40 run.log >&2
+      exit 1
+    fi
+  )
+}
+
+expect_accept() {
+  name="$1"
+
+  (
+    cd "${name}"
+    ${MPIRUN} "${hphi}" -e namelist.def > run.log 2>&1 || {
+      echo "[${name}] ERROR: run failed but was expected to succeed" >&2
+      tail -40 run.log >&2
+      exit 1
+    }
+  )
+}
+
+prepare_case empty_file 0 list_inv_temp_empty.def
+: > empty_file/list_inv_temp_empty.def
+expect_reject empty_file "must contain at least one complete row"
+
+prepare_case malformed_rows 0 list_inv_temp_bad.def
+cat > malformed_rows/list_inv_temp_bad.def <<EOF
+0.0 4 1 0
+1.0 4
+EOF
+expect_reject malformed_rows "invalid row"
+
+prepare_case extra_tuple 0 list_inv_temp_extra.def
+cat > extra_tuple/list_inv_temp_extra.def <<EOF
+0.0 4 1 0 1.0 4 1 0
+EOF
+expect_reject extra_tuple "invalid row"
+
+prepare_case restart_in 3 list_inv_temp.def
+cat > restart_in/list_inv_temp.def <<EOF
+0.0 4 1 0
+1.0 4 1 0
+EOF
+expect_reject restart_in "cannot be combined with Restart=2 or Restart=3"
+
+prepare_case trailing_blank 0 list_inv_temp_trailing_blank.def
+cat > trailing_blank/list_inv_temp_trailing_blank.def <<EOF
+0.0 4 1 0
+1.0 4 1 0
+
+EOF
+expect_accept trailing_blank
+
+echo "cTPQ InvTemp validation rejects empty, malformed, extra-field, and restart-combined inputs, and accepts trailing blanks: OK"


### PR DESCRIPTION
## Summary

This PR hardens cTPQ `InvTemp` input handling so malformed inverse-temperature schedules fail explicitly instead of causing crashes, silent miscalculation, or MPI hangs.

## Changes

- Reject `InvTemp` together with `Restart=2` or `Restart=3` in cTPQ.
- Reject empty `InvTemp` files.
- Parse `InvTemp` files line by line.
- Allow trailing blank lines.
- Reject incomplete rows and rows with extra tokens.
- Fix the parser boundary check so arrays are not written before validating capacity.
- Propagate non-root MPI allocation failures collectively with `MPI_Allreduce` before broadcasting arrays.
- Add validation tests for empty, malformed, extra-field, restart-combined, and trailing-blank cases.

## Tests

- `cmake --build ../tmp/hphi-m3-build -j4`
- `ctest --test-dir ../tmp/hphi-m3-build -V -R "^(ctpq_invtemp_validation|read_ctpq_spin_chain)$"`
- `MPIRUN="mpirun -np 2" ctest --test-dir ../tmp/hphi-m3-build -V -R "^ctpq_invtemp_validation$"`
- `MPIRUN="mpirun --oversubscribe -np 16" ctest --test-dir ../tmp/hphi-m3-build -V -R "^ctpq_invtemp_validation$"`
- `git diff --check`