### PR TITLE
Enable NBody for canonical general-spin Spin

### DIFF
--- a/src/makeHam.c
+++ b/src/makeHam.c
@@ -485,6 +485,12 @@ int makeHam(struct BindStruct *X) {
             }
           }
         }
+
+        if (X->Def.NNBodyInterAll_OffDiagonal > 0) {
+          if (AddNBodyInterAllToHamSpinGC(X) != 0) {
+            return -1;
+          }
+        }
       }
       break;
 

--- a/src/makeHam.c
+++ b/src/makeHam.c
@@ -564,6 +564,12 @@ int makeHam(struct BindStruct *X) {
             }
           }
         }
+
+        if (X->Def.NNBodyInterAll_OffDiagonal > 0) {
+          if (AddNBodyInterAllToHamSpinGC(X) != 0) {
+            return -1;
+          }
+        }
       }
 
       break;

--- a/src/mltplySpin.c
+++ b/src/mltplySpin.c
@@ -428,6 +428,11 @@ int mltplyGeneralSpin(
     }
   }/*for (i = 0; i < X->Def.NInterAll_OffDiagonal; i += 2)*/
   StopTimer(410);
+  if (X->Def.NNBodyInterAll_OffDiagonal > 0) {
+    if (MultiplyNBodyInterAllSpinGC(X, tmp_v0, tmp_v1) != 0) {
+      return -1;
+    }
+  }
   StopTimer(400);
   return 0;  
 }/*int mltplyGeneralSpin*/

--- a/src/mltplySpin.c
+++ b/src/mltplySpin.c
@@ -1081,6 +1081,12 @@ shared(tmp_v0, tmp_v1)
   }/*for (i = 0; i< X->Def.NInterAll_OffDiagonal; i += 2)*/
   StopTimer(520);
 
+  if (X->Def.NNBodyInterAll_OffDiagonal > 0) {
+    if (MultiplyNBodyInterAllSpinGC(X, tmp_v0, tmp_v1) != 0) {
+      return -1;
+    }
+  }
+
   StopTimer(500);
   return 0;
 }/*int mltplyGeneralSpinGC*/

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -376,6 +376,68 @@ static int nbodyg_rank_flip_mask(const struct BindStruct *X, unsigned int term, 
   return 0;
 }
 
+static int nbodyg_general_spin_partner_rank(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int *partner_rank,
+  int *active
+) {
+  unsigned int k;
+  unsigned long int partner = (unsigned long int)current_rank;
+  int side = 0;
+  const unsigned int n = X->Def.NBodyG_CanonicalN[term];
+  const unsigned int off = X->Def.NBodyG_CanonicalOffset[term];
+
+  *active = TRUE;
+  for (k = 0; k < n; k++) {
+    const int *f = X->Def.NBodyG_CanonicalFactors[off + k];
+    const unsigned int site = (unsigned int)f[0];
+    const int spin_out = f[1];
+    const int spin_in = f[3];
+    int digit;
+    int this_side;
+
+    if (site < X->Def.Nsite) continue;
+
+    digit = GetBitGeneral(site + 1, (unsigned long int)current_rank,
+                          X->Def.SiteToBit, X->Def.Tpow);
+    if (spin_out == spin_in) {
+      if (digit != spin_out) {
+        *active = FALSE;
+        *partner_rank = current_rank;
+        return 0;
+      }
+      continue;
+    }
+
+    if (digit == spin_out) this_side = 1;
+    else if (digit == spin_in) this_side = -1;
+    else {
+      *active = FALSE;
+      *partner_rank = current_rank;
+      return 0;
+    }
+
+    if (side == 0) side = this_side;
+    else if (side != this_side) {
+      *active = FALSE;
+      *partner_rank = current_rank;
+      return 0;
+    }
+
+    if (this_side == 1) {
+      partner += ((long int)spin_in - (long int)spin_out) * X->Def.Tpow[site];
+    }
+    else {
+      partner += ((long int)spin_out - (long int)spin_in) * X->Def.Tpow[site];
+    }
+  }
+
+  *partner_rank = (int)partner;
+  return 0;
+}
+
 static double complex expec_nbodyg_term_to_rank(
   struct BindStruct *X,
   unsigned int term,
@@ -455,7 +517,34 @@ static double complex expec_nbodyg_term_to_rank_spin(
 
 static double complex calc_nbodyg_term_general_spin_gc(struct BindStruct *X, unsigned int term, double complex *vec)
 {
-  double complex dam_pr = expec_nbodyg_term_to_rank_general_spin_gc(X, term, vec, vec, myrank);
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbodyg_general_spin_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return SumMPI_dc(0.0);
+  }
+  if (active == FALSE) {
+    return SumMPI_dc(0.0);
+  }
+  if (origin == myrank) {
+    dam_pr = expec_nbodyg_term_to_rank_general_spin_gc(X, term, vec, vec, myrank);
+    return SumMPI_dc(dam_pr);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    int ierr = MPI_Sendrecv(vec, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                            v1buf, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = expec_nbodyg_term_to_rank_general_spin_gc(X, term, v1buf, vec, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyG reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
   return SumMPI_dc(dam_pr);
 }
 

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -102,13 +102,14 @@ int ParseNBodyGLine(
 static int nbodyg_is_supported_spin_model(const struct DefineList *D)
 {
   if (D->iCalcModel == SpinGC) return TRUE;
-  if (D->iCalcModel == Spin && D->iFlgGeneralSpin == FALSE) return TRUE;
+  if (D->iCalcModel == Spin) return TRUE;
   return FALSE;
 }
 
-static int nbodyg_is_spingc_general_spin(const struct DefineList *D)
+static int nbodyg_is_general_spin(const struct DefineList *D)
 {
-  return D->iCalcModel == SpinGC && D->iFlgGeneralSpin == TRUE;
+  return D->iFlgGeneralSpin == TRUE &&
+         (D->iCalcModel == Spin || D->iCalcModel == SpinGC);
 }
 
 int ValidateNBodyGScope(const struct DefineList *D)
@@ -116,12 +117,7 @@ int ValidateNBodyGScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
   if (nbodyg_is_supported_spin_model(D) == FALSE) {
-    if (D->iCalcModel == Spin && D->iFlgGeneralSpin == TRUE) {
-      fprintf(stdoutMPI, "Error: NBodyG is not supported for canonical Spin general spin.\n");
-    }
-    else {
-      fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and spin-1/2 Spin.\n");
-    }
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and Spin.\n");
     return -1;
   }
   for (t = 0; t < D->NNBodyG; t++) {
@@ -137,7 +133,7 @@ int ValidateNBodyGScope(const struct DefineList *D)
         return -1;
       }
       {
-        const int max_spin = nbodyg_is_spingc_general_spin(D) ? D->LocSpn[f[0]] : 1;
+        const int max_spin = nbodyg_is_general_spin(D) ? D->LocSpn[f[0]] : 1;
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
           return -1;
@@ -249,7 +245,7 @@ int CheckNBodyGSpinConservation(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
-  if (D->iCalcModel != Spin || D->iFlgGeneralSpin != FALSE) return 0;
+  if (D->iCalcModel != Spin) return 0;
 
   for (t = 0; t < D->NNBodyG; t++) {
     const unsigned int n = D->NBodyG_CanonicalN[t];
@@ -357,6 +353,14 @@ static int apply_nbodyg_general_spin_gc(
   *local_out = lo;
   *rank_out = (int)ro;
   return 1;
+}
+
+static int convert_nbodyg_general_spin_to_list1(
+  const struct BindStruct *X,
+  unsigned long int local_out,
+  unsigned long int *j_out
+) {
+  return ConvertToList1GeneralSpin(local_out, X->Check.sdim, j_out);
 }
 
 static int nbodyg_rank_flip_mask(const struct BindStruct *X, unsigned int term, int *mask)
@@ -505,10 +509,17 @@ static double complex expec_nbodyg_term_to_rank_spin(
     unsigned long int local_out = 0;
     unsigned long int j_out = 0;
     int rank_out = 0;
-    int ret = apply_nbodyg_spingc(X, term, src_list_1[j], rank_in, &local_out, &rank_out);
-    if (ret == 1 && rank_out == myrank &&
+    int ret = (X->Def.iFlgGeneralSpin == TRUE) ?
+      apply_nbodyg_general_spin_gc(X, term, src_list_1[j], rank_in, &local_out, &rank_out) :
+      apply_nbodyg_spingc(X, term, src_list_1[j], rank_in, &local_out, &rank_out);
+    int in_sector = FALSE;
+    if (ret == 1 && rank_out == myrank) {
+      in_sector = (X->Def.iFlgGeneralSpin == TRUE) ?
+        convert_nbodyg_general_spin_to_list1(X, local_out, &j_out) :
         GetOffComp(list_2_1, list_2_2, local_out,
-                   X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out) == TRUE) {
+                   X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+    }
+    if (in_sector == TRUE) {
       dam_pr += conj(bra_vec[j_out]) * src_vec[j];
     }
   }
@@ -580,8 +591,48 @@ static double complex calc_nbodyg_term(struct BindStruct *X, unsigned int term, 
 static double complex calc_nbodyg_term_spin(struct BindStruct *X, unsigned int term, double complex *vec)
 {
   int mask = 0;
-  int origin;
+  int origin = myrank;
+  int active = TRUE;
   double complex dam_pr = 0.0;
+
+  if (X->Def.iFlgGeneralSpin == TRUE) {
+    if (nbodyg_general_spin_partner_rank(X, term, myrank, &origin, &active) != 0) {
+      return SumMPI_dc(0.0);
+    }
+    if (active == FALSE) {
+      return SumMPI_dc(0.0);
+    }
+    if (origin == myrank) {
+      dam_pr = expec_nbodyg_term_to_rank_spin(
+        X, term, list_1, vec, vec, X->Check.idim_max, myrank);
+      return SumMPI_dc(dam_pr);
+    }
+
+#ifdef MPI
+    {
+      MPI_Status statusMPI;
+      unsigned long int idim_max_buf = 0;
+      int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                              &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                              MPI_COMM_WORLD, &statusMPI);
+      if (ierr != 0) exitMPI(-1);
+      ierr = MPI_Sendrecv(list_1, X->Check.idim_max + 1, MPI_UNSIGNED_LONG, origin, 0,
+                          list_1buf, idim_max_buf + 1, MPI_UNSIGNED_LONG, origin, 0,
+                          MPI_COMM_WORLD, &statusMPI);
+      if (ierr != 0) exitMPI(-1);
+      ierr = MPI_Sendrecv(vec, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                          v1buf, idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                          MPI_COMM_WORLD, &statusMPI);
+      if (ierr != 0) exitMPI(-1);
+      dam_pr = expec_nbodyg_term_to_rank_spin(
+        X, term, list_1buf, v1buf, vec, idim_max_buf, origin);
+    }
+#else
+    fprintf(stdoutMPI, "Error: NBodyG reached an MPI-only rank flip path without MPI.\n");
+    return 0.0;
+#endif
+    return SumMPI_dc(dam_pr);
+  }
 
   nbodyg_rank_flip_mask(X, term, &mask);
   origin = myrank ^ mask;
@@ -663,12 +714,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
 
   if (X->Def.NNBodyG < 1) return 0;
   if (nbodyg_is_supported_spin_model(&X->Def) == FALSE) {
-    if (X->Def.iCalcModel == Spin && X->Def.iFlgGeneralSpin == TRUE) {
-      fprintf(stdoutMPI, "Error: NBodyG is not supported for canonical Spin general spin.\n");
-    }
-    else {
-      fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and spin-1/2 Spin.\n");
-    }
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and Spin.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;
@@ -678,7 +724,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
     double complex value = 0.0;
     if (X->Def.NBodyG_IsZero[t] == FALSE) {
       if (X->Def.iCalcModel == Spin) value = calc_nbodyg_term_spin(X, t, vec);
-      else if (nbodyg_is_spingc_general_spin(&X->Def) == TRUE) {
+      else if (nbodyg_is_general_spin(&X->Def) == TRUE) {
         value = calc_nbodyg_term_general_spin_gc(X, t, vec);
       }
       else value = calc_nbodyg_term(X, t, vec);

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -663,7 +663,12 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
 
   if (X->Def.NNBodyG < 1) return 0;
   if (nbodyg_is_supported_spin_model(&X->Def) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and spin-1/2 Spin.\n");
+    if (X->Def.iCalcModel == Spin && X->Def.iFlgGeneralSpin == TRUE) {
+      fprintf(stdoutMPI, "Error: NBodyG is not supported for canonical Spin general spin.\n");
+    }
+    else {
+      fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and spin-1/2 Spin.\n");
+    }
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -316,6 +316,49 @@ static int apply_nbodyg_spingc(
   return 1;
 }
 
+static int apply_nbodyg_general_spin_gc(
+  const struct BindStruct *X,
+  unsigned int term,
+  unsigned long int local_in,
+  int rank_in,
+  unsigned long int *local_out,
+  int *rank_out
+) {
+  const struct DefineList *D = &X->Def;
+  unsigned int k;
+  unsigned long int lo = local_in;
+  unsigned long int ro = (unsigned long int)rank_in;
+  const unsigned int n = D->NBodyG_CanonicalN[term];
+  const unsigned int off = D->NBodyG_CanonicalOffset[term];
+
+  for (k = 0; k < n; k++) {
+    const int *f = D->NBodyG_CanonicalFactors[off + k];
+    const unsigned int site = (unsigned int)f[0];
+    const int spin_out = f[1];
+    const int spin_in = f[3];
+    unsigned long int next = 0;
+
+    if (site < D->Nsite) {
+      if (GetOffCompGeneralSpin(lo, (int)site + 1, spin_in, spin_out,
+                                &next, D->SiteToBit, D->Tpow) == FALSE) {
+        return 0;
+      }
+      lo = next;
+    }
+    else {
+      if (GetOffCompGeneralSpin(ro, (int)site + 1, spin_in, spin_out,
+                                &next, D->SiteToBit, D->Tpow) == FALSE) {
+        return 0;
+      }
+      ro = next;
+    }
+  }
+
+  *local_out = lo;
+  *rank_out = (int)ro;
+  return 1;
+}
+
 static int nbodyg_rank_flip_mask(const struct BindStruct *X, unsigned int term, int *mask)
 {
   unsigned int k;
@@ -357,6 +400,30 @@ static double complex expec_nbodyg_term_to_rank(
   return dam_pr;
 }
 
+static double complex expec_nbodyg_term_to_rank_general_spin_gc(
+  struct BindStruct *X,
+  unsigned int term,
+  const double complex *src_vec,
+  const double complex *bra_vec,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+  const unsigned long int i_max = X->Check.idim_max;
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, src_vec, bra_vec) firstprivate(i_max, term, rank_in, myrank) private(j)
+  for (j = 1; j <= i_max; j++) {
+    unsigned long int local_out = 0;
+    int rank_out = 0;
+    int ret = apply_nbodyg_general_spin_gc(X, term, j - 1, rank_in, &local_out, &rank_out);
+    if (ret == 1 && rank_out == myrank) {
+      dam_pr += conj(bra_vec[local_out + 1]) * src_vec[j];
+    }
+  }
+  return dam_pr;
+}
+
 static double complex expec_nbodyg_term_to_rank_spin(
   struct BindStruct *X,
   unsigned int term,
@@ -384,6 +451,12 @@ static double complex expec_nbodyg_term_to_rank_spin(
     }
   }
   return dam_pr;
+}
+
+static double complex calc_nbodyg_term_general_spin_gc(struct BindStruct *X, unsigned int term, double complex *vec)
+{
+  double complex dam_pr = expec_nbodyg_term_to_rank_general_spin_gc(X, term, vec, vec, myrank);
+  return SumMPI_dc(dam_pr);
 }
 
 static double complex calc_nbodyg_term(struct BindStruct *X, unsigned int term, double complex *vec)
@@ -511,6 +584,9 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
     double complex value = 0.0;
     if (X->Def.NBodyG_IsZero[t] == FALSE) {
       if (X->Def.iCalcModel == Spin) value = calc_nbodyg_term_spin(X, t, vec);
+      else if (nbodyg_is_spingc_general_spin(&X->Def) == TRUE) {
+        value = calc_nbodyg_term_general_spin_gc(X, t, vec);
+      }
       else value = calc_nbodyg_term(X, t, vec);
     }
     write_nbodyg_line(fp, &X->Def, t, value);

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -99,16 +99,29 @@ int ParseNBodyGLine(
   return 0;
 }
 
+static int nbodyg_is_supported_spin_model(const struct DefineList *D)
+{
+  if (D->iCalcModel == SpinGC) return TRUE;
+  if (D->iCalcModel == Spin && D->iFlgGeneralSpin == FALSE) return TRUE;
+  return FALSE;
+}
+
+static int nbodyg_is_spingc_general_spin(const struct DefineList *D)
+{
+  return D->iCalcModel == SpinGC && D->iFlgGeneralSpin == TRUE;
+}
+
 int ValidateNBodyGScope(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
-  if (D->iCalcModel != SpinGC && D->iCalcModel != Spin) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for spin-1/2 SpinGC/Spin.\n");
-    return -1;
-  }
-  if (D->iFlgGeneralSpin != FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for spin-1/2 SpinGC/Spin.\n");
+  if (nbodyg_is_supported_spin_model(D) == FALSE) {
+    if (D->iCalcModel == Spin && D->iFlgGeneralSpin == TRUE) {
+      fprintf(stdoutMPI, "Error: NBodyG is not supported for canonical Spin general spin.\n");
+    }
+    else {
+      fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and spin-1/2 Spin.\n");
+    }
     return -1;
   }
   for (t = 0; t < D->NNBodyG; t++) {
@@ -123,9 +136,12 @@ int ValidateNBodyGScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: NBodyG currently requires site_out == site_in for every factor.\n");
         return -1;
       }
-      if (f[1] < 0 || f[1] > 1 || f[3] < 0 || f[3] > 1) {
-        fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
-        return -1;
+      {
+        const int max_spin = nbodyg_is_spingc_general_spin(D) ? D->LocSpn[f[0]] : 1;
+        if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
+          fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
+          return -1;
+        }
       }
     }
   }
@@ -484,9 +500,8 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
   unsigned int t;
 
   if (X->Def.NNBodyG < 1) return 0;
-  if ((X->Def.iCalcModel != SpinGC && X->Def.iCalcModel != Spin) ||
-      X->Def.iFlgGeneralSpin != FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for spin-1/2 SpinGC/Spin.\n");
+  if (nbodyg_is_supported_spin_model(&X->Def) == FALSE) {
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and spin-1/2 Spin.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -125,13 +125,14 @@ int ParseNBodyInterAllLine(
 static int nbody_is_supported_spin_model(const struct DefineList *D)
 {
   if (D->iCalcModel == SpinGC) return TRUE;
-  if (D->iCalcModel == Spin && D->iFlgGeneralSpin == FALSE) return TRUE;
+  if (D->iCalcModel == Spin) return TRUE;
   return FALSE;
 }
 
-static int nbody_is_spingc_general_spin(const struct DefineList *D)
+static int nbody_is_general_spin(const struct DefineList *D)
 {
-  return D->iCalcModel == SpinGC && D->iFlgGeneralSpin == TRUE;
+  return D->iFlgGeneralSpin == TRUE &&
+         (D->iCalcModel == Spin || D->iCalcModel == SpinGC);
 }
 
 int ValidateNBodyInterAllScope(const struct DefineList *D)
@@ -139,12 +140,7 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
   if (nbody_is_supported_spin_model(D) == FALSE) {
-    if (D->iCalcModel == Spin && D->iFlgGeneralSpin == TRUE) {
-      fprintf(stdoutMPI, "Error: NBodyInterAll is not supported for canonical Spin general spin.\n");
-    }
-    else {
-      fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC and spin-1/2 Spin.\n");
-    }
+    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC and Spin.\n");
     return -1;
   }
   if (D->iCalcType == TimeEvolution) {
@@ -164,7 +160,7 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
         return -1;
       }
       {
-        const int max_spin = nbody_is_spingc_general_spin(D) ? D->LocSpn[f[0]] : 1;
+        const int max_spin = nbody_is_general_spin(D) ? D->LocSpn[f[0]] : 1;
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
           return -1;
@@ -269,7 +265,7 @@ int CheckNBodyInterAllSpinConservation(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
-  if (D->iCalcModel != Spin || D->iFlgGeneralSpin != FALSE) return 0;
+  if (D->iCalcModel != Spin) return 0;
 
   for (t = 0; t < D->NNBodyInterAll; t++) {
     const unsigned int n = D->NBodyInterAll_CanonicalN[t];
@@ -399,6 +395,14 @@ static int apply_nbody_interall_bits(
   return 1;
 }
 
+static int convert_nbody_general_spin_to_list1(
+  const struct BindStruct *X,
+  unsigned long int local_out,
+  unsigned long int *j_out
+) {
+  return ConvertToList1GeneralSpin(local_out, X->Check.sdim, j_out);
+}
+
 static int apply_nbody_interall_general_spin_gc(
   const struct BindStruct *X,
   unsigned int term_index,
@@ -452,7 +456,7 @@ int ApplyNBodyInterAllSpinGC(
   double complex *matrix_element
 ) {
   int ret;
-  if (nbody_is_spingc_general_spin(&X->Def) == TRUE) {
+  if (nbody_is_general_spin(&X->Def) == TRUE) {
     ret = apply_nbody_interall_general_spin_gc(X, term_index, local_in, rank_in, local_out, rank_out);
   }
   else {
@@ -478,7 +482,9 @@ int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X)
       for (j = 1; j <= i_max; j++) {
         unsigned long int local_out = 0;
         int rank_out = 0;
-        int ret = apply_nbody_interall_bits(X, term, list_1[j], myrank, &local_out, &rank_out);
+        int ret = (X->Def.iFlgGeneralSpin == TRUE) ?
+          apply_nbody_interall_general_spin_gc(X, term, list_1[j], myrank, &local_out, &rank_out) :
+          apply_nbody_interall_bits(X, term, list_1[j], myrank, &local_out, &rank_out);
         if (ret == 1 && local_out == list_1[j] && rank_out == myrank) {
           list_Diagonal[j] += coeff;
         }
@@ -629,15 +635,73 @@ static double complex apply_nbody_term_to_rank_spin(
     unsigned long int j_out = 0;
     int rank_out = 0;
     double complex me = X->Def.ParaNBodyInterAll[term];
-    int ret = apply_nbody_interall_bits(X, term, src_list_1[j], rank_in, &intra_out, &rank_out);
-    if (ret == 1 && rank_out == myrank &&
+    int ret = (X->Def.iFlgGeneralSpin == TRUE) ?
+      apply_nbody_interall_general_spin_gc(X, term, src_list_1[j], rank_in, &intra_out, &rank_out) :
+      apply_nbody_interall_bits(X, term, src_list_1[j], rank_in, &intra_out, &rank_out);
+    int in_sector = FALSE;
+    if (ret == 1 && rank_out == myrank) {
+      in_sector = (X->Def.iFlgGeneralSpin == TRUE) ?
+        convert_nbody_general_spin_to_list1(X, intra_out, &j_out) :
         GetOffComp(list_2_1, list_2_2, intra_out,
-                   X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out) == TRUE) {
+                   X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+    }
+    if (in_sector == TRUE) {
       const double complex dmv = me * src_v1[j];
       if (do_update) tmp_v0[j_out] += dmv;
       dam_pr += conj(cur_v1[j_out]) * dmv;
     }
   }
+  return dam_pr;
+}
+
+static double complex multiply_nbody_pair_spin_general_spin(
+  struct BindStruct *X,
+  unsigned int offdiag_pair_pos,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  const unsigned int term0 = X->Def.NBodyInterAll_OffDiagonalIndex[offdiag_pair_pos];
+  const unsigned int term1 = X->Def.NBodyInterAll_OffDiagonalIndex[offdiag_pair_pos + 1];
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbody_interall_general_spin_partner_rank(X, term0, myrank, &origin, &active) != 0) {
+    return 0.0;
+  }
+  if (active == FALSE || origin == myrank) {
+    dam_pr += apply_nbody_term_to_rank_spin(
+      X, term0, tmp_v0, list_1, tmp_v1, tmp_v1, X->Check.idim_max, myrank);
+    dam_pr += apply_nbody_term_to_rank_spin(
+      X, term1, tmp_v0, list_1, tmp_v1, tmp_v1, X->Check.idim_max, myrank);
+    return dam_pr;
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(list_1, X->Check.idim_max + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        list_1buf, idim_max_buf + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(tmp_v1, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf,  idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr += apply_nbody_term_to_rank_spin(
+      X, term0, tmp_v0, list_1buf, v1buf, tmp_v1, idim_max_buf, origin);
+    dam_pr += apply_nbody_term_to_rank_spin(
+      X, term1, tmp_v0, list_1buf, v1buf, tmp_v1, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyInterAll reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
   return dam_pr;
 }
 
@@ -777,9 +841,14 @@ int MultiplyNBodyInterAllSpinGC(
 
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p += 2) {
     if (X->Def.iCalcModel == Spin) {
-      X->Large.prdct += multiply_nbody_pair_spin(X, p, tmp_v0, tmp_v1);
+      if (X->Def.iFlgGeneralSpin == TRUE) {
+        X->Large.prdct += multiply_nbody_pair_spin_general_spin(X, p, tmp_v0, tmp_v1);
+      }
+      else {
+        X->Large.prdct += multiply_nbody_pair_spin(X, p, tmp_v0, tmp_v1);
+      }
     }
-    else if (nbody_is_spingc_general_spin(&X->Def) == TRUE) {
+    else if (nbody_is_general_spin(&X->Def) == TRUE) {
       X->Large.prdct += multiply_nbody_pair_general_spin_gc(X, p, tmp_v0, tmp_v1);
     }
     else {
@@ -811,8 +880,11 @@ int AddNBodyInterAllToHamSpinGC(struct BindStruct *X)
         }
         if (X->Def.iCalcModel == Spin) {
           unsigned long int j_out = 0;
-          if (GetOffComp(list_2_1, list_2_2, local_out,
-                         X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out) == TRUE) {
+          const int in_sector = (X->Def.iFlgGeneralSpin == TRUE) ?
+            convert_nbody_general_spin_to_list1(X, local_out, &j_out) :
+            GetOffComp(list_2_1, list_2_2, local_out,
+                       X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+          if (in_sector == TRUE) {
             Ham[j_out][j] += me;
           }
         }

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -122,16 +122,29 @@ int ParseNBodyInterAllLine(
   return 0;
 }
 
+static int nbody_is_supported_spin_model(const struct DefineList *D)
+{
+  if (D->iCalcModel == SpinGC) return TRUE;
+  if (D->iCalcModel == Spin && D->iFlgGeneralSpin == FALSE) return TRUE;
+  return FALSE;
+}
+
+static int nbody_is_spingc_general_spin(const struct DefineList *D)
+{
+  return D->iCalcModel == SpinGC && D->iFlgGeneralSpin == TRUE;
+}
+
 int ValidateNBodyInterAllScope(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
-  if (D->iCalcModel != SpinGC && D->iCalcModel != Spin) {
-    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for spin-1/2 SpinGC/Spin.\n");
-    return -1;
-  }
-  if (D->iFlgGeneralSpin != FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for spin-1/2 SpinGC/Spin.\n");
+  if (nbody_is_supported_spin_model(D) == FALSE) {
+    if (D->iCalcModel == Spin && D->iFlgGeneralSpin == TRUE) {
+      fprintf(stdoutMPI, "Error: NBodyInterAll is not supported for canonical Spin general spin.\n");
+    }
+    else {
+      fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC and spin-1/2 Spin.\n");
+    }
     return -1;
   }
   if (D->iCalcType == TimeEvolution) {
@@ -150,9 +163,12 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: NBodyInterAll currently requires site_out == site_in for every factor.\n");
         return -1;
       }
-      if (f[1] < 0 || f[1] > 1 || f[3] < 0 || f[3] > 1) {
-        fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
-        return -1;
+      {
+        const int max_spin = nbody_is_spingc_general_spin(D) ? D->LocSpn[f[0]] : 1;
+        if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
+          fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
+          return -1;
+        }
       }
     }
   }
@@ -401,8 +417,7 @@ int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X)
 {
   unsigned int i;
   if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
-  if ((X->Def.iCalcModel != SpinGC && X->Def.iCalcModel != Spin) ||
-      X->Def.iFlgGeneralSpin != FALSE) return -1;
+  if (nbody_is_supported_spin_model(&X->Def) == FALSE) return -1;
 
   for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
     const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
@@ -609,8 +624,7 @@ int MultiplyNBodyInterAllSpinGC(
 ) {
   unsigned int p;
   if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
-  if ((X->Def.iCalcModel != SpinGC && X->Def.iCalcModel != Spin) ||
-      X->Def.iFlgGeneralSpin != FALSE) return -1;
+  if (nbody_is_supported_spin_model(&X->Def) == FALSE) return -1;
 
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p += 2) {
     if (X->Def.iCalcModel == Spin) {
@@ -628,8 +642,7 @@ int AddNBodyInterAllToHamSpinGC(struct BindStruct *X)
   unsigned int p;
   unsigned long int j;
   if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
-  if ((X->Def.iCalcModel != SpinGC && X->Def.iCalcModel != Spin) ||
-      X->Def.iFlgGeneralSpin != FALSE) return -1;
+  if (nbody_is_supported_spin_model(&X->Def) == FALSE) return -1;
 
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
     const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -399,6 +399,49 @@ static int apply_nbody_interall_bits(
   return 1;
 }
 
+static int apply_nbody_interall_general_spin_gc(
+  const struct BindStruct *X,
+  unsigned int term_index,
+  unsigned long int local_in,
+  int rank_in,
+  unsigned long int *local_out,
+  int *rank_out
+) {
+  const struct DefineList *D = &X->Def;
+  unsigned int k;
+  unsigned long int lo = local_in;
+  unsigned long int ro = (unsigned long int)rank_in;
+  const unsigned int n = D->NBodyInterAll_CanonicalN[term_index];
+  const unsigned int off = D->NBodyInterAll_CanonicalOffset[term_index];
+
+  for (k = 0; k < n; k++) {
+    const int *f = D->NBodyInterAll_CanonicalFactors[off + k];
+    const unsigned int site = (unsigned int)f[0];
+    const int spin_out = f[1];
+    const int spin_in = f[3];
+    unsigned long int next = 0;
+
+    if (site < D->Nsite) {
+      if (GetOffCompGeneralSpin(lo, (int)site + 1, spin_in, spin_out,
+                                &next, D->SiteToBit, D->Tpow) == FALSE) {
+        return 0;
+      }
+      lo = next;
+    }
+    else {
+      if (GetOffCompGeneralSpin(ro, (int)site + 1, spin_in, spin_out,
+                                &next, D->SiteToBit, D->Tpow) == FALSE) {
+        return 0;
+      }
+      ro = next;
+    }
+  }
+
+  *local_out = lo;
+  *rank_out = (int)ro;
+  return 1;
+}
+
 int ApplyNBodyInterAllSpinGC(
   const struct BindStruct *X,
   unsigned int term_index,
@@ -408,7 +451,13 @@ int ApplyNBodyInterAllSpinGC(
   int *rank_out,
   double complex *matrix_element
 ) {
-  int ret = apply_nbody_interall_bits(X, term_index, local_in, rank_in, local_out, rank_out);
+  int ret;
+  if (nbody_is_spingc_general_spin(&X->Def) == TRUE) {
+    ret = apply_nbody_interall_general_spin_gc(X, term_index, local_in, rank_in, local_out, rank_out);
+  }
+  else {
+    ret = apply_nbody_interall_bits(X, term_index, local_in, rank_in, local_out, rank_out);
+  }
   if (ret == 1) *matrix_element = X->Def.ParaNBodyInterAll[term_index];
   return ret;
 }
@@ -464,6 +513,68 @@ static int nbody_rank_flip_mask(const struct BindStruct *X, unsigned int term, i
     }
   }
   *mask = m;
+  return 0;
+}
+
+static int nbody_interall_general_spin_partner_rank(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int *partner_rank,
+  int *active
+) {
+  unsigned int k;
+  unsigned long int partner = (unsigned long int)current_rank;
+  int side = 0;
+  const unsigned int n = X->Def.NBodyInterAll_CanonicalN[term];
+  const unsigned int off = X->Def.NBodyInterAll_CanonicalOffset[term];
+
+  *active = TRUE;
+  for (k = 0; k < n; k++) {
+    const int *f = X->Def.NBodyInterAll_CanonicalFactors[off + k];
+    const unsigned int site = (unsigned int)f[0];
+    const int spin_out = f[1];
+    const int spin_in = f[3];
+    int digit;
+    int this_side;
+
+    if (site < X->Def.Nsite) continue;
+
+    digit = GetBitGeneral(site + 1, (unsigned long int)current_rank,
+                          X->Def.SiteToBit, X->Def.Tpow);
+    if (spin_out == spin_in) {
+      if (digit != spin_out) {
+        *active = FALSE;
+        *partner_rank = current_rank;
+        return 0;
+      }
+      continue;
+    }
+
+    if (digit == spin_out) this_side = 1;
+    else if (digit == spin_in) this_side = -1;
+    else {
+      *active = FALSE;
+      *partner_rank = current_rank;
+      return 0;
+    }
+
+    if (side == 0) side = this_side;
+    else if (side != this_side) {
+      *active = FALSE;
+      *partner_rank = current_rank;
+      return 0;
+    }
+
+    if (this_side == 1) {
+      partner += ((long int)spin_in - (long int)spin_out) * X->Def.Tpow[site];
+    }
+    else {
+      partner += ((long int)spin_out - (long int)spin_in) * X->Def.Tpow[site];
+    }
+  }
+
+  *partner_rank = (int)partner;
   return 0;
 }
 
@@ -567,6 +678,44 @@ static double complex multiply_nbody_pair(
   return dam_pr;
 }
 
+static double complex multiply_nbody_pair_general_spin_gc(
+  struct BindStruct *X,
+  unsigned int offdiag_pair_pos,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  const unsigned int term0 = X->Def.NBodyInterAll_OffDiagonalIndex[offdiag_pair_pos];
+  const unsigned int term1 = X->Def.NBodyInterAll_OffDiagonalIndex[offdiag_pair_pos + 1];
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbody_interall_general_spin_partner_rank(X, term0, myrank, &origin, &active) != 0) {
+    return 0.0;
+  }
+  if (active == FALSE || origin == myrank) {
+    dam_pr += apply_nbody_term_to_rank(X, term0, tmp_v0, tmp_v1, tmp_v1, myrank);
+    dam_pr += apply_nbody_term_to_rank(X, term1, tmp_v0, tmp_v1, tmp_v1, myrank);
+    return dam_pr;
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    int ierr = MPI_Sendrecv(tmp_v1, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                            v1buf,  X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr += apply_nbody_term_to_rank(X, term0, tmp_v0, v1buf, tmp_v1, origin);
+    dam_pr += apply_nbody_term_to_rank(X, term1, tmp_v0, v1buf, tmp_v1, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyInterAll reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return dam_pr;
+}
+
 static double complex multiply_nbody_pair_spin(
   struct BindStruct *X,
   unsigned int offdiag_pair_pos,
@@ -629,6 +778,9 @@ int MultiplyNBodyInterAllSpinGC(
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p += 2) {
     if (X->Def.iCalcModel == Spin) {
       X->Large.prdct += multiply_nbody_pair_spin(X, p, tmp_v0, tmp_v1);
+    }
+    else if (nbody_is_spingc_general_spin(&X->Def) == TRUE) {
+      X->Large.prdct += multiply_nbody_pair_general_spin_gc(X, p, tmp_v0, tmp_v1);
     }
     else {
       X->Large.prdct += multiply_nbody_pair(X, p, tmp_v0, tmp_v1);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,9 @@ add_hphi_test(lanczos_spingc_nbodyg)
 add_hphi_test(lanczos_spin_nbody_interall)
 add_hphi_test(lanczos_spingc_spinone_nbody_interall)
 add_hphi_test(lanczos_spingc_spinone_nbodyg)
+add_hphi_test(lanczos_spin_spinone_nbody_interall)
+add_hphi_test(lanczos_spin_spinone_nbodyg)
+add_hphi_test(fulldiag_spin_spinone_nbodyg)
 add_hphi_test(nbody_spingc_spinone_validation)
 add_hphi_test(lanczos_genspingc_ladder)
 add_hphi_test(lanczos_tjgc_dimension)
@@ -123,10 +126,15 @@ set_tests_properties(
     PROPERTIES LABELS "spinone;genspin;validation;nbody")
 set_tests_properties(
     lanczos_spingc_spinone_nbody_interall
+    lanczos_spin_spinone_nbody_interall
     PROPERTIES LABELS "lanczos;genspin;spinone;nbody")
 set_tests_properties(
     lanczos_spingc_spinone_nbodyg
+    lanczos_spin_spinone_nbodyg
     PROPERTIES LABELS "lanczos;genspin;spinone;nbody")
+set_tests_properties(
+    fulldiag_spin_spinone_nbodyg
+    PROPERTIES LABELS "fulldiag;genspin;spinone;nbody")
 set_tests_properties(
     spinless_onebody_sigma_validation
     PROPERTIES LABELS "spinless;validation")
@@ -371,6 +379,10 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone_np9 exact:9)
     add_hphi_mpi_test(mpi_nbodyg_spingc_spinone exact:3)
     add_hphi_mpi_test(mpi_nbodyg_spingc_spinone_np9 exact:9)
+    add_hphi_mpi_test(mpi_nbody_interall_spin_spinone exact:3)
+    add_hphi_mpi_test(mpi_nbody_interall_spin_spinone_np9 exact:9)
+    add_hphi_mpi_test(mpi_nbodyg_spin_spinone exact:3)
+    add_hphi_mpi_test(mpi_nbodyg_spin_spinone_np9 exact:9)
 
     # MPI consistency test labels
     set_tests_properties(
@@ -396,6 +408,10 @@ if(MPI_FOUND)
         mpi_nbody_interall_spingc_spinone_np9
         mpi_nbodyg_spingc_spinone
         mpi_nbodyg_spingc_spinone_np9
+        mpi_nbody_interall_spin_spinone
+        mpi_nbody_interall_spin_spinone_np9
+        mpi_nbodyg_spin_spinone
+        mpi_nbodyg_spin_spinone_np9
         PROPERTIES LABELS "mpi;consistency;genspin;spinone;nbody")
     set_tests_properties(
         mpi_consistency_kondo mpi_consistency_te_kondo

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -367,6 +367,8 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_nbodyg_spingc exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spin exact:4)
     add_hphi_mpi_test(mpi_nbodyg_spin exact:4)
+    add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone exact:3)
+    add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone_np9 exact:9)
 
     # MPI consistency test labels
     set_tests_properties(
@@ -387,6 +389,10 @@ if(MPI_FOUND)
         mpi_nbody_interall_spingc mpi_nbodyg_spingc
         mpi_nbody_interall_spin mpi_nbodyg_spin
         PROPERTIES LABELS "mpi;consistency;spin;nbody")
+    set_tests_properties(
+        mpi_nbody_interall_spingc_spinone
+        mpi_nbody_interall_spingc_spinone_np9
+        PROPERTIES LABELS "mpi;consistency;genspin;spinone;nbody")
     set_tests_properties(
         mpi_consistency_kondo mpi_consistency_te_kondo
         PROPERTIES LABELS "mpi;consistency;kondo")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -369,6 +369,8 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_nbodyg_spin exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone exact:3)
     add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone_np9 exact:9)
+    add_hphi_mpi_test(mpi_nbodyg_spingc_spinone exact:3)
+    add_hphi_mpi_test(mpi_nbodyg_spingc_spinone_np9 exact:9)
 
     # MPI consistency test labels
     set_tests_properties(
@@ -392,6 +394,8 @@ if(MPI_FOUND)
     set_tests_properties(
         mpi_nbody_interall_spingc_spinone
         mpi_nbody_interall_spingc_spinone_np9
+        mpi_nbodyg_spingc_spinone
+        mpi_nbodyg_spingc_spinone_np9
         PROPERTIES LABELS "mpi;consistency;genspin;spinone;nbody")
     set_tests_properties(
         mpi_consistency_kondo mpi_consistency_te_kondo

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,7 @@ add_hphi_test(lanczos_spingc_nbody_interall_n1)
 add_hphi_test(lanczos_spingc_nbodyg)
 add_hphi_test(lanczos_spin_nbody_interall)
 add_hphi_test(lanczos_spingc_spinone_nbody_interall)
+add_hphi_test(lanczos_spingc_spinone_nbodyg)
 add_hphi_test(nbody_spingc_spinone_validation)
 add_hphi_test(lanczos_genspingc_ladder)
 add_hphi_test(lanczos_tjgc_dimension)
@@ -122,6 +123,9 @@ set_tests_properties(
     PROPERTIES LABELS "spinone;genspin;validation;nbody")
 set_tests_properties(
     lanczos_spingc_spinone_nbody_interall
+    PROPERTIES LABELS "lanczos;genspin;spinone;nbody")
+set_tests_properties(
+    lanczos_spingc_spinone_nbodyg
     PROPERTIES LABELS "lanczos;genspin;spinone;nbody")
 set_tests_properties(
     spinless_onebody_sigma_validation

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_hphi_test(lanczos_spingc_nbody_interall)
 add_hphi_test(lanczos_spingc_nbody_interall_n1)
 add_hphi_test(lanczos_spingc_nbodyg)
 add_hphi_test(lanczos_spin_nbody_interall)
+add_hphi_test(lanczos_spingc_spinone_nbody_interall)
 add_hphi_test(nbody_spingc_spinone_validation)
 add_hphi_test(lanczos_genspingc_ladder)
 add_hphi_test(lanczos_tjgc_dimension)
@@ -119,6 +120,9 @@ set_tests_properties(
 set_tests_properties(
     nbody_spingc_spinone_validation
     PROPERTIES LABELS "spinone;genspin;validation;nbody")
+set_tests_properties(
+    lanczos_spingc_spinone_nbody_interall
+    PROPERTIES LABELS "lanczos;genspin;spinone;nbody")
 set_tests_properties(
     spinless_onebody_sigma_validation
     PROPERTIES LABELS "spinless;validation")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_hphi_test(lanczos_spingc_nbody_interall)
 add_hphi_test(lanczos_spingc_nbody_interall_n1)
 add_hphi_test(lanczos_spingc_nbodyg)
 add_hphi_test(lanczos_spin_nbody_interall)
+add_hphi_test(nbody_spingc_spinone_validation)
 add_hphi_test(lanczos_genspingc_ladder)
 add_hphi_test(lanczos_tjgc_dimension)
 add_hphi_test(lanczos_tjgc_exchange)
@@ -115,6 +116,9 @@ set_tests_properties(
 set_tests_properties(
     nbodyg_validation
     PROPERTIES LABELS "spin;validation;nbody")
+set_tests_properties(
+    nbody_spingc_spinone_validation
+    PROPERTIES LABELS "spinone;genspin;validation;nbody")
 set_tests_properties(
     spinless_onebody_sigma_validation
     PROPERTIES LABELS "spinless;validation")

--- a/test/fulldiag_spin_spinone_nbodyg.sh
+++ b/test/fulldiag_spin_spinone_nbodyg.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -e
+
+testname="fulldiag_spin_spinone_nbodyg"
+hphi="../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 1.0
+2S = 2
+2Sz = 0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 5
+========================
+========NBodyG==========
+========================
+1 0 2 0 2
+1 1 1 1 1
+2 0 2 0 0 1 0 1 2
+2 0 0 0 2 1 2 1 0
+2 0 2 0 1 0 2 0 1
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated"; exit 1; }
+cp output/zvo_NBodyG.dat nbodyg_lanczos.dat
+
+sed -e 's/^CalcType.*/CalcType   2/' -e 's/^OutputHam.*/OutputHam   0/' calcmod.def > calcmod.fulldiag
+mv calcmod.def calcmod.lanczos
+mv calcmod.fulldiag calcmod.def
+rm -rf output
+run_hphi log_fulldiag.txt "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG_eigen0.dat || {
+  echo "zvo_NBodyG_eigen0.dat was not generated"
+  ls output
+  exit 1
+}
+cp output/zvo_NBodyG_eigen0.dat nbodyg_fulldiag.dat
+
+awk -v t="${tol}" '
+  function prefix(line, out) {
+    out = line;
+    sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+    return out;
+  }
+  NR == FNR {
+    s_prefix[NR] = prefix($0);
+    s_re[NR] = $(NF - 1);
+    s_im[NR] = $NF;
+    n = NR;
+    next;
+  }
+  {
+    m = FNR;
+    if (prefix($0) != s_prefix[m]) bad = 1;
+    dr = $(NF - 1) - s_re[m];
+    di = $NF - s_im[m];
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    if (dr >= t || di >= t) bad = 1;
+  }
+  END { exit (n == m && bad != 1) ? 0 : 1; }
+' nbodyg_lanczos.dat nbodyg_fulldiag.dat || {
+  echo "canonical Spin spin-one NBodyG FullDiag output mismatch"
+  paste nbodyg_lanczos.dat nbodyg_fulldiag.dat
+  exit 1
+}
+
+echo "canonical Spin spin-one NBodyG FullDiag output matches Lanczos output."

--- a/test/lanczos_spin_spinone_nbody_interall.sh
+++ b/test/lanczos_spin_spinone_nbody_interall.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_spin_spinone_nbody_interall"
+hphi="../../src/HPhi"
+tol="0.000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 0.0
+2S = 2
+2Sz = 0
+Lanczos_max = 100
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 5
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 2 0.1250000000000000 0.0000000000000000
+1 1 1 1 1 -0.0750000000000000 0.0000000000000000
+2 0 2 0 0 1 0 1 2 0.2000000000000000 0.0000000000000000
+2 0 0 0 2 1 2 1 0 0.2000000000000000 0.0000000000000000
+3 0 2 0 2 1 1 1 1 2 0 2 0 0.0500000000000000 0.0000000000000000
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+e_lanczos=$(awk '/^Energy/{print $2; exit}' output/zvo_energy.dat)
+
+sed -e 's/^CalcType.*/CalcType   2/' -e 's/^OutputHam.*/OutputHam   0/' calcmod.def > calcmod.fulldiag
+mv calcmod.def calcmod.lanczos
+mv calcmod.fulldiag calcmod.def
+rm -rf output
+run_hphi log_fulldiag.txt "${hphi}" -e namelist.def
+if [ -f output/zvo_phys.dat ]; then
+  e_fulldiag=$(awk 'NR==2{print $1; exit}' output/zvo_phys.dat)
+else
+  e_fulldiag=$(awk 'NR==1{print $2; exit}' output/Eigenvalue.dat)
+fi
+
+diff=$(awk -v a="${e_lanczos}" -v b="${e_fulldiag}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.12g", d}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "canonical Spin spin-one NBodyInterAll Lanczos/FullDiag energy mismatch: ${e_lanczos} vs ${e_fulldiag}"
+  exit 1
+}
+
+sed -e 's/^OutputHam.*/OutputHam   1/' calcmod.def > calcmod.outputham
+mv calcmod.outputham calcmod.def
+rm -rf output
+run_hphi log_outputham.txt "${hphi}" -e namelist.def
+
+test -f output/zvo_Ham.dat || { echo "zvo_Ham.dat was not generated"; exit 1; }
+awk 'NR>2 && $1 != $2 {found=1} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "canonical Spin spin-one NBodyInterAll produced no off-diagonal Hamiltonian entry"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+awk 'NR>2 && $1 == $2 {
+  d1 = $3 - 0.125000; if (d1 < 0) d1 = -d1;
+  d2 = $3 + 0.075000; if (d2 < 0) d2 = -d2;
+  if (d1 < 0.000001 || d2 < 0.000001) found=1;
+} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "canonical Spin spin-one diagonal NBodyInterAll term was not folded into the diagonal"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+
+echo "canonical Spin spin-one NBodyInterAll Lanczos, FullDiag, and OutputHam checks passed."

--- a/test/lanczos_spin_spinone_nbodyg.sh
+++ b/test/lanczos_spin_spinone_nbodyg.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_spin_spinone_nbodyg"
+hphi="../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 1.0
+2S = 2
+2Sz = 0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 5
+========================
+========NBodyG==========
+========================
+1 0 2 0 2
+1 1 1 1 1
+2 0 2 0 0 1 0 1 2
+2 0 0 0 2 1 2 1 0
+2 0 2 0 1 0 2 0 1
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated"; exit 1; }
+
+awk 'NF >= 7 {count++} END{exit count == 5 ? 0 : 1}' output/zvo_NBodyG.dat || {
+  echo "Unexpected NBodyG output line count"
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+awk -v t="${tol}" '
+  $1 == 1 && $2 == 0 && $3 == 2 && $4 == 0 && $5 == 2 {
+    re = $6; if (re < 0) re = -re;
+    found_diag = (re > t);
+  }
+  $1 == 2 && $2 == 0 && $3 == 2 && $4 == 0 && $5 == 1 && $6 == 0 && $7 == 2 && $8 == 0 && $9 == 1 {
+    re = $(NF - 1); im = $NF;
+    if (re < 0) re = -re;
+    if (im < 0) im = -im;
+    found_zero = (re < t && im < t);
+  }
+  END { exit (found_diag && found_zero) ? 0 : 1; }
+' output/zvo_NBodyG.dat || {
+  echo "Expected nonzero diagonal and zero same-site NBodyG outputs were not found"
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+echo "canonical Spin spin-one NBodyG serial output checks passed."

--- a/test/lanczos_spingc_spinone_nbody_interall.sh
+++ b/test/lanczos_spingc_spinone_nbody_interall.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_spingc_spinone_nbody_interall"
+hphi="../../src/HPhi"
+tol="0.000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 0.0
+2S = 2
+Lanczos_max = 100
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 5
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 2 0.1250000000000000 0.0000000000000000
+1 1 1 1 1 -0.0750000000000000 0.0000000000000000
+2 0 2 0 0 1 0 1 2 0.2000000000000000 0.0000000000000000
+2 0 0 0 2 1 2 1 0 0.2000000000000000 0.0000000000000000
+3 0 2 0 2 1 1 1 1 2 0 2 0 0.0500000000000000 0.0000000000000000
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+e_lanczos=$(awk '/^Energy/{print $2; exit}' output/zvo_energy.dat)
+
+sed -e 's/^CalcType.*/CalcType   2/' -e 's/^OutputHam.*/OutputHam   0/' calcmod.def > calcmod.fulldiag
+mv calcmod.def calcmod.lanczos
+mv calcmod.fulldiag calcmod.def
+rm -rf output
+run_hphi log_fulldiag.txt "${hphi}" -e namelist.def
+if [ -f output/zvo_phys.dat ]; then
+  e_fulldiag=$(awk 'NR==2{print $1; exit}' output/zvo_phys.dat)
+else
+  e_fulldiag=$(awk 'NR==1{print $2; exit}' output/Eigenvalue.dat)
+fi
+
+diff=$(awk -v a="${e_lanczos}" -v b="${e_fulldiag}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.12g", d}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "SpinGC spin-one NBodyInterAll Lanczos/FullDiag energy mismatch: ${e_lanczos} vs ${e_fulldiag}"
+  exit 1
+}
+
+sed -e 's/^OutputHam.*/OutputHam   1/' calcmod.def > calcmod.outputham
+mv calcmod.outputham calcmod.def
+rm -rf output
+run_hphi log_outputham.txt "${hphi}" -e namelist.def
+
+test -f output/zvo_Ham.dat || { echo "zvo_Ham.dat was not generated"; exit 1; }
+awk 'NR>2 && $1 != $2 {found=1} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "SpinGC spin-one NBodyInterAll produced no off-diagonal Hamiltonian entry"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+awk 'NR>2 && $1 == $2 {
+  d1 = $3 - 0.125000; if (d1 < 0) d1 = -d1;
+  d2 = $3 + 0.075000; if (d2 < 0) d2 = -d2;
+  if (d1 < 0.000001 || d2 < 0.000001) found=1;
+} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "SpinGC spin-one diagonal NBodyInterAll term was not folded into the diagonal"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+
+echo "SpinGC spin-one NBodyInterAll Lanczos, FullDiag, and OutputHam checks passed."

--- a/test/lanczos_spingc_spinone_nbodyg.sh
+++ b/test/lanczos_spingc_spinone_nbodyg.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_spingc_spinone_nbodyg"
+hphi="../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 1.0
+2S = 2
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 5
+========================
+========NBodyG==========
+========================
+1 0 2 0 2
+1 1 1 1 0
+2 0 2 0 0 1 0 1 2
+2 0 0 0 2 1 2 1 0
+2 0 2 0 1 0 2 0 1
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated"; exit 1; }
+
+awk 'NF >= 7 {count++} END{exit count == 5 ? 0 : 1}' output/zvo_NBodyG.dat || {
+  echo "Unexpected NBodyG output line count"
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+awk -v t="${tol}" '
+  $1 == 1 && $2 == 0 && $3 == 2 && $4 == 0 && $5 == 2 {
+    re = $6; if (re < 0) re = -re;
+    found_diag = (re > t);
+  }
+  $1 == 2 && $2 == 0 && $3 == 2 && $4 == 0 && $5 == 1 && $6 == 0 && $7 == 2 && $8 == 0 && $9 == 1 {
+    re = $(NF - 1); im = $NF;
+    if (re < 0) re = -re;
+    if (im < 0) im = -im;
+    found_zero = (re < t && im < t);
+  }
+  END { exit (found_diag && found_zero) ? 0 : 1; }
+' output/zvo_NBodyG.dat || {
+  echo "Expected nonzero diagonal and zero same-site NBodyG outputs were not found"
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+echo "SpinGC spin-one NBodyG serial output checks passed."

--- a/test/mpi_nbody_interall_spin_spinone.sh
+++ b/test/mpi_nbody_interall_spin_spinone.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_spin_spinone"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 2
+J = 0.0
+2S = 2
+2Sz = 0
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 4
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 2 0.1000000000000000 0.0000000000000000
+1 1 2 1 2 0.1000000000000000 0.0000000000000000
+2 0 2 0 0 1 0 1 2 0.2500000000000000 0.0000000000000000
+2 0 0 0 2 1 2 1 0 0.2500000000000000 0.0000000000000000
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {count++; d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{if(count==0) print "missing"; else printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d != "missing" && d + 0 < t) ? 0 : 1}' || {
+  echo "canonical Spin spin-one np=3 NBodyInterAll energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
+  exit 1
+}
+
+echo "canonical Spin spin-one NBodyInterAll MPI np=3 matches serial energy."

--- a/test/mpi_nbody_interall_spin_spinone_np9.sh
+++ b/test/mpi_nbody_interall_spin_spinone_np9.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_spin_spinone_np9"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 3
+J = 0.0
+2S = 2
+2Sz = 0
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 1 2 1 0 2 0 2 2 0.2000000000000000 0.0000000000000000
+2 1 0 1 2 2 2 2 0 0.2000000000000000 0.0000000000000000
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {count++; d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{if(count==0) print "missing"; else printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d != "missing" && d + 0 < t) ? 0 : 1}' || {
+  echo "canonical Spin spin-one np=9 NBodyInterAll energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+echo "canonical Spin spin-one NBodyInterAll MPI np=9 matches serial energy."

--- a/test/mpi_nbody_interall_spingc_spinone.sh
+++ b/test/mpi_nbody_interall_spingc_spinone.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_spingc_spinone"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 2
+J = 0.0
+2S = 2
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 4
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 2 0.1000000000000000 0.0000000000000000
+1 1 2 1 2 0.1000000000000000 0.0000000000000000
+1 1 2 1 0 0.2500000000000000 0.0000000000000000
+1 1 0 1 2 0.2500000000000000 0.0000000000000000
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {count++; d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{if(count==0) print "missing"; else printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d != "missing" && d + 0 < t) ? 0 : 1}' || {
+  echo "SpinGC spin-one np=3 NBodyInterAll energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
+  exit 1
+}
+
+echo "SpinGC spin-one NBodyInterAll MPI np=3 matches serial energy."

--- a/test/mpi_nbody_interall_spingc_spinone_np9.sh
+++ b/test/mpi_nbody_interall_spingc_spinone_np9.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_spingc_spinone_np9"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 3
+J = 0.0
+2S = 2
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 1 2 1 0 2 0 2 2 0.2000000000000000 0.0000000000000000
+2 1 0 1 2 2 2 2 0 0.2000000000000000 0.0000000000000000
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {count++; d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{if(count==0) print "missing"; else printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d != "missing" && d + 0 < t) ? 0 : 1}' || {
+  echo "SpinGC spin-one np=9 NBodyInterAll energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+echo "SpinGC spin-one NBodyInterAll MPI np=9 matches serial energy."

--- a/test/mpi_nbodyg_spin_spinone.sh
+++ b/test/mpi_nbodyg_spin_spinone.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbodyg_spin_spinone"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 2
+J = 1.0
+2S = 2
+2Sz = 0
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 4
+========================
+========NBodyG==========
+========================
+1 1 2 1 2
+2 0 0 0 2 1 2 1 0
+2 0 2 0 0 1 0 1 2
+2 0 2 0 1 0 2 0 1
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_mpi.dat
+cd ..
+
+awk -v t="${tol}" '
+  function prefix(line, out) {
+    out = line;
+    sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+    return out;
+  }
+  NR == FNR {
+    s_prefix[NR] = prefix($0);
+    s_re[NR] = $(NF - 1);
+    s_im[NR] = $NF;
+    n = NR;
+    next;
+  }
+  {
+    m = FNR;
+    if (prefix($0) != s_prefix[m]) bad = 1;
+    dr = $(NF - 1) - s_re[m];
+    di = $NF - s_im[m];
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    if (dr >= t || di >= t) bad = 1;
+  }
+  END { exit (n == m && bad != 1) ? 0 : 1; }
+' nbodyg_serial.dat nbodyg_mpi.dat || {
+  echo "canonical Spin spin-one np=3 NBodyG output mismatch"
+  paste nbodyg_serial.dat nbodyg_mpi.dat
+  exit 1
+}
+
+echo "canonical Spin spin-one NBodyG MPI np=3 output matches serial output."

--- a/test/mpi_nbodyg_spin_spinone_np9.sh
+++ b/test/mpi_nbodyg_spin_spinone_np9.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbodyg_spin_spinone_np9"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 3
+J = 1.0
+2S = 2
+2Sz = 0
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 4
+========================
+========NBodyG==========
+========================
+1 2 2 2 2
+2 1 2 1 0 2 0 2 2
+2 1 0 1 2 2 2 2 0
+3 0 2 0 2 1 2 1 0 2 0 2 2
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_mpi.dat
+cd ..
+
+awk -v t="${tol}" '
+  function prefix(line, out) {
+    out = line;
+    sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+    return out;
+  }
+  NR == FNR {
+    s_prefix[NR] = prefix($0);
+    s_re[NR] = $(NF - 1);
+    s_im[NR] = $NF;
+    n = NR;
+    next;
+  }
+  {
+    m = FNR;
+    if (prefix($0) != s_prefix[m]) bad = 1;
+    dr = $(NF - 1) - s_re[m];
+    di = $NF - s_im[m];
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    if (dr >= t || di >= t) bad = 1;
+  }
+  END { exit (n == m && bad != 1) ? 0 : 1; }
+' nbodyg_serial.dat nbodyg_mpi.dat || {
+  echo "canonical Spin spin-one np=9 NBodyG output mismatch"
+  paste nbodyg_serial.dat nbodyg_mpi.dat
+  exit 1
+}
+
+echo "canonical Spin spin-one NBodyG MPI np=9 output matches serial output."

--- a/test/mpi_nbodyg_spingc_spinone.sh
+++ b/test/mpi_nbodyg_spingc_spinone.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbodyg_spingc_spinone"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 2
+J = 1.0
+2S = 2
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 4
+========================
+========NBodyG==========
+========================
+1 1 2 1 2
+2 0 0 0 2 1 2 1 0
+2 0 2 0 2 1 2 1 0
+2 1 0 1 2 1 2 1 0
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_mpi.dat
+cd ..
+
+awk -v t="${tol}" '
+  function prefix(line, out) {
+    out = line;
+    sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+    return out;
+  }
+  NR == FNR {
+    s_prefix[NR] = prefix($0);
+    s_re[NR] = $(NF - 1);
+    s_im[NR] = $NF;
+    n = NR;
+    next;
+  }
+  {
+    m = FNR;
+    if (prefix($0) != s_prefix[m]) bad = 1;
+    dr = $(NF - 1) - s_re[m];
+    di = $NF - s_im[m];
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    if (dr >= t || di >= t) bad = 1;
+  }
+  END { exit (n == m && bad != 1) ? 0 : 1; }
+' nbodyg_serial.dat nbodyg_mpi.dat || {
+  echo "SpinGC spin-one np=3 NBodyG output mismatch"
+  paste nbodyg_serial.dat nbodyg_mpi.dat
+  exit 1
+}
+
+awk -v t="${tol}" '
+  $1 == 2 && $2 == 0 && $3 == 0 && $4 == 0 && $5 == 2 && $6 == 1 && $7 == 2 && $8 == 1 && $9 == 0 {
+    re = $(NF - 1); im = $NF;
+    if (re < 0) re = -re;
+    if (im < 0) im = -im;
+    found = (re > t || im > t);
+  }
+  END { exit found ? 0 : 1; }
+' nbodyg_serial.dat || {
+  echo "SpinGC spin-one np=3 NBodyG local/inter-process flip expectation is zero"
+  cat nbodyg_serial.dat
+  exit 1
+}
+
+echo "SpinGC spin-one NBodyG MPI np=3 output matches serial output."

--- a/test/mpi_nbodyg_spingc_spinone_np9.sh
+++ b/test/mpi_nbodyg_spingc_spinone_np9.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbodyg_spingc_spinone_np9"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 3
+J = 1.0
+2S = 2
+Lanczos_max = 100
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 4
+========================
+========NBodyG==========
+========================
+1 2 2 2 2
+2 1 2 1 0 2 0 2 2
+2 1 0 1 2 2 2 2 0
+3 0 2 0 2 1 2 1 0 2 0 2 2
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_mpi.dat
+cd ..
+
+awk -v t="${tol}" '
+  function prefix(line, out) {
+    out = line;
+    sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+    return out;
+  }
+  NR == FNR {
+    s_prefix[NR] = prefix($0);
+    s_re[NR] = $(NF - 1);
+    s_im[NR] = $NF;
+    n = NR;
+    next;
+  }
+  {
+    m = FNR;
+    if (prefix($0) != s_prefix[m]) bad = 1;
+    dr = $(NF - 1) - s_re[m];
+    di = $NF - s_im[m];
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    if (dr >= t || di >= t) bad = 1;
+  }
+  END { exit (n == m && bad != 1) ? 0 : 1; }
+' nbodyg_serial.dat nbodyg_mpi.dat || {
+  echo "SpinGC spin-one np=9 NBodyG output mismatch"
+  paste nbodyg_serial.dat nbodyg_mpi.dat
+  exit 1
+}
+
+echo "SpinGC spin-one NBodyG MPI np=9 output matches serial output."

--- a/test/nbody_spingc_spinone_validation.sh
+++ b/test/nbody_spingc_spinone_validation.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+set -e
+
+testname="nbody_spingc_spinone_validation"
+hphi="../../../src/HPhi"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+expect_fail() {
+  dir="$1"
+  pattern="$2"
+  cd "${dir}"
+  set +e
+  "${hphi}" -e namelist.def > log.txt 2>&1
+  rc=$?
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    echo "Expected ${dir} to fail, but it succeeded"
+    exit 1
+  fi
+  grep -q "${pattern}" log.txt || {
+    echo "Expected pattern '${pattern}' was not found in ${dir}/log.txt"
+    cat log.txt
+    exit 1
+  }
+  cd ..
+}
+
+make_spingc_spinone_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 0.0
+2S = 2
+Lanczos_max = 50
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cd ..
+}
+
+make_spin_canonical_general_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "Spin"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 0.0
+2S = 2
+2Sz = 0
+Lanczos_max = 50
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cd ..
+}
+
+rm -rf bad_spin zero_interall bad_pair spin_general_reject nbodyg_bad_spin
+
+make_spingc_spinone_base bad_spin
+cat > bad_spin/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 3 0 3 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_spin/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spingc_spinone_base zero_interall
+cat > zero_interall/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+2 0 2 0 1 0 0 0 2 0.1000000000000000 0.0000000000000000
+EOF
+cat > zero_interall/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spingc_spinone_base bad_pair
+cat > bad_pair/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 0 0.1000000000000000 0.0000000000000000
+1 1 0 1 2 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_pair/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spin_canonical_general_base spin_general_reject
+cat > spin_general_reject/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 2 0.1000000000000000 0.0000000000000000
+EOF
+cat > spin_general_reject/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 2 0 2
+EOF
+
+make_spingc_spinone_base nbodyg_bad_spin
+cat > nbodyg_bad_spin/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > nbodyg_bad_spin/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 3 0 3
+EOF
+
+expect_fail bad_spin "Spin index of NBodyInterAll is incorrect"
+expect_fail zero_interall "zero same-site operator product"
+expect_fail bad_pair "Hermite pair has inconsistent factors"
+expect_fail spin_general_reject "NBodyInterAll is not supported for canonical Spin general spin"
+expect_fail nbodyg_bad_spin "Spin index of NBodyG is incorrect"
+
+echo "SpinGC spin-one NBody validation rejects malformed inputs."

--- a/test/nbody_spingc_spinone_validation.sh
+++ b/test/nbody_spingc_spinone_validation.sh
@@ -74,7 +74,8 @@ EOF
   cd ..
 }
 
-rm -rf bad_spin zero_interall bad_pair spin_general_reject nbodyg_bad_spin
+rm -rf bad_spin zero_interall bad_pair spin_general_accept \
+  spin_general_bad_interall_sz spin_general_bad_nbodyg_sz nbodyg_bad_spin
 
 make_spingc_spinone_base bad_spin
 cat > bad_spin/nbodyinterall.def <<EOF
@@ -128,8 +129,8 @@ NNBodyG 0
 ========================
 EOF
 
-make_spin_canonical_general_base spin_general_reject
-cat > spin_general_reject/nbodyinterall.def <<EOF
+make_spin_canonical_general_base spin_general_accept
+cat > spin_general_accept/nbodyinterall.def <<EOF
 ========================
 NNBodyInterAll 1
 ========================
@@ -137,13 +138,47 @@ NNBodyInterAll 1
 ========================
 1 0 2 0 2 0.1000000000000000 0.0000000000000000
 EOF
-cat > spin_general_reject/nbodyg.def <<EOF
+cat > spin_general_accept/nbodyg.def <<EOF
 ========================
 NNBodyG 1
 ========================
 ========NBodyG==========
 ========================
 1 0 2 0 2
+EOF
+
+make_spin_canonical_general_base spin_general_bad_interall_sz
+cat > spin_general_bad_interall_sz/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > spin_general_bad_interall_sz/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spin_canonical_general_base spin_general_bad_nbodyg_sz
+cat > spin_general_bad_nbodyg_sz/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > spin_general_bad_nbodyg_sz/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 2 0 0
 EOF
 
 make_spingc_spinone_base nbodyg_bad_spin
@@ -166,7 +201,11 @@ EOF
 expect_fail bad_spin "Spin index of NBodyInterAll is incorrect"
 expect_fail zero_interall "zero same-site operator product"
 expect_fail bad_pair "Hermite pair has inconsistent factors"
-expect_fail spin_general_reject "NBodyInterAll is not supported for canonical Spin general spin"
+cd spin_general_accept
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+expect_fail spin_general_bad_interall_sz "does not conserve total Sz"
+expect_fail spin_general_bad_nbodyg_sz "does not conserve total Sz"
 expect_fail nbodyg_bad_spin "Spin index of NBodyG is incorrect"
 
-echo "SpinGC spin-one NBody validation rejects malformed inputs."
+echo "SpinGC/canonical Spin spin-one NBody validation rejects malformed and Sz-nonconserving inputs."


### PR DESCRIPTION
## Summary

This PR enables `NBodyInterAll` and `NBodyG` for canonical `Spin` general-spin models.

It builds on the canonical spin-1/2 NBody support and SpinGC general-spin support already merged into `feature/nbody-spin-canonical`.

## Changes

- Allow canonical `Spin` with `iFlgGeneralSpin == TRUE` in NBody validation gates.
- Reuse the existing general-spin raw apply logic for `SpinGC` and add canonical `Spin` list-index conversion.
- Use `ConvertToList1GeneralSpin(..., X->Check.sdim, ...)` for canonical general-spin NBody paths.
- Wire off-diagonal `NBodyInterAll` into:
  - canonical general-spin Lanczos multiply path
  - FullDiag/OutputHam Hamiltonian construction
- Extend NBodyG expectation evaluation for canonical general spin, including MPI rank-flip paths.
- Add spin-1 canonical regression tests for serial, FullDiag, OutputHam, and MPI paths.
- Extend validation tests for canonical general-spin Sz conservation failures.

## Tests

Passed locally:

```sh
cmake -S . -B build
cmake --build build -j4

ctest --test-dir build -R 'lanczos_(spin|spingc).*nbody|fulldiag_spin_spinone_nbodyg|nbody_spingc_spinone_validation' --output-on-failure -j1

MPIRUN='mpiexec --oversubscribe -np 4' \
  ctest --test-dir build -R 'mpi_nbody(g|_interall)_(spin|spingc)$' --output-on-failure -j1

MPIRUN='mpiexec --oversubscribe -np 3' \
  ctest --test-dir build -R 'mpi_nbody(g|_interall)_(spin|spingc)_spinone$' --output-on-failure -j1

MPIRUN='mpiexec --oversubscribe -np 9' \
  ctest --test-dir build -R 'mpi_nbody(g|_interall)_(spin|spingc)_spinone_np9' --output-on-failure -j1

git diff --check
```

## Notes

The FullDiag NBodyG test guards the canonical general-spin list-index conversion.
Lanczos paths happen to have `X->Large.ihfbit == X->Check.sdim`, but FullDiag does not, so this test catches accidental use of `X->Large.ihfbit` instead of `X->Check.sdim`.