### PR TITLE
Add HubbardGC NBody interaction and correlation support

### DIFF
--- a/src/diagonalcalc.c
+++ b/src/diagonalcalc.c
@@ -195,7 +195,12 @@ int diagonalcalc
     }
 
   if (X->Def.NNBodyInterAll_Diagonal > 0) {
-    if (SetDiagonalNBodyInterAllSpinGC(X) != 0) {
+    if (X->Def.iCalcModel == HubbardGC) {
+      if (SetDiagonalNBodyInterAllHubbardGC(X) != 0) {
+        return -1;
+      }
+    }
+    else if (SetDiagonalNBodyInterAllSpinGC(X) != 0) {
       return -1;
     }
   }

--- a/src/include/nbody_interall.h
+++ b/src/include/nbody_interall.h
@@ -34,9 +34,16 @@ int ApplyNBodyInterAllSpinGC(
 );
 
 int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X);
+int SetDiagonalNBodyInterAllHubbardGC(struct BindStruct *X);
 int MultiplyNBodyInterAllSpinGC(
   struct BindStruct *X,
   double complex *tmp_v0,
   double complex *tmp_v1
 );
+int MultiplyNBodyInterAllHubbardGC(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+);
 int AddNBodyInterAllToHamSpinGC(struct BindStruct *X);
+int AddNBodyInterAllToHamHubbardGC(struct BindStruct *X);

--- a/src/makeHam.c
+++ b/src/makeHam.c
@@ -191,6 +191,11 @@ int makeHam(struct BindStruct *X) {
           }
         }
       }
+      if (X->Def.NNBodyInterAll_OffDiagonal > 0) {
+        if (AddNBodyInterAllToHamHubbardGC(X) != 0) {
+          return -1;
+        }
+      }
       //Pair hopping
       for (i = 0; i < X->Def.NPairHopping / 2; i++) {
         for (ihermite = 0; ihermite < 2; ihermite++) {

--- a/src/mltplyHubbard.c
+++ b/src/mltplyHubbard.c
@@ -142,6 +142,7 @@ Other
 #include "CalcTime.h"
 #include "mltplyHubbardCore.h"
 #include "mltplyMPIHubbardCore.h"
+#include "nbody_interall.h"
 
 #ifdef MPI
 // Static storage for batched transfers (MPIsingle)
@@ -632,6 +633,13 @@ int mltplyHubbardGC(
     X->Large.prdct += dam_pr;
   }/*for (i = 0; i < X->Def.NInterAll_OffDiagonal; i+=2)*/
   StopTimer(220);
+
+  if (X->Def.NNBodyInterAll_OffDiagonal > 0) {
+    if (MultiplyNBodyInterAllHubbardGC(X, tmp_v0, tmp_v1) != 0) {
+      return -1;
+    }
+  }
+
   /**
   Pair hopping
   */

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -103,6 +103,7 @@ static int nbodyg_is_supported_spin_model(const struct DefineList *D)
 {
   if (D->iCalcModel == SpinGC) return TRUE;
   if (D->iCalcModel == Spin) return TRUE;
+  if (D->iCalcModel == HubbardGC) return TRUE;
   return FALSE;
 }
 
@@ -117,7 +118,7 @@ int ValidateNBodyGScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
   if (nbodyg_is_supported_spin_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and Spin.\n");
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, and HubbardGC.\n");
     return -1;
   }
   for (t = 0; t < D->NNBodyG; t++) {
@@ -128,12 +129,13 @@ int ValidateNBodyGScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: Site index of NBodyG is incorrect.\n");
         return -1;
       }
-      if (f[0] != f[2]) {
+      if (D->iCalcModel != HubbardGC && f[0] != f[2]) {
         fprintf(stdoutMPI, "Error: NBodyG currently requires site_out == site_in for every factor.\n");
         return -1;
       }
       {
-        const int max_spin = nbodyg_is_general_spin(D) ? D->LocSpn[f[0]] : 1;
+        const int max_spin = (D->iCalcModel == HubbardGC) ? 1 :
+          (nbodyg_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
           return -1;
@@ -180,6 +182,21 @@ int NormalizeNBodyGTerms(struct DefineList *D)
   for (t = 0; t < D->NNBodyG; t++) {
     const unsigned int nraw = D->NBodyG_N[t];
     const unsigned int off = D->NBodyG_Offset[t];
+    if (D->iCalcModel == HubbardGC) {
+      D->NBodyG_IsZero[t] = FALSE;
+      D->NBodyG_CanonicalOffset[t] = total;
+      D->NBodyG_CanonicalN[t] = nraw;
+      for (k = 0; k < nraw; k++) {
+        const int *f = D->NBodyG_Factors[off + k];
+        D->NBodyG_CanonicalFactors[total + k][0] = f[0];
+        D->NBodyG_CanonicalFactors[total + k][1] = f[1];
+        D->NBodyG_CanonicalFactors[total + k][2] = f[2];
+        D->NBodyG_CanonicalFactors[total + k][3] = f[3];
+      }
+      total += nraw;
+      continue;
+    }
+
     int *sites = (int *)malloc(nraw * sizeof(int));
     int *outs = (int *)malloc(nraw * sizeof(int));
     int *ins = (int *)malloc(nraw * sizeof(int));
@@ -355,6 +372,173 @@ static int apply_nbodyg_general_spin_gc(
   return 1;
 }
 
+static int apply_hubbardgc_annihilate_mask(
+  unsigned long int mask,
+  unsigned long int *state,
+  int *sign
+) {
+  int sgn = 1;
+  if ((*state & mask) == 0) return 0;
+  SgnBit(*state & (mask - 1), &sgn);
+  *sign *= sgn;
+  *state &= ~mask;
+  return 1;
+}
+
+static int apply_hubbardgc_create_mask(
+  unsigned long int mask,
+  unsigned long int *state,
+  int *sign
+) {
+  int sgn = 1;
+  if ((*state & mask) != 0) return 0;
+  SgnBit(*state & (mask - 1), &sgn);
+  *sign *= sgn;
+  *state |= mask;
+  return 1;
+}
+
+static int apply_nbodyg_hubbardgc_full(
+  const struct BindStruct *X,
+  unsigned int term,
+  unsigned long int local_in,
+  int rank_in,
+  unsigned long int *local_out,
+  int *rank_out,
+  int *sign
+) {
+  const struct DefineList *D = &X->Def;
+  unsigned int k;
+  unsigned long int state;
+  const unsigned long int block = D->OrgTpow[2 * D->Nsite];
+  const unsigned int n = D->NBodyG_CanonicalN[term];
+  const unsigned int off = D->NBodyG_CanonicalOffset[term];
+
+  state = local_in + block * (unsigned long int)rank_in;
+  *sign = 1;
+
+  for (k = n; k > 0; k--) {
+    const int *f = D->NBodyG_CanonicalFactors[off + k - 1];
+    const unsigned int site_out = (unsigned int)f[0];
+    const unsigned int spin_out = (unsigned int)f[1];
+    const unsigned int site_in = (unsigned int)f[2];
+    const unsigned int spin_in = (unsigned int)f[3];
+    const unsigned long int mask_in = D->OrgTpow[2 * site_in + spin_in];
+    const unsigned long int mask_out = D->OrgTpow[2 * site_out + spin_out];
+
+    if (apply_hubbardgc_annihilate_mask(mask_in, &state, sign) == 0) return 0;
+    if (apply_hubbardgc_create_mask(mask_out, &state, sign) == 0) return 0;
+  }
+
+  *local_out = state % block;
+  *rank_out = (int)(state / block);
+  return 1;
+}
+
+static int apply_hubbardgc_rank_annihilate(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned int spin,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[2 * site + spin];
+  if ((*rank_state & mask) == 0) return 0;
+  *rank_state &= ~mask;
+  return 1;
+}
+
+static int apply_hubbardgc_rank_create(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned int spin,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[2 * site + spin];
+  if ((*rank_state & mask) != 0) return 0;
+  *rank_state |= mask;
+  return 1;
+}
+
+static int apply_hubbardgc_rank_factor(
+  const struct DefineList *D,
+  const int *f,
+  int dagger,
+  unsigned long int *rank_state
+) {
+  const unsigned int site_out = (unsigned int)f[0];
+  const unsigned int spin_out = (unsigned int)f[1];
+  const unsigned int site_in = (unsigned int)f[2];
+  const unsigned int spin_in = (unsigned int)f[3];
+
+  if (dagger == FALSE) {
+    if (apply_hubbardgc_rank_annihilate(D, site_in, spin_in, rank_state) == 0) return 0;
+    if (apply_hubbardgc_rank_create(D, site_out, spin_out, rank_state) == 0) return 0;
+  }
+  else {
+    if (apply_hubbardgc_rank_annihilate(D, site_out, spin_out, rank_state) == 0) return 0;
+    if (apply_hubbardgc_rank_create(D, site_in, spin_in, rank_state) == 0) return 0;
+  }
+  return 1;
+}
+
+static int apply_hubbardgc_rank_part(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int dagger,
+  int *partner_rank
+) {
+  const struct DefineList *D = &X->Def;
+  const unsigned int n = D->NBodyG_CanonicalN[term];
+  const unsigned int off = D->NBodyG_CanonicalOffset[term];
+  unsigned int k;
+  unsigned long int rank_state = (unsigned long int)current_rank;
+
+  if (dagger == FALSE) {
+    for (k = n; k > 0; k--) {
+      if (apply_hubbardgc_rank_factor(D, D->NBodyG_CanonicalFactors[off + k - 1],
+                                      FALSE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+  else {
+    for (k = 0; k < n; k++) {
+      if (apply_hubbardgc_rank_factor(D, D->NBodyG_CanonicalFactors[off + k],
+                                      TRUE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+
+  *partner_rank = (int)rank_state;
+  return 1;
+}
+
+static int nbodyg_hubbardgc_partner_rank(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int *partner_rank,
+  int *active
+) {
+  if (apply_hubbardgc_rank_part(X, term, current_rank, FALSE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  if (apply_hubbardgc_rank_part(X, term, current_rank, TRUE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  *active = FALSE;
+  *partner_rank = current_rank;
+  return 0;
+}
+
 static int convert_nbodyg_general_spin_to_list1(
   const struct BindStruct *X,
   unsigned long int local_out,
@@ -524,6 +708,71 @@ static double complex expec_nbodyg_term_to_rank_spin(
     }
   }
   return dam_pr;
+}
+
+static double complex expec_nbodyg_term_to_rank_hubbardgc(
+  struct BindStruct *X,
+  unsigned int term,
+  const double complex *src_vec,
+  const double complex *bra_vec,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, src_vec, bra_vec) firstprivate(src_i_max, term, rank_in, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbodyg_hubbardgc_full(X, term, j - 1, rank_in, &local_out, &rank_out, &sign);
+    if (ret == 1 && rank_out == myrank) {
+      dam_pr += conj(bra_vec[local_out + 1]) * sign * src_vec[j];
+    }
+  }
+  return dam_pr;
+}
+
+static double complex calc_nbodyg_term_hubbardgc(struct BindStruct *X, unsigned int term, double complex *vec)
+{
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbodyg_hubbardgc_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return SumMPI_dc(0.0);
+  }
+  if (active == FALSE) {
+    return SumMPI_dc(0.0);
+  }
+  if (origin == myrank) {
+    dam_pr = expec_nbodyg_term_to_rank_hubbardgc(
+      X, term, vec, vec, X->Check.idim_max, myrank);
+    return SumMPI_dc(dam_pr);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(vec, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf, idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = expec_nbodyg_term_to_rank_hubbardgc(
+      X, term, v1buf, vec, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyG reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return SumMPI_dc(dam_pr);
 }
 
 static double complex calc_nbodyg_term_general_spin_gc(struct BindStruct *X, unsigned int term, double complex *vec)
@@ -714,7 +963,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
 
   if (X->Def.NNBodyG < 1) return 0;
   if (nbodyg_is_supported_spin_model(&X->Def) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC and Spin.\n");
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, and HubbardGC.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;
@@ -724,6 +973,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
     double complex value = 0.0;
     if (X->Def.NBodyG_IsZero[t] == FALSE) {
       if (X->Def.iCalcModel == Spin) value = calc_nbodyg_term_spin(X, t, vec);
+      else if (X->Def.iCalcModel == HubbardGC) value = calc_nbodyg_term_hubbardgc(X, t, vec);
       else if (nbodyg_is_general_spin(&X->Def) == TRUE) {
         value = calc_nbodyg_term_general_spin_gc(X, t, vec);
       }

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -398,6 +398,13 @@ static int apply_hubbardgc_create_mask(
   return 1;
 }
 
+static unsigned long int get_hubbardgc_local_block(
+  const struct DefineList *D
+) {
+  if (D->Nsite == 0) return 1;
+  return D->OrgTpow[2 * D->Nsite - 1] * 2;
+}
+
 static int apply_nbodyg_hubbardgc_full(
   const struct BindStruct *X,
   unsigned int term,
@@ -410,7 +417,7 @@ static int apply_nbodyg_hubbardgc_full(
   const struct DefineList *D = &X->Def;
   unsigned int k;
   unsigned long int state;
-  const unsigned long int block = D->OrgTpow[2 * D->Nsite];
+  const unsigned long int block = get_hubbardgc_local_block(D);
   const unsigned int n = D->NBodyG_CanonicalN[term];
   const unsigned int off = D->NBodyG_CanonicalOffset[term];
 

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -504,6 +504,13 @@ static int apply_hubbardgc_create_mask(
   return 1;
 }
 
+static unsigned long int get_hubbardgc_local_block(
+  const struct DefineList *D
+) {
+  if (D->Nsite == 0) return 1;
+  return D->OrgTpow[2 * D->Nsite - 1] * 2;
+}
+
 static int apply_nbody_interall_hubbardgc_full(
   const struct BindStruct *X,
   unsigned int term_index,
@@ -516,7 +523,7 @@ static int apply_nbody_interall_hubbardgc_full(
   const struct DefineList *D = &X->Def;
   unsigned int k;
   unsigned long int state;
-  const unsigned long int block = D->OrgTpow[2 * D->Nsite];
+  const unsigned long int block = get_hubbardgc_local_block(D);
   const unsigned int n = D->NBodyInterAll_CanonicalN[term_index];
   const unsigned int off = D->NBodyInterAll_CanonicalOffset[term_index];
 

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -126,6 +126,7 @@ static int nbody_is_supported_spin_model(const struct DefineList *D)
 {
   if (D->iCalcModel == SpinGC) return TRUE;
   if (D->iCalcModel == Spin) return TRUE;
+  if (D->iCalcModel == HubbardGC) return TRUE;
   return FALSE;
 }
 
@@ -140,7 +141,7 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
   if (nbody_is_supported_spin_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC and Spin.\n");
+    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC, Spin, and HubbardGC.\n");
     return -1;
   }
   if (D->iCalcType == TimeEvolution) {
@@ -155,12 +156,13 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: Site index of NBodyInterAll is incorrect.\n");
         return -1;
       }
-      if (f[0] != f[2]) {
+      if (D->iCalcModel != HubbardGC && f[0] != f[2]) {
         fprintf(stdoutMPI, "Error: NBodyInterAll currently requires site_out == site_in for every factor.\n");
         return -1;
       }
       {
-        const int max_spin = nbody_is_general_spin(D) ? D->LocSpn[f[0]] : 1;
+        const int max_spin = (D->iCalcModel == HubbardGC) ? 1 :
+          (nbody_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
           return -1;
@@ -207,6 +209,20 @@ int NormalizeNBodyInterAllTerms(struct DefineList *D)
   for (t = 0; t < D->NNBodyInterAll; t++) {
     const unsigned int nraw = D->NBodyInterAll_N[t];
     const unsigned int off = D->NBodyInterAll_Offset[t];
+    if (D->iCalcModel == HubbardGC) {
+      D->NBodyInterAll_CanonicalOffset[t] = total;
+      D->NBodyInterAll_CanonicalN[t] = nraw;
+      for (k = 0; k < nraw; k++) {
+        const int *f = D->NBodyInterAll_Factors[off + k];
+        D->NBodyInterAll_CanonicalFactors[total + k][0] = f[0];
+        D->NBodyInterAll_CanonicalFactors[total + k][1] = f[1];
+        D->NBodyInterAll_CanonicalFactors[total + k][2] = f[2];
+        D->NBodyInterAll_CanonicalFactors[total + k][3] = f[3];
+      }
+      total += nraw;
+      continue;
+    }
+
     int *sites = (int *)malloc(nraw * sizeof(int));
     int *outs = (int *)malloc(nraw * sizeof(int));
     int *ins = (int *)malloc(nraw * sizeof(int));
@@ -296,7 +312,13 @@ int ClassifyNBodyInterAllTerms(struct DefineList *D)
     int diagonal = TRUE;
     for (k = 0; k < n; k++) {
       const int *f = D->NBodyInterAll_CanonicalFactors[off + k];
-      if (f[1] != f[3]) {
+      if (D->iCalcModel == HubbardGC) {
+        if (f[0] != f[2] || f[1] != f[3]) {
+          diagonal = FALSE;
+          break;
+        }
+      }
+      else if (f[1] != f[3]) {
         diagonal = FALSE;
         break;
       }
@@ -335,10 +357,20 @@ int CheckNBodyInterAllHermitePairs(const struct DefineList *D)
     }
     for (k = 0; k < n0; k++) {
       const int *f0 = D->NBodyInterAll_CanonicalFactors[off0 + k];
-      const int *f1 = D->NBodyInterAll_CanonicalFactors[off1 + k];
-      if (f0[0] != f1[0] || f0[1] != f1[3] || f0[3] != f1[1]) {
-        fprintf(stdoutMPI, "Error: Off-diagonal NBodyInterAll Hermite pair has inconsistent factors.\n");
-        return -1;
+      const int *f1 = (D->iCalcModel == HubbardGC) ?
+        D->NBodyInterAll_CanonicalFactors[off1 + n0 - 1 - k] :
+        D->NBodyInterAll_CanonicalFactors[off1 + k];
+      if (D->iCalcModel == HubbardGC) {
+        if (f0[0] != f1[2] || f0[1] != f1[3] || f0[2] != f1[0] || f0[3] != f1[1]) {
+          fprintf(stdoutMPI, "Error: Off-diagonal NBodyInterAll Hermite pair has inconsistent factors.\n");
+          return -1;
+        }
+      }
+      else {
+        if (f0[0] != f1[0] || f0[1] != f1[3] || f0[3] != f1[1]) {
+          fprintf(stdoutMPI, "Error: Off-diagonal NBodyInterAll Hermite pair has inconsistent factors.\n");
+          return -1;
+        }
       }
     }
     if (cabs(D->ParaNBodyInterAll[t1] - conj(D->ParaNBodyInterAll[t0])) > eps_CheckImag0) {
@@ -446,6 +478,173 @@ static int apply_nbody_interall_general_spin_gc(
   return 1;
 }
 
+static int apply_hubbardgc_annihilate_mask(
+  unsigned long int mask,
+  unsigned long int *state,
+  int *sign
+) {
+  int sgn = 1;
+  if ((*state & mask) == 0) return 0;
+  SgnBit(*state & (mask - 1), &sgn);
+  *sign *= sgn;
+  *state &= ~mask;
+  return 1;
+}
+
+static int apply_hubbardgc_create_mask(
+  unsigned long int mask,
+  unsigned long int *state,
+  int *sign
+) {
+  int sgn = 1;
+  if ((*state & mask) != 0) return 0;
+  SgnBit(*state & (mask - 1), &sgn);
+  *sign *= sgn;
+  *state |= mask;
+  return 1;
+}
+
+static int apply_nbody_interall_hubbardgc_full(
+  const struct BindStruct *X,
+  unsigned int term_index,
+  unsigned long int local_in,
+  int rank_in,
+  unsigned long int *local_out,
+  int *rank_out,
+  int *sign
+) {
+  const struct DefineList *D = &X->Def;
+  unsigned int k;
+  unsigned long int state;
+  const unsigned long int block = D->OrgTpow[2 * D->Nsite];
+  const unsigned int n = D->NBodyInterAll_CanonicalN[term_index];
+  const unsigned int off = D->NBodyInterAll_CanonicalOffset[term_index];
+
+  state = local_in + block * (unsigned long int)rank_in;
+  *sign = 1;
+
+  for (k = n; k > 0; k--) {
+    const int *f = D->NBodyInterAll_CanonicalFactors[off + k - 1];
+    const unsigned int site_out = (unsigned int)f[0];
+    const unsigned int spin_out = (unsigned int)f[1];
+    const unsigned int site_in = (unsigned int)f[2];
+    const unsigned int spin_in = (unsigned int)f[3];
+    const unsigned long int mask_in = D->OrgTpow[2 * site_in + spin_in];
+    const unsigned long int mask_out = D->OrgTpow[2 * site_out + spin_out];
+
+    if (apply_hubbardgc_annihilate_mask(mask_in, &state, sign) == 0) return 0;
+    if (apply_hubbardgc_create_mask(mask_out, &state, sign) == 0) return 0;
+  }
+
+  *local_out = state % block;
+  *rank_out = (int)(state / block);
+  return 1;
+}
+
+static int apply_hubbardgc_rank_annihilate(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned int spin,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[2 * site + spin];
+  if ((*rank_state & mask) == 0) return 0;
+  *rank_state &= ~mask;
+  return 1;
+}
+
+static int apply_hubbardgc_rank_create(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned int spin,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[2 * site + spin];
+  if ((*rank_state & mask) != 0) return 0;
+  *rank_state |= mask;
+  return 1;
+}
+
+static int apply_hubbardgc_rank_factor(
+  const struct DefineList *D,
+  const int *f,
+  int dagger,
+  unsigned long int *rank_state
+) {
+  const unsigned int site_out = (unsigned int)f[0];
+  const unsigned int spin_out = (unsigned int)f[1];
+  const unsigned int site_in = (unsigned int)f[2];
+  const unsigned int spin_in = (unsigned int)f[3];
+
+  if (dagger == FALSE) {
+    if (apply_hubbardgc_rank_annihilate(D, site_in, spin_in, rank_state) == 0) return 0;
+    if (apply_hubbardgc_rank_create(D, site_out, spin_out, rank_state) == 0) return 0;
+  }
+  else {
+    if (apply_hubbardgc_rank_annihilate(D, site_out, spin_out, rank_state) == 0) return 0;
+    if (apply_hubbardgc_rank_create(D, site_in, spin_in, rank_state) == 0) return 0;
+  }
+  return 1;
+}
+
+static int apply_hubbardgc_rank_part(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int dagger,
+  int *partner_rank
+) {
+  const struct DefineList *D = &X->Def;
+  const unsigned int n = D->NBodyInterAll_CanonicalN[term];
+  const unsigned int off = D->NBodyInterAll_CanonicalOffset[term];
+  unsigned int k;
+  unsigned long int rank_state = (unsigned long int)current_rank;
+
+  if (dagger == FALSE) {
+    for (k = n; k > 0; k--) {
+      if (apply_hubbardgc_rank_factor(D, D->NBodyInterAll_CanonicalFactors[off + k - 1],
+                                      FALSE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+  else {
+    for (k = 0; k < n; k++) {
+      if (apply_hubbardgc_rank_factor(D, D->NBodyInterAll_CanonicalFactors[off + k],
+                                      TRUE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+
+  *partner_rank = (int)rank_state;
+  return 1;
+}
+
+static int nbody_interall_hubbardgc_partner_rank(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int *partner_rank,
+  int *active
+) {
+  if (apply_hubbardgc_rank_part(X, term, current_rank, FALSE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  if (apply_hubbardgc_rank_part(X, term, current_rank, TRUE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  *active = FALSE;
+  *partner_rank = current_rank;
+  return 0;
+}
+
 int ApplyNBodyInterAllSpinGC(
   const struct BindStruct *X,
   unsigned int term_index,
@@ -471,6 +670,7 @@ int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X)
   unsigned int i;
   if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
   if (nbody_is_supported_spin_model(&X->Def) == FALSE) return -1;
+  if (X->Def.iCalcModel == HubbardGC) return -1;
 
   for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
     const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
@@ -499,6 +699,33 @@ int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X)
       int ret = ApplyNBodyInterAllSpinGC(X, term, j - 1, myrank, &local_out, &rank_out, &me);
       if (ret == 1 && local_out == j - 1 && rank_out == myrank) {
         list_Diagonal[j] += coeff;
+      }
+    }
+  }
+  return 0;
+}
+
+int SetDiagonalNBodyInterAllHubbardGC(struct BindStruct *X)
+{
+  unsigned int i;
+  if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
+  if (X->Def.iCalcModel != HubbardGC) return -1;
+
+  for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
+    const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
+    const double coeff = creal(X->Def.ParaNBodyInterAll[term]);
+    const unsigned long int i_max = X->Check.idim_max;
+    unsigned long int j;
+
+#pragma omp parallel for default(none) shared(list_Diagonal, X) firstprivate(i_max, term, coeff, myrank) private(j)
+    for (j = 1; j <= i_max; j++) {
+      unsigned long int local_out = 0;
+      int rank_out = 0;
+      int sign = 1;
+      int ret = apply_nbody_interall_hubbardgc_full(
+        X, term, j - 1, myrank, &local_out, &rank_out, &sign);
+      if (ret == 1 && local_out == j - 1 && rank_out == myrank) {
+        list_Diagonal[j] += coeff * sign;
       }
     }
   }
@@ -830,6 +1057,93 @@ static double complex multiply_nbody_pair_spin(
   return dam_pr;
 }
 
+static double complex apply_nbody_hubbardgc_term_to_rank(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  const double complex *src_v1,
+  double complex *cur_v1,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+  const int do_update = (X->Large.mode == M_MLTPLY || X->Large.mode == M_CALCSPEC);
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, tmp_v0, src_v1, cur_v1) firstprivate(src_i_max, term, rank_in, do_update, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbody_interall_hubbardgc_full(
+      X, term, j - 1, rank_in, &local_out, &rank_out, &sign);
+    if (ret == 1 && rank_out == myrank) {
+      const double complex dmv = X->Def.ParaNBodyInterAll[term] * sign * src_v1[j];
+      if (do_update) tmp_v0[local_out + 1] += dmv;
+      dam_pr += conj(cur_v1[local_out + 1]) * dmv;
+    }
+  }
+  return dam_pr;
+}
+
+static double complex multiply_nbody_hubbardgc_term(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbody_interall_hubbardgc_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return 0.0;
+  }
+  if (active == FALSE) return 0.0;
+  if (origin == myrank) {
+    return apply_nbody_hubbardgc_term_to_rank(
+      X, term, tmp_v0, tmp_v1, tmp_v1, X->Check.idim_max, myrank);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(tmp_v1, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf,  idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = apply_nbody_hubbardgc_term_to_rank(
+      X, term, tmp_v0, v1buf, tmp_v1, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyInterAll reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return dam_pr;
+}
+
+int MultiplyNBodyInterAllHubbardGC(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  unsigned int p;
+  if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
+  if (X->Def.iCalcModel != HubbardGC) return -1;
+
+  for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
+    const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
+    X->Large.prdct += multiply_nbody_hubbardgc_term(X, term, tmp_v0, tmp_v1);
+  }
+  return 0;
+}
+
 int MultiplyNBodyInterAllSpinGC(
   struct BindStruct *X,
   double complex *tmp_v0,
@@ -853,6 +1167,33 @@ int MultiplyNBodyInterAllSpinGC(
     }
     else {
       X->Large.prdct += multiply_nbody_pair(X, p, tmp_v0, tmp_v1);
+    }
+  }
+  return 0;
+}
+
+int AddNBodyInterAllToHamHubbardGC(struct BindStruct *X)
+{
+  unsigned int p;
+  unsigned long int j;
+  if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
+  if (X->Def.iCalcModel != HubbardGC) return -1;
+
+  for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
+    const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
+    for (j = 1; j <= X->Check.idim_max; j++) {
+      unsigned long int local_out = 0;
+      int rank_out = 0;
+      int sign = 1;
+      int ret = apply_nbody_interall_hubbardgc_full(
+        X, term, j - 1, myrank, &local_out, &rank_out, &sign);
+      if (ret == 1) {
+        if (rank_out != myrank) {
+          fprintf(stdoutMPI, "Error: FullDiag NBodyInterAll cannot handle inter-process output.\n");
+          return -1;
+        }
+        Ham[local_out + 1][j] += X->Def.ParaNBodyInterAll[term] * sign;
+      }
     }
   }
   return 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,8 @@ add_hphi_test(lanczos_spin_kagome)
 add_hphi_test(lanczos_spin_ladder_DM)
 add_hphi_test(lanczos_genspin_ladder)
 add_hphi_test(lanczos_hubbardgc_tri)
+add_hphi_test(lanczos_hubbardgc_nbody_interall)
+add_hphi_test(lanczos_hubbardgc_nbodyg)
 add_hphi_test(lanczos_kondogc_chain)
 add_hphi_test(lanczos_spingc_honey)
 add_hphi_test(lanczos_spingc_hcor)
@@ -77,6 +79,7 @@ add_hphi_test(lanczos_tjgc_dimension)
 add_hphi_test(lanczos_tjgc_exchange)
 add_hphi_test(nbody_interall_validation)
 add_hphi_test(nbodyg_validation)
+add_hphi_test(nbody_hubbardgc_validation)
 add_hphi_test_with_srcdir(lanczos_spinless)
 add_hphi_test_with_srcdir(lanczos_spinless_GC)
 add_hphi_test_with_srcdir(lanczos_spinless_calchs0)
@@ -90,6 +93,7 @@ add_hphi_test(lanczos_genspin_ladder_restart)
 # Lanczos test labels
 set_tests_properties(
     lanczos_hubbard_square lanczos_hubbardgc_tri
+    lanczos_hubbardgc_nbody_interall lanczos_hubbardgc_nbodyg
     lanczos_hubbard_square_restart
     lanczos_hubbard_square_calchs2 lanczos_hubbard_square_ncond_calchs2
     lanczos_hubbard_chain_polarized_calchs2
@@ -124,6 +128,9 @@ set_tests_properties(
 set_tests_properties(
     nbody_spingc_spinone_validation
     PROPERTIES LABELS "spinone;genspin;validation;nbody")
+set_tests_properties(
+    nbody_hubbardgc_validation
+    PROPERTIES LABELS "hubbard;validation;nbody")
 set_tests_properties(
     lanczos_spingc_spinone_nbody_interall
     lanczos_spin_spinone_nbody_interall
@@ -198,6 +205,7 @@ add_hphi_test(fulldiag_kondo_chain)
 add_hphi_test(fulldiag_spin_tri)
 add_hphi_test(fulldiag_genspin_ladder)
 add_hphi_test(fulldiag_hubbardgc_tri)
+add_hphi_test(fulldiag_hubbardgc_nbody_interall)
 add_hphi_test(fulldiag_tj_calchs1)
 add_hphi_test(fulldiag_kondogc_chain)
 add_hphi_test(fulldiag_spingc_tri)
@@ -207,6 +215,7 @@ add_hphi_test(fulldiag_genspingc_ladder)
 # Full diag test labels
 set_tests_properties(
     fulldiag_hubbard_chain fulldiag_hubbardgc_tri fulldiag_Hamiltonian_IO
+    fulldiag_hubbardgc_nbody_interall
     PROPERTIES LABELS "fulldiag;hubbard")
 set_tests_properties(
     fulldiag_kondo_chain fulldiag_kondogc_chain
@@ -373,6 +382,8 @@ if(MPI_FOUND)
     add_hphi_mpi_test_with_srcdir(mpi_nobatch_equivalence_spinless exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spingc exact:4)
     add_hphi_mpi_test(mpi_nbodyg_spingc exact:4)
+    add_hphi_mpi_test(mpi_nbody_interall_hubbardgc exact:4)
+    add_hphi_mpi_test(mpi_nbodyg_hubbardgc exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spin exact:4)
     add_hphi_mpi_test(mpi_nbodyg_spin exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone exact:3)
@@ -395,6 +406,7 @@ if(MPI_FOUND)
     set_tests_properties(
         mpi_consistency_hubbard mpi_consistency_hubbardgc mpi_consistency_te_hubbard
         mpi_consistency_te_hubbardgc_twobody mpi_consistency_te_hubbard_twobody
+        mpi_nbody_interall_hubbardgc mpi_nbodyg_hubbardgc
         PROPERTIES LABELS "mpi;consistency;hubbard")
     set_tests_properties(
         mpi_consistency_spin mpi_consistency_spingc mpi_consistency_te_spin

--- a/test/fulldiag_hubbardgc_nbody_interall.sh
+++ b/test/fulldiag_hubbardgc_nbody_interall.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+testname="fulldiag_hubbardgc_nbody_interall"
+hphi="../../src/HPhi"
+tol="0.000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 3
+t = 0.0
+U = 0.0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1250000000000000 0.0000000000000000
+2 2 0 0 0 1 1 1 1 0.2500000000000000 0.0000000000000000
+2 1 1 1 1 0 0 2 0 0.2500000000000000 0.0000000000000000
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+e_lanczos=$(awk '/^Energy/{print $2; exit}' output/zvo_energy.dat)
+
+sed -e 's/^CalcType.*/CalcType   2/' -e 's/^OutputHam.*/OutputHam   0/' calcmod.def > calcmod.fulldiag
+mv calcmod.def calcmod.lanczos
+mv calcmod.fulldiag calcmod.def
+rm -rf output
+run_hphi log_fulldiag.txt "${hphi}" -e namelist.def
+if [ -f output/zvo_phys.dat ]; then
+  e_fulldiag=$(awk 'NR==2{print $1; exit}' output/zvo_phys.dat)
+else
+  e_fulldiag=$(awk 'NR==1{print $2; exit}' output/Eigenvalue.dat)
+fi
+
+diff=$(awk -v a="${e_lanczos}" -v b="${e_fulldiag}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.12g", d}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "HubbardGC NBodyInterAll Lanczos/FullDiag energy mismatch: ${e_lanczos} vs ${e_fulldiag}"
+  exit 1
+}
+
+sed -e 's/^OutputHam.*/OutputHam   1/' calcmod.def > calcmod.outputham
+mv calcmod.outputham calcmod.def
+rm -rf output
+run_hphi log_outputham.txt "${hphi}" -e namelist.def
+
+test -f output/zvo_Ham.dat || { echo "zvo_Ham.dat was not generated"; exit 1; }
+awk 'NR>2 && $1 != $2 {found=1} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "HubbardGC NBodyInterAll produced no off-diagonal Hamiltonian entry"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+awk 'NR>2 && $1 == $2 {
+  d = $3 - 0.125000;
+  if (d < 0) d = -d;
+  if (d < 0.000001) found=1;
+} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "HubbardGC diagonal NBodyInterAll term was not folded into the diagonal"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+
+echo "HubbardGC NBodyInterAll Lanczos, FullDiag, and OutputHam checks passed."

--- a/test/lanczos_hubbardgc_nbody_interall.sh
+++ b/test/lanczos_hubbardgc_nbody_interall.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_hubbardgc_nbody_interall"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+make_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 0.0
+U = 0.0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  cd ..
+}
+
+rm -rf nbody legacy
+make_base nbody
+make_base legacy
+
+cd nbody
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 3 0 0 0 1 1 1 1 0.3700000000000000 0.1100000000000000
+2 1 1 1 1 0 0 3 0 0.3700000000000000 -0.1100000000000000
+EOF
+run_hphi log_nbody.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_nbody.dat
+cd ..
+
+cd legacy
+printf '    InterAll  interall.def\n' >> namelist.def
+cat > interall.def <<EOF
+========================
+NInterAll 2
+========================
+========zInterAll=======
+========================
+3 0 0 0 1 1 1 1 0.3700000000000000 0.1100000000000000
+1 1 1 1 0 0 3 0 0.3700000000000000 -0.1100000000000000
+EOF
+run_hphi log_legacy.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_legacy.dat
+cd ..
+
+diff=$(paste energy_nbody.dat energy_legacy.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "HubbardGC NBodyInterAll energy differs from legacy InterAll: max diff ${diff}"
+  paste energy_nbody.dat energy_legacy.dat
+  exit 1
+}
+
+echo "HubbardGC NBodyInterAll N=2 matches legacy InterAll in Lanczos."

--- a/test/lanczos_hubbardgc_nbodyg.sh
+++ b/test/lanczos_hubbardgc_nbodyg.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_hubbardgc_nbodyg"
+hphi="../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 2.0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+
+cat > greenone.def <<EOF
+========================
+NCisAjs 1
+========================
+========GreenOne========
+========================
+0 0 0 0
+EOF
+
+cat > greentwo.def <<EOF
+========================
+NCisAjsCktAlt 1
+========================
+========GreenTwo========
+========================
+0 0 1 0 1 1 0 1
+EOF
+
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 3
+========================
+========NBodyG==========
+========================
+1 0 0 0 0
+1 1 0 0 0
+2 0 0 1 0 1 1 0 1
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated"; exit 1; }
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 0 && $2 == 0 && $3 == 0 && $4 == 0) {
+      ref_re = $5;
+      ref_im = $6;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 1 && $2 == 0 && $3 == 0 && $4 == 0 && $5 == 0 {
+    dr = $6 - ref_re;
+    di = $7 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajs.dat output/zvo_NBodyG.dat || {
+  echo "HubbardGC NBodyG number operator does not match cisajs"
+  cat output/zvo_cisajs.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 0 && $2 == 0 && $3 == 1 && $4 == 0 &&
+        $5 == 1 && $6 == 1 && $7 == 0 && $8 == 1) {
+      ref_re = $9;
+      ref_im = $10;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 2 && $2 == 0 && $3 == 0 && $4 == 1 && $5 == 0 &&
+      $6 == 1 && $7 == 1 && $8 == 0 && $9 == 1 {
+    dr = $10 - ref_re;
+    di = $11 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajscktalt.dat output/zvo_NBodyG.dat || {
+  echo "HubbardGC NBodyG two-body value does not match cisajscktalt"
+  cat output/zvo_cisajscktalt.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+awk '$1 == 1 && $2 == 1 && $3 == 0 && $4 == 0 && $5 == 0 {found=1} END{exit found ? 0 : 1}' output/zvo_NBodyG.dat || {
+  echo "HubbardGC NBodyG hopping line was not written"
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+echo "HubbardGC NBodyG number, hopping output, and two-body checks passed."

--- a/test/mpi_nbody_interall_hubbardgc.sh
+++ b/test/mpi_nbody_interall_hubbardgc.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_hubbardgc"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 0.0
+U = 0.0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+1 3 0 3 0 0.1250000000000000 0.0000000000000000
+2 3 0 0 0 1 1 1 1 0.3700000000000000 0.1100000000000000
+2 1 1 1 1 0 0 3 0 0.3700000000000000 -0.1100000000000000
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "Serial/MPI HubbardGC NBodyInterAll energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
+  exit 1
+}
+
+echo "HubbardGC NBodyInterAll MPI np=4 matches serial energy."

--- a/test/mpi_nbodyg_hubbardgc.sh
+++ b/test/mpi_nbodyg_hubbardgc.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbodyg_hubbardgc"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 2.0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 3
+========================
+========NBodyG==========
+========================
+1 3 0 3 0
+1 3 0 0 0
+2 3 0 0 0 1 1 1 1
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_mpi.dat
+cd ..
+
+awk -v t="${tol}" '
+  function prefix(line, out) {
+    out = line;
+    sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+    return out;
+  }
+  NR == FNR {
+    s_prefix[NR] = prefix($0);
+    s_re[NR] = $(NF - 1);
+    s_im[NR] = $NF;
+    n = NR;
+    next;
+  }
+  {
+    m = FNR;
+    if (prefix($0) != s_prefix[m]) bad = 1;
+    dr = $(NF - 1) - s_re[m];
+    di = $NF - s_im[m];
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    if (dr >= t || di >= t) bad = 1;
+  }
+  END { exit (n == m && bad != 1) ? 0 : 1; }
+' nbodyg_serial.dat nbodyg_mpi.dat || {
+  echo "Serial/MPI HubbardGC NBodyG output mismatch"
+  paste nbodyg_serial.dat nbodyg_mpi.dat
+  exit 1
+}
+
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
+  exit 1
+}
+
+awk -v t="${tol}" '
+  $1 == 1 && $2 == 3 && $3 == 0 && $4 == 3 && $5 == 0 {
+    re = $6; if (re < 0) re = -re;
+    found = (re > t);
+  }
+  END { exit found ? 0 : 1; }
+' nbodyg_mpi.dat || {
+  echo "Inter-process HubbardGC diagonal NBodyG operator was zero or missing"
+  cat nbodyg_mpi.dat
+  exit 1
+}
+
+echo "HubbardGC NBodyG MPI np=4 output matches serial output."

--- a/test/nbody_hubbardgc_validation.sh
+++ b/test/nbody_hubbardgc_validation.sh
@@ -1,0 +1,192 @@
+#!/bin/sh
+set -e
+
+testname="nbody_hubbardgc_validation"
+hphi="../../../src/HPhi"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+expect_fail() {
+  dir="$1"
+  pattern="$2"
+  cd "${dir}"
+  set +e
+  "${hphi}" -e namelist.def > log.txt 2>&1
+  rc=$?
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    echo "Expected ${dir} to fail, but it succeeded"
+    exit 1
+  fi
+  grep -q "${pattern}" log.txt || {
+    echo "Expected pattern '${pattern}' was not found in ${dir}/log.txt"
+    cat log.txt
+    exit 1
+  }
+  cd ..
+}
+
+make_hubbardgc_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 0.0
+U = 0.0
+Lanczos_max = 50
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cd ..
+}
+
+make_spingc_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "SpinGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+J = 0.0
+2S = 1
+Lanczos_max = 50
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cd ..
+}
+
+rm -rf accept bad_spin_interall bad_spin_nbodyg bad_pair diag_im spin_cross_site
+
+make_hubbardgc_base accept
+cat > accept/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 1 0 0 0 2 1 2 1 0.1000000000000000 0.0000000000000000
+2 2 1 2 1 0 0 1 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > accept/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 1 0 0 0
+EOF
+
+make_hubbardgc_base bad_spin_interall
+cat > bad_spin_interall/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_spin_interall/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_hubbardgc_base bad_spin_nbodyg
+cat > bad_spin_nbodyg/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > bad_spin_nbodyg/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 2 0 0
+EOF
+
+make_hubbardgc_base bad_pair
+cat > bad_pair/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 1 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_pair/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_hubbardgc_base diag_im
+cat > diag_im/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.1000000000000000
+EOF
+cat > diag_im/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spingc_base spin_cross_site
+cat > spin_cross_site/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 1 1 0 1 0.1000000000000000 0.0000000000000000
+EOF
+cat > spin_cross_site/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 1 1 0 1
+EOF
+
+cd accept
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+expect_fail bad_spin_interall "Spin index of NBodyInterAll is incorrect"
+expect_fail bad_spin_nbodyg "Spin index of NBodyG is incorrect"
+expect_fail bad_pair "adjacent Hermite"
+expect_fail diag_im "finite imaginary"
+expect_fail spin_cross_site "requires site_out == site_in"
+
+echo "HubbardGC NBody validation accepts cross-site fermion factors and rejects malformed inputs."


### PR DESCRIPTION
## Summary

- Add `NBodyInterAll` support for `HubbardGC`
- Add `NBodyG` support for `HubbardGC`
- Add dedicated HubbardGC fermion apply, diagonal, mltply, FullDiag, and MPI paths
- Add validation, Lanczos, FullDiag, and MPI tests for HubbardGC N-body interaction/correlation

## Details

This PR extends the generic N-body interaction/correlation support to `HubbardGC`.

The implementation uses the Hubbard full-bit orbital layout:

- orbital index: `2 * site + spin`
- spin: `0 = up`, `1 = down`
- full state reconstruction: `local_state + OrgTpow[2 * Nsite] * rank`
- fermion sign from the parity of occupied lower orbitals in the intermediate state

For `NBodyInterAll`, this PR adds HubbardGC-specific diagonal, multiplication, and FullDiag Hamiltonian construction paths. It intentionally avoids reusing the Spin/SpinGC matrix-unit apply path.

For `NBodyG`, this PR adds HubbardGC-specific expectation evaluation, including MPI partner-rank handling based on the forward operator and reverse-dagger preimage symmetry.

The legacy `ArrangeInterAllOffDiagonal` normalization is not copied into the generic N-body path. Terms are applied in the input factor order, and fermion signs are computed directly from the intermediate full-bit state.

## Tests

Added tests:

- `nbody_hubbardgc_validation`
- `lanczos_hubbardgc_nbodyg`
- `lanczos_hubbardgc_nbody_interall`
- `fulldiag_hubbardgc_nbody_interall`
- `mpi_nbodyg_hubbardgc`
- `mpi_nbody_interall_hubbardgc`

Manual validation:

```sh
cmake -S . -B build
cmake --build build -j4
MPIRUN="mpirun --oversubscribe -np 4" ctest --test-dir build \
  -R '^(nbody_hubbardgc_validation|lanczos_hubbardgc_nbody_interall|lanczos_hubbardgc_nbodyg|fulldiag_hubbardgc_nbody_interall|mpi_nbodyg_hubbardgc|mpi_nbody_interall_hubbardgc)$' \
  --output-on-failure
```

All passed.

Additional regression checks for existing Spin/SpinGC N-body tests and spin-one MPI tests also passed.

## Notes

- Canonical `Hubbard`, `Kondo`, `tJ`, and `spinless` remain unsupported by this PR.
- The HubbardGC apply helpers are currently duplicated between `nbody_interall.c` and `nbody_correlation.c`. This is intentional for this first implementation, but they can be factored into a shared helper later.
- Off-diagonal Hermitian pairs are still processed term-by-term, so MPI communication can be less efficient than the legacy four-body `InterAll` path. Correctness is prioritized here.
