### PR TITLE
Add canonical Hubbard support for NBodyInterAll and NBodyG

### DIFF
--- a/src/diagonalcalc.c
+++ b/src/diagonalcalc.c
@@ -200,6 +200,11 @@ int diagonalcalc
         return -1;
       }
     }
+    else if (X->Def.iCalcModel == Hubbard) {
+      if (SetDiagonalNBodyInterAllHubbard(X) != 0) {
+        return -1;
+      }
+    }
     else if (SetDiagonalNBodyInterAllSpinGC(X) != 0) {
       return -1;
     }

--- a/src/include/nbody_correlation.h
+++ b/src/include/nbody_correlation.h
@@ -18,4 +18,5 @@ int ParseNBodyGLine(
 int ValidateNBodyGScope(const struct DefineList *D);
 int NormalizeNBodyGTerms(struct DefineList *D);
 int CheckNBodyGSpinConservation(const struct DefineList *D);
+int CheckNBodyGHubbardConservation(const struct DefineList *D);
 int expec_nbodyg(struct BindStruct *X, double complex *vec);

--- a/src/include/nbody_interall.h
+++ b/src/include/nbody_interall.h
@@ -20,6 +20,7 @@ int ParseNBodyInterAllLine(
 int ValidateNBodyInterAllScope(const struct DefineList *D);
 int NormalizeNBodyInterAllTerms(struct DefineList *D);
 int CheckNBodyInterAllSpinConservation(const struct DefineList *D);
+int CheckNBodyInterAllHubbardConservation(const struct DefineList *D);
 int ClassifyNBodyInterAllTerms(struct DefineList *D);
 int CheckNBodyInterAllHermitePairs(const struct DefineList *D);
 
@@ -35,6 +36,7 @@ int ApplyNBodyInterAllSpinGC(
 
 int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X);
 int SetDiagonalNBodyInterAllHubbardGC(struct BindStruct *X);
+int SetDiagonalNBodyInterAllHubbard(struct BindStruct *X);
 int MultiplyNBodyInterAllSpinGC(
   struct BindStruct *X,
   double complex *tmp_v0,
@@ -45,5 +47,11 @@ int MultiplyNBodyInterAllHubbardGC(
   double complex *tmp_v0,
   double complex *tmp_v1
 );
+int MultiplyNBodyInterAllHubbard(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+);
 int AddNBodyInterAllToHamSpinGC(struct BindStruct *X);
 int AddNBodyInterAllToHamHubbardGC(struct BindStruct *X);
+int AddNBodyInterAllToHamHubbard(struct BindStruct *X);

--- a/src/makeHam.c
+++ b/src/makeHam.c
@@ -319,6 +319,12 @@ int makeHam(struct BindStruct *X) {
         }
       }
 
+      if (X->Def.iCalcModel == Hubbard && X->Def.NNBodyInterAll_OffDiagonal > 0) {
+        if (AddNBodyInterAllToHamHubbard(X) != 0) {
+          return -1;
+        }
+      }
+
       //Pair hopping
       for (i = 0; i < X->Def.NPairHopping / 2; i++) {
         for (ihermite = 0; ihermite < 2; ihermite++) {

--- a/src/mltplyHubbard.c
+++ b/src/mltplyHubbard.c
@@ -353,6 +353,12 @@ int mltplyHubbard(
     X->Large.prdct += dam_pr;
   }/*for (i = 0; i < X->Def.NInterAll_OffDiagonal; i+=2)*/
   StopTimer(320);
+
+  if (X->Def.iCalcModel == Hubbard && X->Def.NNBodyInterAll_OffDiagonal > 0) {
+    if (MultiplyNBodyInterAllHubbard(X, tmp_v0, tmp_v1) != 0) {
+      return -1;
+    }
+  }
   /**
   Pair hopping
   */

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -104,7 +104,13 @@ static int nbodyg_is_supported_spin_model(const struct DefineList *D)
   if (D->iCalcModel == SpinGC) return TRUE;
   if (D->iCalcModel == Spin) return TRUE;
   if (D->iCalcModel == HubbardGC) return TRUE;
+  if (D->iCalcModel == Hubbard) return TRUE;
   return FALSE;
+}
+
+static int nbodyg_is_hubbard_model(const struct DefineList *D)
+{
+  return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
 }
 
 static int nbodyg_is_general_spin(const struct DefineList *D)
@@ -118,7 +124,7 @@ int ValidateNBodyGScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
   if (nbodyg_is_supported_spin_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, and HubbardGC.\n");
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, and Hubbard.\n");
     return -1;
   }
   for (t = 0; t < D->NNBodyG; t++) {
@@ -129,12 +135,12 @@ int ValidateNBodyGScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: Site index of NBodyG is incorrect.\n");
         return -1;
       }
-      if (D->iCalcModel != HubbardGC && f[0] != f[2]) {
+      if (nbodyg_is_hubbard_model(D) == FALSE && f[0] != f[2]) {
         fprintf(stdoutMPI, "Error: NBodyG currently requires site_out == site_in for every factor.\n");
         return -1;
       }
       {
-        const int max_spin = (D->iCalcModel == HubbardGC) ? 1 :
+        const int max_spin = (nbodyg_is_hubbard_model(D) == TRUE) ? 1 :
           (nbodyg_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
@@ -182,7 +188,7 @@ int NormalizeNBodyGTerms(struct DefineList *D)
   for (t = 0; t < D->NNBodyG; t++) {
     const unsigned int nraw = D->NBodyG_N[t];
     const unsigned int off = D->NBodyG_Offset[t];
-    if (D->iCalcModel == HubbardGC) {
+    if (nbodyg_is_hubbard_model(D) == TRUE) {
       D->NBodyG_IsZero[t] = FALSE;
       D->NBodyG_CanonicalOffset[t] = total;
       D->NBodyG_CanonicalN[t] = nraw;
@@ -277,6 +283,35 @@ int CheckNBodyGSpinConservation(const struct DefineList *D)
       fprintf(stdoutMPI,
               "Error: NBodyG term %u does not conserve total Sz: delta2Sz=%d.\n",
               t + 1, 2 * delta_nup);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int CheckNBodyGHubbardConservation(const struct DefineList *D)
+{
+  unsigned int t, k;
+  if (D->NNBodyG == 0) return 0;
+  if (D->iCalcModel != Hubbard) return 0;
+
+  for (t = 0; t < D->NNBodyG; t++) {
+    const unsigned int n = D->NBodyG_CanonicalN[t];
+    const unsigned int off = D->NBodyG_CanonicalOffset[t];
+    int delta_nup = 0;
+    int delta_ndown = 0;
+    if (D->NBodyG_IsZero[t] == TRUE) continue;
+    for (k = 0; k < n; k++) {
+      const int *f = D->NBodyG_CanonicalFactors[off + k];
+      if (f[1] == 0) delta_nup++;
+      else delta_ndown++;
+      if (f[3] == 0) delta_nup--;
+      else delta_ndown--;
+    }
+    if (delta_nup != 0 || delta_ndown != 0) {
+      fprintf(stdoutMPI,
+              "Error: NBodyG term %u does not conserve particle numbers: delta_Nup=%d delta_Ndown=%d.\n",
+              t + 1, delta_nup, delta_ndown);
       return -1;
     }
   }
@@ -742,6 +777,40 @@ static double complex expec_nbodyg_term_to_rank_hubbardgc(
   return dam_pr;
 }
 
+static double complex expec_nbodyg_term_to_rank_hubbard(
+  struct BindStruct *X,
+  unsigned int term,
+  const unsigned long int *src_list_1,
+  const double complex *src_vec,
+  const double complex *bra_vec,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, src_list_1, src_vec, bra_vec, list_2_1, list_2_2) \
+  firstprivate(src_i_max, term, rank_in, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    unsigned long int j_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbodyg_hubbardgc_full(
+      X, term, src_list_1[j], rank_in, &local_out, &rank_out, &sign);
+    int in_sector = FALSE;
+    if (ret == 1 && rank_out == myrank) {
+      in_sector = GetOffComp(list_2_1, list_2_2, local_out,
+                             X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+    }
+    if (in_sector == TRUE) {
+      dam_pr += conj(bra_vec[j_out]) * sign * src_vec[j];
+    }
+  }
+  return dam_pr;
+}
+
 static double complex calc_nbodyg_term_hubbardgc(struct BindStruct *X, unsigned int term, double complex *vec)
 {
   int origin = myrank;
@@ -774,6 +843,50 @@ static double complex calc_nbodyg_term_hubbardgc(struct BindStruct *X, unsigned 
     if (ierr != 0) exitMPI(-1);
     dam_pr = expec_nbodyg_term_to_rank_hubbardgc(
       X, term, v1buf, vec, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyG reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return SumMPI_dc(dam_pr);
+}
+
+static double complex calc_nbodyg_term_hubbard(struct BindStruct *X, unsigned int term, double complex *vec)
+{
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbodyg_hubbardgc_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return SumMPI_dc(0.0);
+  }
+  if (active == FALSE) {
+    return SumMPI_dc(0.0);
+  }
+  if (origin == myrank) {
+    dam_pr = expec_nbodyg_term_to_rank_hubbard(
+      X, term, list_1, vec, vec, X->Check.idim_max, myrank);
+    return SumMPI_dc(dam_pr);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(list_1, X->Check.idim_max + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        list_1buf, idim_max_buf + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(vec, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf, idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = expec_nbodyg_term_to_rank_hubbard(
+      X, term, list_1buf, v1buf, vec, idim_max_buf, origin);
   }
 #else
   fprintf(stdoutMPI, "Error: NBodyG reached an MPI-only rank flip path without MPI.\n");
@@ -970,7 +1083,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
 
   if (X->Def.NNBodyG < 1) return 0;
   if (nbodyg_is_supported_spin_model(&X->Def) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, and HubbardGC.\n");
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, and Hubbard.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;
@@ -980,6 +1093,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
     double complex value = 0.0;
     if (X->Def.NBodyG_IsZero[t] == FALSE) {
       if (X->Def.iCalcModel == Spin) value = calc_nbodyg_term_spin(X, t, vec);
+      else if (X->Def.iCalcModel == Hubbard) value = calc_nbodyg_term_hubbard(X, t, vec);
       else if (X->Def.iCalcModel == HubbardGC) value = calc_nbodyg_term_hubbardgc(X, t, vec);
       else if (nbodyg_is_general_spin(&X->Def) == TRUE) {
         value = calc_nbodyg_term_general_spin_gc(X, t, vec);

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -127,7 +127,13 @@ static int nbody_is_supported_spin_model(const struct DefineList *D)
   if (D->iCalcModel == SpinGC) return TRUE;
   if (D->iCalcModel == Spin) return TRUE;
   if (D->iCalcModel == HubbardGC) return TRUE;
+  if (D->iCalcModel == Hubbard) return TRUE;
   return FALSE;
+}
+
+static int nbody_is_hubbard_model(const struct DefineList *D)
+{
+  return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
 }
 
 static int nbody_is_general_spin(const struct DefineList *D)
@@ -141,7 +147,7 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
   if (nbody_is_supported_spin_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC, Spin, and HubbardGC.\n");
+    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC, Spin, HubbardGC, and Hubbard.\n");
     return -1;
   }
   if (D->iCalcType == TimeEvolution) {
@@ -156,12 +162,12 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: Site index of NBodyInterAll is incorrect.\n");
         return -1;
       }
-      if (D->iCalcModel != HubbardGC && f[0] != f[2]) {
+      if (nbody_is_hubbard_model(D) == FALSE && f[0] != f[2]) {
         fprintf(stdoutMPI, "Error: NBodyInterAll currently requires site_out == site_in for every factor.\n");
         return -1;
       }
       {
-        const int max_spin = (D->iCalcModel == HubbardGC) ? 1 :
+        const int max_spin = (nbody_is_hubbard_model(D) == TRUE) ? 1 :
           (nbody_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
@@ -209,7 +215,7 @@ int NormalizeNBodyInterAllTerms(struct DefineList *D)
   for (t = 0; t < D->NNBodyInterAll; t++) {
     const unsigned int nraw = D->NBodyInterAll_N[t];
     const unsigned int off = D->NBodyInterAll_Offset[t];
-    if (D->iCalcModel == HubbardGC) {
+    if (nbody_is_hubbard_model(D) == TRUE) {
       D->NBodyInterAll_CanonicalOffset[t] = total;
       D->NBodyInterAll_CanonicalN[t] = nraw;
       for (k = 0; k < nraw; k++) {
@@ -301,6 +307,34 @@ int CheckNBodyInterAllSpinConservation(const struct DefineList *D)
   return 0;
 }
 
+int CheckNBodyInterAllHubbardConservation(const struct DefineList *D)
+{
+  unsigned int t, k;
+  if (D->NNBodyInterAll == 0) return 0;
+  if (D->iCalcModel != Hubbard) return 0;
+
+  for (t = 0; t < D->NNBodyInterAll; t++) {
+    const unsigned int n = D->NBodyInterAll_CanonicalN[t];
+    const unsigned int off = D->NBodyInterAll_CanonicalOffset[t];
+    int delta_nup = 0;
+    int delta_ndown = 0;
+    for (k = 0; k < n; k++) {
+      const int *f = D->NBodyInterAll_CanonicalFactors[off + k];
+      if (f[1] == 0) delta_nup++;
+      else delta_ndown++;
+      if (f[3] == 0) delta_nup--;
+      else delta_ndown--;
+    }
+    if (delta_nup != 0 || delta_ndown != 0) {
+      fprintf(stdoutMPI,
+              "Error: NBodyInterAll term %u does not conserve particle numbers: delta_Nup=%d delta_Ndown=%d.\n",
+              t + 1, delta_nup, delta_ndown);
+      return -1;
+    }
+  }
+  return 0;
+}
+
 int ClassifyNBodyInterAllTerms(struct DefineList *D)
 {
   unsigned int t, k;
@@ -312,7 +346,7 @@ int ClassifyNBodyInterAllTerms(struct DefineList *D)
     int diagonal = TRUE;
     for (k = 0; k < n; k++) {
       const int *f = D->NBodyInterAll_CanonicalFactors[off + k];
-      if (D->iCalcModel == HubbardGC) {
+      if (nbody_is_hubbard_model(D) == TRUE) {
         if (f[0] != f[2] || f[1] != f[3]) {
           diagonal = FALSE;
           break;
@@ -357,10 +391,10 @@ int CheckNBodyInterAllHermitePairs(const struct DefineList *D)
     }
     for (k = 0; k < n0; k++) {
       const int *f0 = D->NBodyInterAll_CanonicalFactors[off0 + k];
-      const int *f1 = (D->iCalcModel == HubbardGC) ?
+      const int *f1 = (nbody_is_hubbard_model(D) == TRUE) ?
         D->NBodyInterAll_CanonicalFactors[off1 + n0 - 1 - k] :
         D->NBodyInterAll_CanonicalFactors[off1 + k];
-      if (D->iCalcModel == HubbardGC) {
+      if (nbody_is_hubbard_model(D) == TRUE) {
         if (f0[0] != f1[2] || f0[1] != f1[3] || f0[2] != f1[0] || f0[3] != f1[1]) {
           fprintf(stdoutMPI, "Error: Off-diagonal NBodyInterAll Hermite pair has inconsistent factors.\n");
           return -1;
@@ -677,7 +711,7 @@ int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X)
   unsigned int i;
   if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
   if (nbody_is_supported_spin_model(&X->Def) == FALSE) return -1;
-  if (X->Def.iCalcModel == HubbardGC) return -1;
+  if (nbody_is_hubbard_model(&X->Def) == TRUE) return -1;
 
   for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
     const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
@@ -732,6 +766,33 @@ int SetDiagonalNBodyInterAllHubbardGC(struct BindStruct *X)
       int ret = apply_nbody_interall_hubbardgc_full(
         X, term, j - 1, myrank, &local_out, &rank_out, &sign);
       if (ret == 1 && local_out == j - 1 && rank_out == myrank) {
+        list_Diagonal[j] += coeff * sign;
+      }
+    }
+  }
+  return 0;
+}
+
+int SetDiagonalNBodyInterAllHubbard(struct BindStruct *X)
+{
+  unsigned int i;
+  if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
+  if (X->Def.iCalcModel != Hubbard) return -1;
+
+  for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
+    const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
+    const double coeff = creal(X->Def.ParaNBodyInterAll[term]);
+    const unsigned long int i_max = X->Check.idim_max;
+    unsigned long int j;
+
+#pragma omp parallel for default(none) shared(list_Diagonal, list_1, X) firstprivate(i_max, term, coeff, myrank) private(j)
+    for (j = 1; j <= i_max; j++) {
+      unsigned long int local_out = 0;
+      int rank_out = 0;
+      int sign = 1;
+      int ret = apply_nbody_interall_hubbardgc_full(
+        X, term, list_1[j], myrank, &local_out, &rank_out, &sign);
+      if (ret == 1 && local_out == list_1[j] && rank_out == myrank) {
         list_Diagonal[j] += coeff * sign;
       }
     }
@@ -1094,6 +1155,44 @@ static double complex apply_nbody_hubbardgc_term_to_rank(
   return dam_pr;
 }
 
+static double complex apply_nbody_hubbard_term_to_rank(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  const unsigned long int *src_list_1,
+  const double complex *src_v1,
+  double complex *cur_v1,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+  const int do_update = (X->Large.mode == M_MLTPLY || X->Large.mode == M_CALCSPEC);
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, tmp_v0, src_list_1, src_v1, cur_v1, list_2_1, list_2_2) \
+  firstprivate(src_i_max, term, rank_in, do_update, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    unsigned long int j_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbody_interall_hubbardgc_full(
+      X, term, src_list_1[j], rank_in, &local_out, &rank_out, &sign);
+    int in_sector = FALSE;
+    if (ret == 1 && rank_out == myrank) {
+      in_sector = GetOffComp(list_2_1, list_2_2, local_out,
+                             X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+    }
+    if (in_sector == TRUE) {
+      const double complex dmv = X->Def.ParaNBodyInterAll[term] * sign * src_v1[j];
+      if (do_update) tmp_v0[j_out] += dmv;
+      dam_pr += conj(cur_v1[j_out]) * dmv;
+    }
+  }
+  return dam_pr;
+}
+
 static double complex multiply_nbody_hubbardgc_term(
   struct BindStruct *X,
   unsigned int term,
@@ -1135,6 +1234,51 @@ static double complex multiply_nbody_hubbardgc_term(
   return dam_pr;
 }
 
+static double complex multiply_nbody_hubbard_term(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbody_interall_hubbardgc_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return 0.0;
+  }
+  if (active == FALSE) return 0.0;
+  if (origin == myrank) {
+    return apply_nbody_hubbard_term_to_rank(
+      X, term, tmp_v0, list_1, tmp_v1, tmp_v1, X->Check.idim_max, myrank);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(list_1, X->Check.idim_max + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        list_1buf, idim_max_buf + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(tmp_v1, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf,  idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = apply_nbody_hubbard_term_to_rank(
+      X, term, tmp_v0, list_1buf, v1buf, tmp_v1, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyInterAll reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return dam_pr;
+}
+
 int MultiplyNBodyInterAllHubbardGC(
   struct BindStruct *X,
   double complex *tmp_v0,
@@ -1151,6 +1295,22 @@ int MultiplyNBodyInterAllHubbardGC(
   return 0;
 }
 
+int MultiplyNBodyInterAllHubbard(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  unsigned int p;
+  if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
+  if (X->Def.iCalcModel != Hubbard) return -1;
+
+  for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
+    const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
+    X->Large.prdct += multiply_nbody_hubbard_term(X, term, tmp_v0, tmp_v1);
+  }
+  return 0;
+}
+
 int MultiplyNBodyInterAllSpinGC(
   struct BindStruct *X,
   double complex *tmp_v0,
@@ -1159,6 +1319,7 @@ int MultiplyNBodyInterAllSpinGC(
   unsigned int p;
   if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
   if (nbody_is_supported_spin_model(&X->Def) == FALSE) return -1;
+  if (nbody_is_hubbard_model(&X->Def) == TRUE) return -1;
 
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p += 2) {
     if (X->Def.iCalcModel == Spin) {
@@ -1174,6 +1335,39 @@ int MultiplyNBodyInterAllSpinGC(
     }
     else {
       X->Large.prdct += multiply_nbody_pair(X, p, tmp_v0, tmp_v1);
+    }
+  }
+  return 0;
+}
+
+int AddNBodyInterAllToHamHubbard(struct BindStruct *X)
+{
+  unsigned int p;
+  unsigned long int j;
+  if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
+  if (X->Def.iCalcModel != Hubbard) return -1;
+
+  for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
+    const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
+    for (j = 1; j <= X->Check.idim_max; j++) {
+      unsigned long int local_out = 0;
+      unsigned long int j_out = 0;
+      int rank_out = 0;
+      int sign = 1;
+      int ret = apply_nbody_interall_hubbardgc_full(
+        X, term, list_1[j], myrank, &local_out, &rank_out, &sign);
+      if (ret == 1) {
+        int in_sector;
+        if (rank_out != myrank) {
+          fprintf(stdoutMPI, "Error: FullDiag NBodyInterAll cannot handle inter-process output.\n");
+          return -1;
+        }
+        in_sector = GetOffComp(list_2_1, list_2_2, local_out,
+                               X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+        if (in_sector == TRUE) {
+          Ham[j_out][j] += X->Def.ParaNBodyInterAll[term] * sign;
+        }
+      }
     }
   }
   return 0;
@@ -1212,6 +1406,7 @@ int AddNBodyInterAllToHamSpinGC(struct BindStruct *X)
   unsigned long int j;
   if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
   if (nbody_is_supported_spin_model(&X->Def) == FALSE) return -1;
+  if (nbody_is_hubbard_model(&X->Def) == TRUE) return -1;
 
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
     const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];

--- a/src/readdef.c
+++ b/src/readdef.c
@@ -1744,6 +1744,7 @@ int ReadDefFileIdxPara(
       if (ValidateNBodyInterAllScope(X) != 0 ||
           NormalizeNBodyInterAllTerms(X) != 0 ||
           CheckNBodyInterAllSpinConservation(X) != 0 ||
+          CheckNBodyInterAllHubbardConservation(X) != 0 ||
           ClassifyNBodyInterAllTerms(X) != 0 ||
           CheckNBodyInterAllHermitePairs(X) != 0) {
         fclose(fp);
@@ -1796,7 +1797,8 @@ int ReadDefFileIdxPara(
 
       if (ValidateNBodyGScope(X) != 0 ||
           NormalizeNBodyGTerms(X) != 0 ||
-          CheckNBodyGSpinConservation(X) != 0) {
+          CheckNBodyGSpinConservation(X) != 0 ||
+          CheckNBodyGHubbardConservation(X) != 0) {
         fclose(fp);
         return ReadDefFileError(defname);
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,8 @@ add_hphi_test(lanczos_genspin_ladder)
 add_hphi_test(lanczos_hubbardgc_tri)
 add_hphi_test(lanczos_hubbardgc_nbody_interall)
 add_hphi_test(lanczos_hubbardgc_nbodyg)
+add_hphi_test(lanczos_hubbard_nbody_interall)
+add_hphi_test(lanczos_hubbard_nbodyg)
 add_hphi_test(lanczos_kondogc_chain)
 add_hphi_test(lanczos_spingc_honey)
 add_hphi_test(lanczos_spingc_hcor)
@@ -80,6 +82,7 @@ add_hphi_test(lanczos_tjgc_exchange)
 add_hphi_test(nbody_interall_validation)
 add_hphi_test(nbodyg_validation)
 add_hphi_test(nbody_hubbardgc_validation)
+add_hphi_test(nbody_hubbard_validation)
 add_hphi_test_with_srcdir(lanczos_spinless)
 add_hphi_test_with_srcdir(lanczos_spinless_GC)
 add_hphi_test_with_srcdir(lanczos_spinless_calchs0)
@@ -94,6 +97,7 @@ add_hphi_test(lanczos_genspin_ladder_restart)
 set_tests_properties(
     lanczos_hubbard_square lanczos_hubbardgc_tri
     lanczos_hubbardgc_nbody_interall lanczos_hubbardgc_nbodyg
+    lanczos_hubbard_nbody_interall lanczos_hubbard_nbodyg
     lanczos_hubbard_square_restart
     lanczos_hubbard_square_calchs2 lanczos_hubbard_square_ncond_calchs2
     lanczos_hubbard_chain_polarized_calchs2
@@ -129,7 +133,7 @@ set_tests_properties(
     nbody_spingc_spinone_validation
     PROPERTIES LABELS "spinone;genspin;validation;nbody")
 set_tests_properties(
-    nbody_hubbardgc_validation
+    nbody_hubbardgc_validation nbody_hubbard_validation
     PROPERTIES LABELS "hubbard;validation;nbody")
 set_tests_properties(
     lanczos_spingc_spinone_nbody_interall
@@ -206,6 +210,7 @@ add_hphi_test(fulldiag_spin_tri)
 add_hphi_test(fulldiag_genspin_ladder)
 add_hphi_test(fulldiag_hubbardgc_tri)
 add_hphi_test(fulldiag_hubbardgc_nbody_interall)
+add_hphi_test(fulldiag_hubbard_nbody_interall)
 add_hphi_test(fulldiag_tj_calchs1)
 add_hphi_test(fulldiag_kondogc_chain)
 add_hphi_test(fulldiag_spingc_tri)
@@ -216,6 +221,7 @@ add_hphi_test(fulldiag_genspingc_ladder)
 set_tests_properties(
     fulldiag_hubbard_chain fulldiag_hubbardgc_tri fulldiag_Hamiltonian_IO
     fulldiag_hubbardgc_nbody_interall
+    fulldiag_hubbard_nbody_interall
     PROPERTIES LABELS "fulldiag;hubbard")
 set_tests_properties(
     fulldiag_kondo_chain fulldiag_kondogc_chain
@@ -384,6 +390,8 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_nbodyg_spingc exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_hubbardgc exact:4)
     add_hphi_mpi_test(mpi_nbodyg_hubbardgc exact:4)
+    add_hphi_mpi_test(mpi_nbody_interall_hubbard exact:4)
+    add_hphi_mpi_test(mpi_nbodyg_hubbard exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spin exact:4)
     add_hphi_mpi_test(mpi_nbodyg_spin exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone exact:3)
@@ -407,6 +415,7 @@ if(MPI_FOUND)
         mpi_consistency_hubbard mpi_consistency_hubbardgc mpi_consistency_te_hubbard
         mpi_consistency_te_hubbardgc_twobody mpi_consistency_te_hubbard_twobody
         mpi_nbody_interall_hubbardgc mpi_nbodyg_hubbardgc
+        mpi_nbody_interall_hubbard mpi_nbodyg_hubbard
         PROPERTIES LABELS "mpi;consistency;hubbard")
     set_tests_properties(
         mpi_consistency_spin mpi_consistency_spingc mpi_consistency_te_spin

--- a/test/fulldiag_hubbard_nbody_interall.sh
+++ b/test/fulldiag_hubbard_nbody_interall.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -e
+
+testname="fulldiag_hubbard_nbody_interall"
+hphi="../../src/HPhi"
+tol="0.000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 0.0
+nelec = 4
+2Sz = 0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1250000000000000 0.0000000000000000
+2 3 0 0 0 1 1 1 1 0.2500000000000000 0.0000000000000000
+2 1 1 1 1 0 0 3 0 0.2500000000000000 0.0000000000000000
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+e_lanczos=$(awk '/^Energy/{print $2; exit}' output/zvo_energy.dat)
+
+sed -e 's/^CalcType.*/CalcType   2/' -e 's/^OutputHam.*/OutputHam   0/' calcmod.def > calcmod.fulldiag
+mv calcmod.def calcmod.lanczos
+mv calcmod.fulldiag calcmod.def
+rm -rf output
+run_hphi log_fulldiag.txt "${hphi}" -e namelist.def
+if [ -f output/zvo_phys.dat ]; then
+  e_fulldiag=$(awk 'NR==2{print $1; exit}' output/zvo_phys.dat)
+else
+  e_fulldiag=$(awk 'NR==1{print $2; exit}' output/Eigenvalue.dat)
+fi
+
+diff=$(awk -v a="${e_lanczos}" -v b="${e_fulldiag}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.12g", d}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "Hubbard NBodyInterAll Lanczos/FullDiag energy mismatch: ${e_lanczos} vs ${e_fulldiag}"
+  exit 1
+}
+
+sed -e 's/^OutputHam.*/OutputHam   1/' calcmod.def > calcmod.outputham
+mv calcmod.outputham calcmod.def
+rm -rf output
+run_hphi log_outputham.txt "${hphi}" -e namelist.def
+
+test -f output/zvo_Ham.dat || { echo "zvo_Ham.dat was not generated"; exit 1; }
+awk 'NR>2 && $1 != $2 {found=1} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "Hubbard NBodyInterAll produced no off-diagonal Hamiltonian entry"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+awk 'NR>2 && $1 == $2 {
+  d = $3 - 0.125000;
+  if (d < 0) d = -d;
+  if (d < 0.000001) found=1;
+} END{exit found ? 0 : 1}' output/zvo_Ham.dat || {
+  echo "Hubbard diagonal NBodyInterAll term was not folded into the diagonal"
+  cat output/zvo_Ham.dat
+  exit 1
+}
+
+echo "Hubbard NBodyInterAll Lanczos, FullDiag, and OutputHam checks passed."

--- a/test/lanczos_hubbard_nbody_interall.sh
+++ b/test/lanczos_hubbard_nbody_interall.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_hubbard_nbody_interall"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+make_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 0.0
+nelec = 4
+2Sz = 0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  cd ..
+}
+
+rm -rf nbody legacy
+make_base nbody
+make_base legacy
+
+cd nbody
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 3 0 0 0 1 1 1 1 0.3700000000000000 0.1100000000000000
+2 1 1 1 1 0 0 3 0 0.3700000000000000 -0.1100000000000000
+EOF
+run_hphi log_nbody.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_nbody.dat
+cd ..
+
+cd legacy
+printf '    InterAll  interall.def\n' >> namelist.def
+cat > interall.def <<EOF
+========================
+NInterAll 2
+========================
+========zInterAll=======
+========================
+3 0 0 0 1 1 1 1 0.3700000000000000 0.1100000000000000
+1 1 1 1 0 0 3 0 0.3700000000000000 -0.1100000000000000
+EOF
+run_hphi log_legacy.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_legacy.dat
+cd ..
+
+diff=$(paste energy_nbody.dat energy_legacy.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "Hubbard NBodyInterAll N=2 energy differs from legacy InterAll: max diff ${diff}"
+  paste energy_nbody.dat energy_legacy.dat
+  exit 1
+}
+
+echo "Hubbard NBodyInterAll N=2 matches legacy InterAll in Lanczos."

--- a/test/lanczos_hubbard_nbodyg.sh
+++ b/test/lanczos_hubbard_nbodyg.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_hubbard_nbodyg"
+hphi="../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > stan.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 2.0
+nelec = 4
+2Sz = 0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+
+cat > greenone.def <<EOF
+========================
+NCisAjs 2
+========================
+========GreenOne========
+========================
+0 0 0 0
+1 0 0 0
+EOF
+
+cat > greentwo.def <<EOF
+========================
+NCisAjsCktAlt 1
+========================
+========GreenTwo========
+========================
+0 0 1 0 1 1 0 1
+EOF
+
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 3
+========================
+========NBodyG==========
+========================
+1 0 0 0 0
+1 1 0 0 0
+2 0 0 1 0 1 1 0 1
+EOF
+
+run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated"; exit 1; }
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 0 && $2 == 0 && $3 == 0 && $4 == 0) {
+      ref_re = $5;
+      ref_im = $6;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 1 && $2 == 0 && $3 == 0 && $4 == 0 && $5 == 0 {
+    dr = $6 - ref_re;
+    di = $7 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajs.dat output/zvo_NBodyG.dat || {
+  echo "Hubbard NBodyG number operator does not match cisajs"
+  cat output/zvo_cisajs.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 1 && $2 == 0 && $3 == 0 && $4 == 0) {
+      ref_re = $5;
+      ref_im = $6;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 1 && $2 == 1 && $3 == 0 && $4 == 0 && $5 == 0 {
+    dr = $6 - ref_re;
+    di = $7 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajs.dat output/zvo_NBodyG.dat || {
+  echo "Hubbard NBodyG hopping operator does not match cisajs"
+  cat output/zvo_cisajs.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 0 && $2 == 0 && $3 == 1 && $4 == 0 &&
+        $5 == 1 && $6 == 1 && $7 == 0 && $8 == 1) {
+      ref_re = $9;
+      ref_im = $10;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 2 && $2 == 0 && $3 == 0 && $4 == 1 && $5 == 0 &&
+      $6 == 1 && $7 == 1 && $8 == 0 && $9 == 1 {
+    dr = $10 - ref_re;
+    di = $11 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajscktalt.dat output/zvo_NBodyG.dat || {
+  echo "Hubbard NBodyG two-body value does not match cisajscktalt"
+  cat output/zvo_cisajscktalt.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+echo "Hubbard NBodyG number, hopping, and two-body checks passed."

--- a/test/mpi_nbody_interall_hubbard.sh
+++ b/test/mpi_nbody_interall_hubbard.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_hubbard"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 0.0
+nelec = 4
+2Sz = 0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+1 3 0 3 0 0.1250000000000000 0.0000000000000000
+2 3 0 0 0 1 1 1 1 0.3700000000000000 0.1100000000000000
+2 1 1 1 1 0 0 3 0 0.3700000000000000 -0.1100000000000000
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "Serial/MPI Hubbard NBodyInterAll energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
+  exit 1
+}
+
+echo "Hubbard NBodyInterAll MPI np=4 matches serial energy."

--- a/test/mpi_nbodyg_hubbard.sh
+++ b/test/mpi_nbodyg_hubbard.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbodyg_hubbard"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+cat > stan.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 2.0
+nelec = 4
+2Sz = 0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 3
+========================
+========NBodyG==========
+========================
+1 3 0 3 0
+1 3 0 0 0
+2 3 0 0 0 1 1 1 1
+EOF
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_NBodyG.dat ../nbodyg_mpi.dat
+cd ..
+
+awk -v t="${tol}" '
+  function prefix(line, out) {
+    out = line;
+    sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+    return out;
+  }
+  NR == FNR {
+    s_prefix[NR] = prefix($0);
+    s_re[NR] = $(NF - 1);
+    s_im[NR] = $NF;
+    n = NR;
+    next;
+  }
+  {
+    m = FNR;
+    if (prefix($0) != s_prefix[m]) bad = 1;
+    dr = $(NF - 1) - s_re[m];
+    di = $NF - s_im[m];
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    if (dr >= t || di >= t) bad = 1;
+  }
+  END { exit (n == m && bad != 1) ? 0 : 1; }
+' nbodyg_serial.dat nbodyg_mpi.dat || {
+  echo "Serial/MPI Hubbard NBodyG output mismatch"
+  paste nbodyg_serial.dat nbodyg_mpi.dat
+  exit 1
+}
+
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
+  exit 1
+}
+
+awk -v t="${tol}" '
+  $1 == 1 && $2 == 3 && $3 == 0 && $4 == 3 && $5 == 0 {
+    re = $6; if (re < 0) re = -re;
+    found = (re > t);
+  }
+  END { exit found ? 0 : 1; }
+' nbodyg_mpi.dat || {
+  echo "Inter-process Hubbard diagonal NBodyG operator was zero or missing"
+  cat nbodyg_mpi.dat
+  exit 1
+}
+
+echo "Hubbard NBodyG MPI np=4 output matches serial output."

--- a/test/nbody_hubbard_validation.sh
+++ b/test/nbody_hubbard_validation.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+set -e
+
+testname="nbody_hubbard_validation"
+hphi="../../../src/HPhi"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+expect_fail() {
+  dir="$1"
+  pattern="$2"
+  cd "${dir}"
+  set +e
+  "${hphi}" -e namelist.def > log.txt 2>&1
+  rc=$?
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    echo "Expected ${dir} to fail, but it succeeded"
+    exit 1
+  fi
+  grep -q "${pattern}" log.txt || {
+    echo "Expected pattern '${pattern}' was not found in ${dir}/log.txt"
+    cat log.txt
+    exit 1
+  }
+  cd ..
+}
+
+make_hubbard_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "Hubbard"
+method = "FullDiag"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 0.0
+nelec = 4
+2Sz = 0
+Lanczos_max = 50
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cd ..
+}
+
+rm -rf accept bad_interall_particle bad_nbodyg_particle bad_spin_interall bad_pair diag_im
+
+make_hubbard_base accept
+cat > accept/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > accept/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 1 0 0 0
+EOF
+
+make_hubbard_base bad_interall_particle
+cat > bad_interall_particle/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 1 0 0 1 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_interall_particle/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_hubbard_base bad_nbodyg_particle
+cat > bad_nbodyg_particle/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > bad_nbodyg_particle/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 1 0 0 1
+EOF
+
+make_hubbard_base bad_spin_interall
+cat > bad_spin_interall/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 2 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_spin_interall/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_hubbard_base bad_pair
+cat > bad_pair/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 1 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_pair/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_hubbard_base diag_im
+cat > diag_im/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.1000000000000000
+EOF
+cat > diag_im/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+cd accept
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+
+expect_fail bad_interall_particle "does not conserve particle numbers"
+expect_fail bad_nbodyg_particle "does not conserve particle numbers"
+expect_fail bad_spin_interall "Spin index of NBodyInterAll is incorrect"
+expect_fail bad_pair "Off-diagonal NBodyInterAll terms must appear as adjacent Hermite pairs"
+expect_fail diag_im "Diagonal NBodyInterAll term has a finite imaginary part"
+
+echo "canonical Hubbard NBody validation rejects malformed and nonconserving inputs."


### PR DESCRIPTION
## Summary

This PR adds NBodyInterAll / NBodyG support for the canonical Hubbard model, stacked on top of the HubbardGC NBody implementation.

Main changes:

- Enable `Hubbard` as a supported model for NBodyInterAll and NBodyG.
- Reuse the HubbardGC raw fermion apply routines, then map the result back into the canonical Hubbard sector via `GetOffComp`.
- Add canonical Hubbard particle-number conservation validation for NBodyInterAll and NBodyG.
- Add canonical Hubbard dispatch hooks in:
  - `readdef.c`
  - `diagonalcalc.c`
  - `mltplyHubbard.c`
  - `makeHam.c`
  - `nbody_correlation.c`
- Guard Hubbard-only paths with `iCalcModel == Hubbard` so shared Hubbard/tJ/Kondo code paths do not accidentally pick up NBody canonical Hubbard logic.
- Treat only products of number operators as standalone diagonal/self-Hermitian terms; offdiagonal fermion terms still require explicit Hermitian-conjugate pairs.
- Add serial, FullDiag, validation, and MPI regression tests for canonical Hubbard NBodyInterAll / NBodyG.

## Tests

Local verification on `feature/nbody-canonical-hubbard`:

- `git diff --check`
- `cmake --build build-pr242-review -j2`
- New serial / validation tests:
  - `lanczos_hubbard_nbody_interall`
  - `lanczos_hubbard_nbodyg`
  - `fulldiag_hubbard_nbody_interall`
  - `nbody_hubbard_validation`
  - Result: 4/4 pass
- New MPI tests with `MPIRUN="mpirun --oversubscribe -np 4"`:
  - `mpi_nbody_interall_hubbard`
  - `mpi_nbodyg_hubbard`
  - Result: 2/2 pass
- Existing Hubbard/HubbardGC NBody regression:
  - `ctest --test-dir build-pr242-review -R 'hubbardgc_nbody|hubbard_nbody|nbody_hubbard' --output-on-failure`
  - Result: 8/8 pass
- NBody regression:
  - `ctest --test-dir build-pr242-review -R nbody --output-on-failure`
  - Result: non-MPI 21 pass + MPI-only 16 skip, failure 0
- MPI NBody exact:4 regression:
  - `MPIRUN="mpirun --oversubscribe -np 4" ctest --test-dir build-pr242-review -R mpi_nbody --output-on-failure`
  - Result: exact:4 8 pass + exact:3/9 8 skip, failure 0

Notes:

- The skipped MPI tests are spin-one exact:3 / exact:9 cases that are not applicable to the `np=4` run.
- This branch has not modified the local manual exact-check helper files; they are not part of this PR.
