### PR TITLE
Support spinless fermion NBody operators

### DIFF
--- a/src/diagonalcalc.c
+++ b/src/diagonalcalc.c
@@ -208,6 +208,16 @@ int diagonalcalc
         return -1;
       }
     }
+    else if (X->Def.iCalcModel == SpinlessFermionGC) {
+      if (SetDiagonalNBodyInterAllSpinlessGC(X) != 0) {
+        return -1;
+      }
+    }
+    else if (X->Def.iCalcModel == SpinlessFermion) {
+      if (SetDiagonalNBodyInterAllSpinless(X) != 0) {
+        return -1;
+      }
+    }
     else if (SetDiagonalNBodyInterAllSpinGC(X) != 0) {
       return -1;
     }

--- a/src/include/nbody_interall.h
+++ b/src/include/nbody_interall.h
@@ -37,6 +37,8 @@ int ApplyNBodyInterAllSpinGC(
 int SetDiagonalNBodyInterAllSpinGC(struct BindStruct *X);
 int SetDiagonalNBodyInterAllHubbardGC(struct BindStruct *X);
 int SetDiagonalNBodyInterAllHubbard(struct BindStruct *X);
+int SetDiagonalNBodyInterAllSpinlessGC(struct BindStruct *X);
+int SetDiagonalNBodyInterAllSpinless(struct BindStruct *X);
 int MultiplyNBodyInterAllSpinGC(
   struct BindStruct *X,
   double complex *tmp_v0,
@@ -48,6 +50,16 @@ int MultiplyNBodyInterAllHubbardGC(
   double complex *tmp_v1
 );
 int MultiplyNBodyInterAllHubbard(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+);
+int MultiplyNBodyInterAllSpinlessGC(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+);
+int MultiplyNBodyInterAllSpinless(
   struct BindStruct *X,
   double complex *tmp_v0,
   double complex *tmp_v1

--- a/src/mltplySpinless.c
+++ b/src/mltplySpinless.c
@@ -24,6 +24,7 @@
 #include "CalcTime.h"
 #include "mltplyCommon.h"
 #include "DefCommon.h"
+#include "nbody_interall.h"
 
 #ifdef MPI
 // Static storage for batched transfers (initialized once per calculation)
@@ -255,6 +256,19 @@ int mltplySpinlessFermion(struct BindStruct *X, double complex *tmp_v0, double c
   }
   StopTimer(610);
   StopTimer(600);
+
+  if (X->Def.NNBodyInterAll_OffDiagonal > 0) {
+    if (isGC) {
+      if (MultiplyNBodyInterAllSpinlessGC(X, tmp_v0, tmp_v1) != 0) {
+        return -1;
+      }
+    }
+    else {
+      if (MultiplyNBodyInterAllSpinless(X, tmp_v0, tmp_v1) != 0) {
+        return -1;
+      }
+    }
+  }
 
   return 0;
 }

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -99,18 +99,27 @@ int ParseNBodyGLine(
   return 0;
 }
 
-static int nbodyg_is_supported_spin_model(const struct DefineList *D)
-{
-  if (D->iCalcModel == SpinGC) return TRUE;
-  if (D->iCalcModel == Spin) return TRUE;
-  if (D->iCalcModel == HubbardGC) return TRUE;
-  if (D->iCalcModel == Hubbard) return TRUE;
-  return FALSE;
-}
-
 static int nbodyg_is_hubbard_model(const struct DefineList *D)
 {
   return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
+}
+
+static int nbodyg_is_spinless_model(const struct DefineList *D)
+{
+  return D->iCalcModel == SpinlessFermion || D->iCalcModel == SpinlessFermionGC;
+}
+
+static int nbodyg_is_raw_fermion_model(const struct DefineList *D)
+{
+  return nbodyg_is_hubbard_model(D) == TRUE || nbodyg_is_spinless_model(D) == TRUE;
+}
+
+static int nbodyg_is_supported_model(const struct DefineList *D)
+{
+  if (D->iCalcModel == SpinGC) return TRUE;
+  if (D->iCalcModel == Spin) return TRUE;
+  if (nbodyg_is_raw_fermion_model(D) == TRUE) return TRUE;
+  return FALSE;
 }
 
 static int nbodyg_is_general_spin(const struct DefineList *D)
@@ -123,8 +132,8 @@ int ValidateNBodyGScope(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
-  if (nbodyg_is_supported_spin_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, and Hubbard.\n");
+  if (nbodyg_is_supported_model(D) == FALSE) {
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, Hubbard, SpinlessFermionGC, and SpinlessFermion.\n");
     return -1;
   }
   for (t = 0; t < D->NNBodyG; t++) {
@@ -135,11 +144,17 @@ int ValidateNBodyGScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: Site index of NBodyG is incorrect.\n");
         return -1;
       }
-      if (nbodyg_is_hubbard_model(D) == FALSE && f[0] != f[2]) {
+      if (nbodyg_is_raw_fermion_model(D) == FALSE && f[0] != f[2]) {
         fprintf(stdoutMPI, "Error: NBodyG currently requires site_out == site_in for every factor.\n");
         return -1;
       }
-      {
+      if (nbodyg_is_spinless_model(D) == TRUE) {
+        if (f[1] != 0 || f[3] != 0) {
+          fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
+          return -1;
+        }
+      }
+      else {
         const int max_spin = (nbodyg_is_hubbard_model(D) == TRUE) ? 1 :
           (nbodyg_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
@@ -188,7 +203,7 @@ int NormalizeNBodyGTerms(struct DefineList *D)
   for (t = 0; t < D->NNBodyG; t++) {
     const unsigned int nraw = D->NBodyG_N[t];
     const unsigned int off = D->NBodyG_Offset[t];
-    if (nbodyg_is_hubbard_model(D) == TRUE) {
+    if (nbodyg_is_raw_fermion_model(D) == TRUE) {
       D->NBodyG_IsZero[t] = FALSE;
       D->NBodyG_CanonicalOffset[t] = total;
       D->NBodyG_CanonicalN[t] = nraw;
@@ -581,6 +596,148 @@ static int nbodyg_hubbardgc_partner_rank(
   return 0;
 }
 
+static unsigned long int get_spinless_local_block(
+  const struct DefineList *D
+) {
+  if (D->Nsite == 0) return 1;
+  return 1UL << D->Nsite;
+}
+
+static int apply_nbodyg_spinless_full(
+  const struct BindStruct *X,
+  unsigned int term,
+  unsigned long int local_in,
+  int rank_in,
+  unsigned long int *local_out,
+  int *rank_out,
+  int *sign
+) {
+  const struct DefineList *D = &X->Def;
+  unsigned int k;
+  unsigned long int state;
+  const unsigned long int block = get_spinless_local_block(D);
+  const unsigned int n = D->NBodyG_CanonicalN[term];
+  const unsigned int off = D->NBodyG_CanonicalOffset[term];
+
+  state = local_in + block * (unsigned long int)rank_in;
+  *sign = 1;
+
+  for (k = n; k > 0; k--) {
+    const int *f = D->NBodyG_CanonicalFactors[off + k - 1];
+    const unsigned int site_out = (unsigned int)f[0];
+    const unsigned int site_in = (unsigned int)f[2];
+    const unsigned long int mask_in = 1UL << site_in;
+    const unsigned long int mask_out = 1UL << site_out;
+
+    if (apply_hubbardgc_annihilate_mask(mask_in, &state, sign) == 0) return 0;
+    if (apply_hubbardgc_create_mask(mask_out, &state, sign) == 0) return 0;
+  }
+
+  *local_out = state % block;
+  *rank_out = (int)(state / block);
+  return 1;
+}
+
+static int apply_spinless_rank_annihilate(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[site];
+  if ((*rank_state & mask) == 0) return 0;
+  *rank_state &= ~mask;
+  return 1;
+}
+
+static int apply_spinless_rank_create(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[site];
+  if ((*rank_state & mask) != 0) return 0;
+  *rank_state |= mask;
+  return 1;
+}
+
+static int apply_spinless_rank_factor(
+  const struct DefineList *D,
+  const int *f,
+  int dagger,
+  unsigned long int *rank_state
+) {
+  const unsigned int site_out = (unsigned int)f[0];
+  const unsigned int site_in = (unsigned int)f[2];
+
+  if (dagger == FALSE) {
+    if (apply_spinless_rank_annihilate(D, site_in, rank_state) == 0) return 0;
+    if (apply_spinless_rank_create(D, site_out, rank_state) == 0) return 0;
+  }
+  else {
+    if (apply_spinless_rank_annihilate(D, site_out, rank_state) == 0) return 0;
+    if (apply_spinless_rank_create(D, site_in, rank_state) == 0) return 0;
+  }
+  return 1;
+}
+
+static int apply_spinless_rank_part(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int dagger,
+  int *partner_rank
+) {
+  const struct DefineList *D = &X->Def;
+  const unsigned int n = D->NBodyG_CanonicalN[term];
+  const unsigned int off = D->NBodyG_CanonicalOffset[term];
+  unsigned int k;
+  unsigned long int rank_state = (unsigned long int)current_rank;
+
+  if (dagger == FALSE) {
+    for (k = n; k > 0; k--) {
+      if (apply_spinless_rank_factor(D, D->NBodyG_CanonicalFactors[off + k - 1],
+                                     FALSE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+  else {
+    for (k = 0; k < n; k++) {
+      if (apply_spinless_rank_factor(D, D->NBodyG_CanonicalFactors[off + k],
+                                     TRUE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+
+  *partner_rank = (int)rank_state;
+  return 1;
+}
+
+static int nbodyg_spinless_partner_rank(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int *partner_rank,
+  int *active
+) {
+  if (apply_spinless_rank_part(X, term, current_rank, FALSE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  if (apply_spinless_rank_part(X, term, current_rank, TRUE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  *active = FALSE;
+  *partner_rank = current_rank;
+  return 0;
+}
+
 static int convert_nbodyg_general_spin_to_list1(
   const struct BindStruct *X,
   unsigned long int local_out,
@@ -811,6 +968,65 @@ static double complex expec_nbodyg_term_to_rank_hubbard(
   return dam_pr;
 }
 
+static double complex expec_nbodyg_term_to_rank_spinlessgc(
+  struct BindStruct *X,
+  unsigned int term,
+  const double complex *src_vec,
+  const double complex *bra_vec,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, src_vec, bra_vec) firstprivate(src_i_max, term, rank_in, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbodyg_spinless_full(X, term, j - 1, rank_in, &local_out, &rank_out, &sign);
+    if (ret == 1 && rank_out == myrank) {
+      dam_pr += conj(bra_vec[local_out + 1]) * sign * src_vec[j];
+    }
+  }
+  return dam_pr;
+}
+
+static double complex expec_nbodyg_term_to_rank_spinless(
+  struct BindStruct *X,
+  unsigned int term,
+  const unsigned long int *src_list_1,
+  const double complex *src_vec,
+  const double complex *bra_vec,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, src_list_1, src_vec, bra_vec, list_2_1, list_2_2) \
+  firstprivate(src_i_max, term, rank_in, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    unsigned long int j_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbodyg_spinless_full(
+      X, term, src_list_1[j], rank_in, &local_out, &rank_out, &sign);
+    int in_sector = FALSE;
+    if (ret == 1 && rank_out == myrank) {
+      in_sector = GetOffComp(list_2_1, list_2_2, local_out,
+                             X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+    }
+    if (in_sector == TRUE) {
+      dam_pr += conj(bra_vec[j_out]) * sign * src_vec[j];
+    }
+  }
+  return dam_pr;
+}
+
 static double complex calc_nbodyg_term_hubbardgc(struct BindStruct *X, unsigned int term, double complex *vec)
 {
   int origin = myrank;
@@ -886,6 +1102,90 @@ static double complex calc_nbodyg_term_hubbard(struct BindStruct *X, unsigned in
                         MPI_COMM_WORLD, &statusMPI);
     if (ierr != 0) exitMPI(-1);
     dam_pr = expec_nbodyg_term_to_rank_hubbard(
+      X, term, list_1buf, v1buf, vec, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyG reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return SumMPI_dc(dam_pr);
+}
+
+static double complex calc_nbodyg_term_spinlessgc(struct BindStruct *X, unsigned int term, double complex *vec)
+{
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbodyg_spinless_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return SumMPI_dc(0.0);
+  }
+  if (active == FALSE) {
+    return SumMPI_dc(0.0);
+  }
+  if (origin == myrank) {
+    dam_pr = expec_nbodyg_term_to_rank_spinlessgc(
+      X, term, vec, vec, X->Check.idim_max, myrank);
+    return SumMPI_dc(dam_pr);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(vec, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf, idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = expec_nbodyg_term_to_rank_spinlessgc(
+      X, term, v1buf, vec, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyG reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return SumMPI_dc(dam_pr);
+}
+
+static double complex calc_nbodyg_term_spinless(struct BindStruct *X, unsigned int term, double complex *vec)
+{
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbodyg_spinless_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return SumMPI_dc(0.0);
+  }
+  if (active == FALSE) {
+    return SumMPI_dc(0.0);
+  }
+  if (origin == myrank) {
+    dam_pr = expec_nbodyg_term_to_rank_spinless(
+      X, term, list_1, vec, vec, X->Check.idim_max, myrank);
+    return SumMPI_dc(dam_pr);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(list_1, X->Check.idim_max + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        list_1buf, idim_max_buf + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(vec, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf, idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = expec_nbodyg_term_to_rank_spinless(
       X, term, list_1buf, v1buf, vec, idim_max_buf, origin);
   }
 #else
@@ -1082,8 +1382,8 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
   unsigned int t;
 
   if (X->Def.NNBodyG < 1) return 0;
-  if (nbodyg_is_supported_spin_model(&X->Def) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, and Hubbard.\n");
+  if (nbodyg_is_supported_model(&X->Def) == FALSE) {
+    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, Hubbard, SpinlessFermionGC, and SpinlessFermion.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;
@@ -1095,6 +1395,8 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
       if (X->Def.iCalcModel == Spin) value = calc_nbodyg_term_spin(X, t, vec);
       else if (X->Def.iCalcModel == Hubbard) value = calc_nbodyg_term_hubbard(X, t, vec);
       else if (X->Def.iCalcModel == HubbardGC) value = calc_nbodyg_term_hubbardgc(X, t, vec);
+      else if (X->Def.iCalcModel == SpinlessFermion) value = calc_nbodyg_term_spinless(X, t, vec);
+      else if (X->Def.iCalcModel == SpinlessFermionGC) value = calc_nbodyg_term_spinlessgc(X, t, vec);
       else if (nbodyg_is_general_spin(&X->Def) == TRUE) {
         value = calc_nbodyg_term_general_spin_gc(X, t, vec);
       }

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -136,6 +136,24 @@ static int nbody_is_hubbard_model(const struct DefineList *D)
   return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
 }
 
+static int nbody_is_spinless_model(const struct DefineList *D)
+{
+  return D->iCalcModel == SpinlessFermion || D->iCalcModel == SpinlessFermionGC;
+}
+
+static int nbody_is_raw_fermion_model(const struct DefineList *D)
+{
+  return nbody_is_hubbard_model(D) == TRUE || nbody_is_spinless_model(D) == TRUE;
+}
+
+static int nbody_is_supported_model(const struct DefineList *D)
+{
+  if (D->iCalcModel == SpinGC) return TRUE;
+  if (D->iCalcModel == Spin) return TRUE;
+  if (nbody_is_raw_fermion_model(D) == TRUE) return TRUE;
+  return FALSE;
+}
+
 static int nbody_is_general_spin(const struct DefineList *D)
 {
   return D->iFlgGeneralSpin == TRUE &&
@@ -146,12 +164,16 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
-  if (nbody_is_supported_spin_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC, Spin, HubbardGC, and Hubbard.\n");
+  if (nbody_is_supported_model(D) == FALSE) {
+    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC, Spin, HubbardGC, Hubbard, SpinlessFermionGC, and SpinlessFermion.\n");
     return -1;
   }
   if (D->iCalcType == TimeEvolution) {
     fprintf(stdoutMPI, "Error: NBodyInterAll is not yet supported in TimeEvolution.\n");
+    return -1;
+  }
+  if (nbody_is_spinless_model(D) == TRUE && D->iCalcType == FullDiag) {
+    fprintf(stdoutMPI, "Error: NBodyInterAll is not yet supported in FullDiag for SpinlessFermion / SpinlessFermionGC.\n");
     return -1;
   }
   for (t = 0; t < D->NNBodyInterAll; t++) {
@@ -162,11 +184,17 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: Site index of NBodyInterAll is incorrect.\n");
         return -1;
       }
-      if (nbody_is_hubbard_model(D) == FALSE && f[0] != f[2]) {
+      if (nbody_is_raw_fermion_model(D) == FALSE && f[0] != f[2]) {
         fprintf(stdoutMPI, "Error: NBodyInterAll currently requires site_out == site_in for every factor.\n");
         return -1;
       }
-      {
+      if (nbody_is_spinless_model(D) == TRUE) {
+        if (f[1] != 0 || f[3] != 0) {
+          fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
+          return -1;
+        }
+      }
+      else {
         const int max_spin = (nbody_is_hubbard_model(D) == TRUE) ? 1 :
           (nbody_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
@@ -215,7 +243,7 @@ int NormalizeNBodyInterAllTerms(struct DefineList *D)
   for (t = 0; t < D->NNBodyInterAll; t++) {
     const unsigned int nraw = D->NBodyInterAll_N[t];
     const unsigned int off = D->NBodyInterAll_Offset[t];
-    if (nbody_is_hubbard_model(D) == TRUE) {
+    if (nbody_is_raw_fermion_model(D) == TRUE) {
       D->NBodyInterAll_CanonicalOffset[t] = total;
       D->NBodyInterAll_CanonicalN[t] = nraw;
       for (k = 0; k < nraw; k++) {
@@ -346,7 +374,7 @@ int ClassifyNBodyInterAllTerms(struct DefineList *D)
     int diagonal = TRUE;
     for (k = 0; k < n; k++) {
       const int *f = D->NBodyInterAll_CanonicalFactors[off + k];
-      if (nbody_is_hubbard_model(D) == TRUE) {
+      if (nbody_is_raw_fermion_model(D) == TRUE) {
         if (f[0] != f[2] || f[1] != f[3]) {
           diagonal = FALSE;
           break;
@@ -391,10 +419,10 @@ int CheckNBodyInterAllHermitePairs(const struct DefineList *D)
     }
     for (k = 0; k < n0; k++) {
       const int *f0 = D->NBodyInterAll_CanonicalFactors[off0 + k];
-      const int *f1 = (nbody_is_hubbard_model(D) == TRUE) ?
+      const int *f1 = (nbody_is_raw_fermion_model(D) == TRUE) ?
         D->NBodyInterAll_CanonicalFactors[off1 + n0 - 1 - k] :
         D->NBodyInterAll_CanonicalFactors[off1 + k];
-      if (nbody_is_hubbard_model(D) == TRUE) {
+      if (nbody_is_raw_fermion_model(D) == TRUE) {
         if (f0[0] != f1[2] || f0[1] != f1[3] || f0[2] != f1[0] || f0[3] != f1[1]) {
           fprintf(stdoutMPI, "Error: Off-diagonal NBodyInterAll Hermite pair has inconsistent factors.\n");
           return -1;
@@ -686,6 +714,148 @@ static int nbody_interall_hubbardgc_partner_rank(
   return 0;
 }
 
+static unsigned long int get_spinless_local_block(
+  const struct DefineList *D
+) {
+  if (D->Nsite == 0) return 1;
+  return 1UL << D->Nsite;
+}
+
+static int apply_nbody_interall_spinless_full(
+  const struct BindStruct *X,
+  unsigned int term_index,
+  unsigned long int local_in,
+  int rank_in,
+  unsigned long int *local_out,
+  int *rank_out,
+  int *sign
+) {
+  const struct DefineList *D = &X->Def;
+  unsigned int k;
+  unsigned long int state;
+  const unsigned long int block = get_spinless_local_block(D);
+  const unsigned int n = D->NBodyInterAll_CanonicalN[term_index];
+  const unsigned int off = D->NBodyInterAll_CanonicalOffset[term_index];
+
+  state = local_in + block * (unsigned long int)rank_in;
+  *sign = 1;
+
+  for (k = n; k > 0; k--) {
+    const int *f = D->NBodyInterAll_CanonicalFactors[off + k - 1];
+    const unsigned int site_out = (unsigned int)f[0];
+    const unsigned int site_in = (unsigned int)f[2];
+    const unsigned long int mask_in = 1UL << site_in;
+    const unsigned long int mask_out = 1UL << site_out;
+
+    if (apply_hubbardgc_annihilate_mask(mask_in, &state, sign) == 0) return 0;
+    if (apply_hubbardgc_create_mask(mask_out, &state, sign) == 0) return 0;
+  }
+
+  *local_out = state % block;
+  *rank_out = (int)(state / block);
+  return 1;
+}
+
+static int apply_spinless_rank_annihilate(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[site];
+  if ((*rank_state & mask) == 0) return 0;
+  *rank_state &= ~mask;
+  return 1;
+}
+
+static int apply_spinless_rank_create(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[site];
+  if ((*rank_state & mask) != 0) return 0;
+  *rank_state |= mask;
+  return 1;
+}
+
+static int apply_spinless_rank_factor(
+  const struct DefineList *D,
+  const int *f,
+  int dagger,
+  unsigned long int *rank_state
+) {
+  const unsigned int site_out = (unsigned int)f[0];
+  const unsigned int site_in = (unsigned int)f[2];
+
+  if (dagger == FALSE) {
+    if (apply_spinless_rank_annihilate(D, site_in, rank_state) == 0) return 0;
+    if (apply_spinless_rank_create(D, site_out, rank_state) == 0) return 0;
+  }
+  else {
+    if (apply_spinless_rank_annihilate(D, site_out, rank_state) == 0) return 0;
+    if (apply_spinless_rank_create(D, site_in, rank_state) == 0) return 0;
+  }
+  return 1;
+}
+
+static int apply_spinless_rank_part(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int dagger,
+  int *partner_rank
+) {
+  const struct DefineList *D = &X->Def;
+  const unsigned int n = D->NBodyInterAll_CanonicalN[term];
+  const unsigned int off = D->NBodyInterAll_CanonicalOffset[term];
+  unsigned int k;
+  unsigned long int rank_state = (unsigned long int)current_rank;
+
+  if (dagger == FALSE) {
+    for (k = n; k > 0; k--) {
+      if (apply_spinless_rank_factor(D, D->NBodyInterAll_CanonicalFactors[off + k - 1],
+                                     FALSE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+  else {
+    for (k = 0; k < n; k++) {
+      if (apply_spinless_rank_factor(D, D->NBodyInterAll_CanonicalFactors[off + k],
+                                     TRUE, &rank_state) == 0) {
+        return 0;
+      }
+    }
+  }
+
+  *partner_rank = (int)rank_state;
+  return 1;
+}
+
+static int nbody_interall_spinless_partner_rank(
+  const struct BindStruct *X,
+  unsigned int term,
+  int current_rank,
+  int *partner_rank,
+  int *active
+) {
+  if (apply_spinless_rank_part(X, term, current_rank, FALSE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  if (apply_spinless_rank_part(X, term, current_rank, TRUE, partner_rank) == 1) {
+    *active = TRUE;
+    return 0;
+  }
+  *active = FALSE;
+  *partner_rank = current_rank;
+  return 0;
+}
+
 int ApplyNBodyInterAllSpinGC(
   const struct BindStruct *X,
   unsigned int term_index,
@@ -791,6 +961,60 @@ int SetDiagonalNBodyInterAllHubbard(struct BindStruct *X)
       int rank_out = 0;
       int sign = 1;
       int ret = apply_nbody_interall_hubbardgc_full(
+        X, term, list_1[j], myrank, &local_out, &rank_out, &sign);
+      if (ret == 1 && local_out == list_1[j] && rank_out == myrank) {
+        list_Diagonal[j] += coeff * sign;
+      }
+    }
+  }
+  return 0;
+}
+
+int SetDiagonalNBodyInterAllSpinlessGC(struct BindStruct *X)
+{
+  unsigned int i;
+  if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
+  if (X->Def.iCalcModel != SpinlessFermionGC) return -1;
+
+  for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
+    const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
+    const double coeff = creal(X->Def.ParaNBodyInterAll[term]);
+    const unsigned long int i_max = X->Check.idim_max;
+    unsigned long int j;
+
+#pragma omp parallel for default(none) shared(list_Diagonal, X) firstprivate(i_max, term, coeff, myrank) private(j)
+    for (j = 1; j <= i_max; j++) {
+      unsigned long int local_out = 0;
+      int rank_out = 0;
+      int sign = 1;
+      int ret = apply_nbody_interall_spinless_full(
+        X, term, j - 1, myrank, &local_out, &rank_out, &sign);
+      if (ret == 1 && local_out == j - 1 && rank_out == myrank) {
+        list_Diagonal[j] += coeff * sign;
+      }
+    }
+  }
+  return 0;
+}
+
+int SetDiagonalNBodyInterAllSpinless(struct BindStruct *X)
+{
+  unsigned int i;
+  if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
+  if (X->Def.iCalcModel != SpinlessFermion) return -1;
+
+  for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
+    const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
+    const double coeff = creal(X->Def.ParaNBodyInterAll[term]);
+    const unsigned long int i_max = X->Check.idim_max;
+    unsigned long int j;
+
+#pragma omp parallel for default(none) shared(list_Diagonal, list_1, X) firstprivate(i_max, term, coeff, myrank) private(j)
+    for (j = 1; j <= i_max; j++) {
+      unsigned long int local_out = 0;
+      int rank_out = 0;
+      int sign = 1;
+      int ret = apply_nbody_interall_spinless_full(
         X, term, list_1[j], myrank, &local_out, &rank_out, &sign);
       if (ret == 1 && local_out == list_1[j] && rank_out == myrank) {
         list_Diagonal[j] += coeff * sign;
@@ -1193,6 +1417,74 @@ static double complex apply_nbody_hubbard_term_to_rank(
   return dam_pr;
 }
 
+static double complex apply_nbody_spinlessgc_term_to_rank(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  const double complex *src_v1,
+  double complex *cur_v1,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+  const int do_update = (X->Large.mode == M_MLTPLY || X->Large.mode == M_CALCSPEC);
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, tmp_v0, src_v1, cur_v1) firstprivate(src_i_max, term, rank_in, do_update, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbody_interall_spinless_full(
+      X, term, j - 1, rank_in, &local_out, &rank_out, &sign);
+    if (ret == 1 && rank_out == myrank) {
+      const double complex dmv = X->Def.ParaNBodyInterAll[term] * sign * src_v1[j];
+      if (do_update) tmp_v0[local_out + 1] += dmv;
+      dam_pr += conj(cur_v1[local_out + 1]) * dmv;
+    }
+  }
+  return dam_pr;
+}
+
+static double complex apply_nbody_spinless_term_to_rank(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  const unsigned long int *src_list_1,
+  const double complex *src_v1,
+  double complex *cur_v1,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+  const int do_update = (X->Large.mode == M_MLTPLY || X->Large.mode == M_CALCSPEC);
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, tmp_v0, src_list_1, src_v1, cur_v1, list_2_1, list_2_2) \
+  firstprivate(src_i_max, term, rank_in, do_update, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    unsigned long int j_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = apply_nbody_interall_spinless_full(
+      X, term, src_list_1[j], rank_in, &local_out, &rank_out, &sign);
+    int in_sector = FALSE;
+    if (ret == 1 && rank_out == myrank) {
+      in_sector = GetOffComp(list_2_1, list_2_2, local_out,
+                             X->Large.irght, X->Large.ilft, X->Large.ihfbit, &j_out);
+    }
+    if (in_sector == TRUE) {
+      const double complex dmv = X->Def.ParaNBodyInterAll[term] * sign * src_v1[j];
+      if (do_update) tmp_v0[j_out] += dmv;
+      dam_pr += conj(cur_v1[j_out]) * dmv;
+    }
+  }
+  return dam_pr;
+}
+
 static double complex multiply_nbody_hubbardgc_term(
   struct BindStruct *X,
   unsigned int term,
@@ -1279,6 +1571,92 @@ static double complex multiply_nbody_hubbard_term(
   return dam_pr;
 }
 
+static double complex multiply_nbody_spinlessgc_term(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbody_interall_spinless_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return 0.0;
+  }
+  if (active == FALSE) return 0.0;
+  if (origin == myrank) {
+    return apply_nbody_spinlessgc_term_to_rank(
+      X, term, tmp_v0, tmp_v1, tmp_v1, X->Check.idim_max, myrank);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(tmp_v1, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf,  idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = apply_nbody_spinlessgc_term_to_rank(
+      X, term, tmp_v0, v1buf, tmp_v1, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyInterAll reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return dam_pr;
+}
+
+static double complex multiply_nbody_spinless_term(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  int origin = myrank;
+  int active = TRUE;
+  double complex dam_pr = 0.0;
+
+  if (nbody_interall_spinless_partner_rank(X, term, myrank, &origin, &active) != 0) {
+    return 0.0;
+  }
+  if (active == FALSE) return 0.0;
+  if (origin == myrank) {
+    return apply_nbody_spinless_term_to_rank(
+      X, term, tmp_v0, list_1, tmp_v1, tmp_v1, X->Check.idim_max, myrank);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, origin, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, origin, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(list_1, X->Check.idim_max + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        list_1buf, idim_max_buf + 1, MPI_UNSIGNED_LONG, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(tmp_v1, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        v1buf,  idim_max_buf + 1, MPI_DOUBLE_COMPLEX, origin, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = apply_nbody_spinless_term_to_rank(
+      X, term, tmp_v0, list_1buf, v1buf, tmp_v1, idim_max_buf, origin);
+  }
+#else
+  fprintf(stdoutMPI, "Error: NBodyInterAll reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
+  return dam_pr;
+}
+
 int MultiplyNBodyInterAllHubbardGC(
   struct BindStruct *X,
   double complex *tmp_v0,
@@ -1307,6 +1685,38 @@ int MultiplyNBodyInterAllHubbard(
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
     const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
     X->Large.prdct += multiply_nbody_hubbard_term(X, term, tmp_v0, tmp_v1);
+  }
+  return 0;
+}
+
+int MultiplyNBodyInterAllSpinlessGC(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  unsigned int p;
+  if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
+  if (X->Def.iCalcModel != SpinlessFermionGC) return -1;
+
+  for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
+    const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
+    X->Large.prdct += multiply_nbody_spinlessgc_term(X, term, tmp_v0, tmp_v1);
+  }
+  return 0;
+}
+
+int MultiplyNBodyInterAllSpinless(
+  struct BindStruct *X,
+  double complex *tmp_v0,
+  double complex *tmp_v1
+) {
+  unsigned int p;
+  if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
+  if (X->Def.iCalcModel != SpinlessFermion) return -1;
+
+  for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
+    const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
+    X->Large.prdct += multiply_nbody_spinless_term(X, term, tmp_v0, tmp_v1);
   }
   return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,9 @@ add_hphi_test(nbody_hubbardgc_validation)
 add_hphi_test(nbody_hubbard_validation)
 add_hphi_test_with_srcdir(lanczos_spinless)
 add_hphi_test_with_srcdir(lanczos_spinless_GC)
+add_hphi_test_with_srcdir(lanczos_spinless_nbody_interall)
+add_hphi_test_with_srcdir(lanczos_spinless_nbodyg)
+add_hphi_test_with_srcdir(nbody_spinless_validation)
 add_hphi_test_with_srcdir(spinless_interall_diagonal)
 add_hphi_test_with_srcdir(lanczos_spinless_calchs0)
 add_hphi_test_with_srcdir(spinless_onebody_sigma_validation)
@@ -134,6 +137,9 @@ set_tests_properties(
     lanczos_spinless lanczos_spinless_GC lanczos_spinless_calchs0
     PROPERTIES LABELS "lanczos;spinless")
 set_tests_properties(
+    lanczos_spinless_nbody_interall lanczos_spinless_nbodyg
+    PROPERTIES LABELS "lanczos;spinless;nbody")
+set_tests_properties(
     nbodyg_validation
     PROPERTIES LABELS "spin;validation;nbody")
 set_tests_properties(
@@ -142,6 +148,9 @@ set_tests_properties(
 set_tests_properties(
     nbody_hubbardgc_validation nbody_hubbard_validation
     PROPERTIES LABELS "hubbard;validation;nbody")
+set_tests_properties(
+    nbody_spinless_validation
+    PROPERTIES LABELS "spinless;validation;nbody")
 set_tests_properties(
     lanczos_spingc_spinone_nbody_interall
     lanczos_spin_spinone_nbody_interall
@@ -438,6 +447,8 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_nbodyg_hubbardgc exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_hubbard exact:4)
     add_hphi_mpi_test(mpi_nbodyg_hubbard exact:4)
+    add_hphi_mpi_test_with_srcdir(mpi_nbody_interall_spinless exact:4)
+    add_hphi_mpi_test_with_srcdir(mpi_nbodyg_spinless exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spin exact:4)
     add_hphi_mpi_test(mpi_nbodyg_spin exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spingc_spinone exact:3)
@@ -488,6 +499,9 @@ if(MPI_FOUND)
     set_tests_properties(
         mpi_consistency_spinless mpi_consistency_spinless_GC
         PROPERTIES LABELS "mpi;consistency;spinless")
+    set_tests_properties(
+        mpi_nbody_interall_spinless mpi_nbodyg_spinless
+        PROPERTIES LABELS "mpi;consistency;spinless;nbody")
     set_tests_properties(
         lanczos_hubbard_mpidouble lanczos_hubbardgc_mpidouble
         PROPERTIES LABELS "mpi;lanczos;hubbard;batching")

--- a/test/lanczos_spinless_nbody_interall.sh
+++ b/test/lanczos_spinless_nbody_interall.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_spinless_nbody_interall"
+hphi="../../../src/HPhi"
+SRCDIR="$1"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+make_base() {
+  dir="$1"
+  model="$2"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  if [ "${model}" = "SpinlessFermion" ]; then
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 6 -n 3 --hopping 0.0 > log_generate.txt 2>&1
+  else
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 6 --hopping 0.0 > log_generate.txt 2>&1
+  fi
+  cp namelist.def namelist.base
+  cd ..
+}
+
+run_case() {
+  tag="$1"
+  model="$2"
+
+  rm -rf "${tag}_nbody" "${tag}_legacy"
+  make_base "${tag}_nbody" "${model}"
+  make_base "${tag}_legacy" "${model}"
+
+  cd "${tag}_nbody"
+  cp namelist.base namelist.def
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+1 0 0 1 0 0.3700000000000000 0.1100000000000000
+1 1 0 0 0 0.3700000000000000 -0.1100000000000000
+2 2 0 2 0 4 0 4 0 0.2300000000000000 0.0000000000000000
+EOF
+  run_hphi log_nbody.txt "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${tag}_energy_nbody.dat"
+  cd ..
+
+  cd "${tag}_legacy"
+  cp namelist.base namelist.def
+  cat > trans.def <<EOF
+========================
+NTransfer      2
+========================
+========i_j_s_tijs======
+========================
+0 0 1 0 0.3700000000000000 0.1100000000000000
+1 0 0 0 0.3700000000000000 -0.1100000000000000
+EOF
+  printf '    CoulombInter  coulombinter_eq.def\n' >> namelist.def
+  cat > coulombinter_eq.def <<EOF
+=============================================
+NCoulombInter          1
+=============================================
+================CoulombInter=================
+=============================================
+2 4 0.2300000000000000
+EOF
+  run_hphi log_legacy.txt "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${tag}_energy_legacy.dat"
+  cd ..
+
+  diff=$(paste "${tag}_energy_nbody.dat" "${tag}_energy_legacy.dat" \
+    | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${model} NBodyInterAll energy differs from legacy Transfer/CoulombInter: max diff ${diff}"
+    paste "${tag}_energy_nbody.dat" "${tag}_energy_legacy.dat"
+    exit 1
+  }
+}
+
+run_case spinless SpinlessFermion
+run_case spinlessgc SpinlessFermionGC
+
+echo "Spinless NBodyInterAll N=1 hopping and N=2 density terms match legacy operators."

--- a/test/lanczos_spinless_nbodyg.sh
+++ b/test/lanczos_spinless_nbodyg.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_spinless_nbodyg"
+hphi="../../../src/HPhi"
+SRCDIR="$1"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+compare_one() {
+  so="$1"
+  si="$2"
+  label="$3"
+  awk -v t="${tol}" -v so="${so}" -v si="${si}" '
+    NR == FNR {
+      if ($1 == so && $2 == 0 && $3 == si && $4 == 0) {
+        ref_re = $5;
+        ref_im = $6;
+        found_ref = 1;
+      }
+      next;
+    }
+    $1 == 1 && $2 == so && $3 == 0 && $4 == si && $5 == 0 {
+      dr = $6 - ref_re;
+      di = $7 - ref_im;
+      if (dr < 0) dr = -dr;
+      if (di < 0) di = -di;
+      found_nbody = 1;
+      ok = (found_ref && dr < t && di < t);
+    }
+    END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+  ' output/zvo_cisajs.dat output/zvo_NBodyG.dat || {
+    echo "${label} NBodyG one-body value does not match cisajs"
+    cat output/zvo_cisajs.dat
+    cat output/zvo_NBodyG.dat
+    exit 1
+  }
+}
+
+compare_two() {
+  label="$1"
+  awk -v t="${tol}" '
+    NR == FNR {
+      if ($1 == 0 && $2 == 0 && $3 == 1 && $4 == 0 &&
+          $5 == 2 && $6 == 0 && $7 == 2 && $8 == 0) {
+        ref_re = $9;
+        ref_im = $10;
+        found_ref = 1;
+      }
+      next;
+    }
+    $1 == 2 && $2 == 0 && $3 == 0 && $4 == 1 && $5 == 0 &&
+        $6 == 2 && $7 == 0 && $8 == 2 && $9 == 0 {
+      dr = $10 - ref_re;
+      di = $11 - ref_im;
+      if (dr < 0) dr = -dr;
+      if (di < 0) di = -di;
+      found_nbody = 1;
+      ok = (found_ref && dr < t && di < t);
+    }
+    END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+  ' output/zvo_cisajscktalt.dat output/zvo_NBodyG.dat || {
+    echo "${label} NBodyG two-body value does not match cisajscktalt"
+    cat output/zvo_cisajscktalt.dat
+    cat output/zvo_NBodyG.dat
+    exit 1
+  }
+}
+
+run_case() {
+  tag="$1"
+  model="$2"
+
+  rm -rf "${tag}"
+  mkdir -p "${tag}"
+  cd "${tag}"
+  if [ "${model}" = "SpinlessFermion" ]; then
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 6 -n 3 -V 0.5 --onebody-offdiag --offdiag > log_generate.txt 2>&1
+  else
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 6 -V 0.5 --onebody-offdiag --offdiag > log_generate.txt 2>&1
+  fi
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cat > nbodyg.def <<EOF
+========================
+NNBodyG 3
+========================
+========NBodyG==========
+========================
+1 0 0 0 0
+1 0 0 1 0
+2 0 0 1 0 2 0 2 0
+EOF
+  run_hphi log_lanczos.txt "${hphi}" -e namelist.def
+  test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated"; exit 1; }
+
+  compare_one 0 0 "${model}"
+  compare_one 0 1 "${model}"
+  compare_two "${model}"
+  cd ..
+}
+
+run_case spinless SpinlessFermion
+run_case spinlessgc SpinlessFermionGC
+
+echo "Spinless NBodyG N=1 and N=2 values match legacy Green's functions."

--- a/test/mpi_nbody_interall_spinless.sh
+++ b/test/mpi_nbody_interall_spinless.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_spinless"
+hphi="../../../src/HPhi"
+SRCDIR="$1"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+make_case() {
+  dir="$1"
+  model="$2"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  if [ "${model}" = "SpinlessFermion" ]; then
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 8 -n 3 --hopping 0.0 > log_generate.txt 2>&1
+  else
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 8 --hopping 0.0 > log_generate.txt 2>&1
+  fi
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+1 6 0 6 0 0.1250000000000000 0.0000000000000000
+1 7 0 0 0 0.3700000000000000 0.1100000000000000
+1 0 0 7 0 0.3700000000000000 -0.1100000000000000
+EOF
+  cd ..
+}
+
+run_case() {
+  tag="$1"
+  model="$2"
+
+  rm -rf "serial_${tag}" "mpi_${tag}"
+  make_case "serial_${tag}" "${model}"
+
+  cd "serial_${tag}"
+  run_hphi log_serial.txt "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../energy_serial_${tag}.dat"
+  cd ..
+
+  mkdir -p "mpi_${tag}"
+  cp "serial_${tag}"/*.def "mpi_${tag}/"
+  cd "mpi_${tag}"
+  run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../energy_mpi_${tag}.dat"
+  cd ..
+
+  diff=$(paste "energy_serial_${tag}.dat" "energy_mpi_${tag}.dat" \
+    | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${model} serial/MPI NBodyInterAll energy mismatch: max diff ${diff}"
+    paste "energy_serial_${tag}.dat" "energy_mpi_${tag}.dat"
+    exit 1
+  }
+
+  grep -q "INTER process site" "mpi_${tag}/log_mpi.txt" || {
+    echo "${model} MPI run did not print an inter-process site summary"
+    cat "mpi_${tag}/log_mpi.txt"
+    exit 1
+  }
+}
+
+run_case spinless SpinlessFermion
+run_case spinlessgc SpinlessFermionGC
+
+echo "Spinless NBodyInterAll serial/MPI energies match for inter-process factors."

--- a/test/mpi_nbodyg_spinless.sh
+++ b/test/mpi_nbodyg_spinless.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbodyg_spinless"
+hphi="../../../src/HPhi"
+SRCDIR="$1"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+make_case() {
+  dir="$1"
+  model="$2"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  if [ "${model}" = "SpinlessFermion" ]; then
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 8 -n 3 -V 0.5 --onebody-offdiag --offdiag > log_generate.txt 2>&1
+  else
+    python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+      -m "${model}" -s 8 -V 0.5 --onebody-offdiag --offdiag > log_generate.txt 2>&1
+  fi
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cat > nbodyg.def <<EOF
+========================
+NNBodyG 3
+========================
+========NBodyG==========
+========================
+1 6 0 6 0
+1 7 0 0 0
+2 7 0 0 0 6 0 6 0
+EOF
+  cd ..
+}
+
+compare_outputs() {
+  serial_file="$1"
+  mpi_file="$2"
+  label="$3"
+  awk -v t="${tol}" '
+    function prefix(line, out) {
+      out = line;
+      sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+      return out;
+    }
+    NR == FNR {
+      s_prefix[NR] = prefix($0);
+      s_re[NR] = $(NF - 1);
+      s_im[NR] = $NF;
+      n = NR;
+      next;
+    }
+    {
+      m = FNR;
+      if (prefix($0) != s_prefix[m]) bad = 1;
+      dr = $(NF - 1) - s_re[m];
+      di = $NF - s_im[m];
+      if (dr < 0) dr = -dr;
+      if (di < 0) di = -di;
+      if (dr >= t || di >= t) bad = 1;
+    }
+    END { exit (n == m && bad != 1) ? 0 : 1; }
+  ' "${serial_file}" "${mpi_file}" || {
+    echo "${label} serial/MPI NBodyG output mismatch"
+    paste "${serial_file}" "${mpi_file}"
+    exit 1
+  }
+}
+
+run_case() {
+  tag="$1"
+  model="$2"
+
+  rm -rf "serial_${tag}" "mpi_${tag}"
+  make_case "serial_${tag}" "${model}"
+
+  cd "serial_${tag}"
+  run_hphi log_serial.txt "${hphi}" -e namelist.def
+  cp output/zvo_NBodyG.dat "../nbodyg_serial_${tag}.dat"
+  cd ..
+
+  mkdir -p "mpi_${tag}"
+  cp "serial_${tag}"/*.def "mpi_${tag}/"
+  cd "mpi_${tag}"
+  run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_NBodyG.dat "../nbodyg_mpi_${tag}.dat"
+  cd ..
+
+  compare_outputs "nbodyg_serial_${tag}.dat" "nbodyg_mpi_${tag}.dat" "${model}"
+
+  grep -q "INTER process site" "mpi_${tag}/log_mpi.txt" || {
+    echo "${model} MPI run did not print an inter-process site summary"
+    cat "mpi_${tag}/log_mpi.txt"
+    exit 1
+  }
+
+  awk -v t="${tol}" '
+    $1 == 1 && $2 == 6 && $3 == 0 && $4 == 6 && $5 == 0 {
+      re = $6; if (re < 0) re = -re;
+      found = (re > t);
+    }
+    END { exit found ? 0 : 1; }
+  ' "nbodyg_mpi_${tag}.dat" || {
+    echo "${model} inter-process diagonal NBodyG operator was zero or missing"
+    cat "nbodyg_mpi_${tag}.dat"
+    exit 1
+  }
+}
+
+run_case spinless SpinlessFermion
+run_case spinlessgc SpinlessFermionGC
+
+echo "Spinless NBodyG serial/MPI outputs match for inter-process factors."

--- a/test/nbody_spinless_validation.sh
+++ b/test/nbody_spinless_validation.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+set -e
+
+testname="nbody_spinless_validation"
+hphi="../../../src/HPhi"
+SRCDIR="$1"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+expect_fail() {
+  dir="$1"
+  pattern="$2"
+  cd "${dir}"
+  set +e
+  "${hphi}" -e namelist.def > log.txt 2>&1
+  rc=$?
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    echo "Expected ${dir} to fail, but it succeeded"
+    exit 1
+  fi
+  grep -q "${pattern}" log.txt || {
+    echo "Expected pattern '${pattern}' was not found in ${dir}/log.txt"
+    cat log.txt
+    exit 1
+  }
+  cd ..
+}
+
+make_spinless_base() {
+  dir="$1"
+  mkdir -p "${dir}"
+  cd "${dir}"
+  python3 "${SRCDIR}/test/testSpinlessCalc.py" -p /bin/true \
+    -m SpinlessFermion -s 8 -n 3 -V 0.5 > log_generate.txt 2>&1
+  printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  printf '    NBodyG  nbodyg.def\n' >> namelist.def
+  cd ..
+}
+
+rm -rf accept bad_spin_interall bad_spin_nbodyg bad_pair diag_im bad_fulldiag
+
+make_spinless_base accept
+cat > accept/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 0 0 1 0 0.1000000000000000 0.0000000000000000
+1 1 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > accept/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 1 0
+EOF
+
+make_spinless_base bad_spin_interall
+cat > bad_spin_interall/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 1 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_spin_interall/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spinless_base bad_spin_nbodyg
+cat > bad_spin_nbodyg/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > bad_spin_nbodyg/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 1 0 0
+EOF
+
+make_spinless_base bad_pair
+cat > bad_pair/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 1 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_pair/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spinless_base diag_im
+cat > diag_im/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.1000000000000000
+EOF
+cat > diag_im/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_spinless_base bad_fulldiag
+awk '{if ($1 == "CalcType") print "CalcType   2"; else print}' \
+  bad_fulldiag/calcmod.def > bad_fulldiag/calcmod.tmp
+mv bad_fulldiag/calcmod.tmp bad_fulldiag/calcmod.def
+cat > bad_fulldiag/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_fulldiag/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+cd accept
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+
+expect_fail bad_spin_interall "Spin index of NBodyInterAll is incorrect"
+expect_fail bad_spin_nbodyg "Spin index of NBodyG is incorrect"
+expect_fail bad_pair "Off-diagonal NBodyInterAll terms must appear as adjacent Hermite pairs"
+expect_fail diag_im "Diagonal NBodyInterAll term has a finite imaginary part"
+expect_fail bad_fulldiag "NBodyInterAll is not yet supported in FullDiag for SpinlessFermion"
+
+echo "Spinless NBody validation accepts cross-site fermion factors and rejects malformed inputs."


### PR DESCRIPTION
## Summary

Add `NBodyInterAll` and `NBodyG` support for `SpinlessFermion` and `SpinlessFermionGC`.

This extends the existing N-body operator infrastructure to spinless fermions, including diagonal Hamiltonian contributions, off-diagonal matvec paths, MPI rank-changing terms, and arbitrary N-body correlation output.

## Changes

- Enable `NBodyInterAll` validation for `SpinlessFermion` / `SpinlessFermionGC`.
- Require spin indices to be zero for spinless N-body factors.
- Preserve raw fermion operator order for spinless terms, matching Hubbard/HubbardGC handling.
- Add spinless full-bit operator application using one bit per site and standard fermion parity signs.
- Add diagonal `NBodyInterAll` accumulation for canonical and grand-canonical spinless models.
- Add off-diagonal `NBodyInterAll` matvec dispatch from `mltplySpinless.c`.
- Add spinless `NBodyG` expectation value support, including MPI partner-rank handling.
- Reject spinless `NBodyInterAll` in `FullDiag`, which is not implemented in the full Hamiltonian builder.
- Add serial/MPI regression and validation tests for spinless N-body operators.

## Validation

- Built with MPI enabled.
- Built with MPI disabled.
- Ran full serial CTest suite:
  - `113/113` passed, `0` failed.
- Ran MPI-labeled CTest suite with `np=4`:
  - all runnable tests passed, rank-specific precheck skips only.
- Ran new spinless N-body MPI tests with `np=16`:
  - `mpi_nbody_interall_spinless`: passed
  - `mpi_nbodyg_spinless`: passed
- Ran N-body focused regression tests for existing Hubbard/Spin paths:
  - no regressions found.
- Independently checked spinless N=3 `NBodyInterAll` / `NBodyG` against exact diagonalization:
  - ground-state energy absolute difference: `6.939e-17`
  - maximum checked `NBodyG` difference: `4.616e-11`

## Notes

For sparse, block-structured N-body Hamiltonians, deterministic single-basis Lanczos starts such as `initial_iv=1` can converge within the initially selected invariant subspace. This is a general Lanczos/input issue rather than a spinless N-body implementation bug; random starts such as `initial_iv=-1` were used for the independent exact-diagonalization checks.
