### PR TITLE
Support tJ and Kondo NBody operators

### DIFF
--- a/src/diagonalcalc.c
+++ b/src/diagonalcalc.c
@@ -203,7 +203,11 @@ int diagonalcalc
         return -1;
       }
     }
-    else if (X->Def.iCalcModel == Hubbard) {
+    else if (X->Def.iCalcModel == Hubbard ||
+             X->Def.iCalcModel == tJ ||
+             X->Def.iCalcModel == tJGC ||
+             X->Def.iCalcModel == Kondo ||
+             X->Def.iCalcModel == KondoGC) {
       if (SetDiagonalNBodyInterAllHubbard(X) != 0) {
         return -1;
       }

--- a/src/makeHam.c
+++ b/src/makeHam.c
@@ -319,7 +319,12 @@ int makeHam(struct BindStruct *X) {
         }
       }
 
-      if (X->Def.iCalcModel == Hubbard && X->Def.NNBodyInterAll_OffDiagonal > 0) {
+      if ((X->Def.iCalcModel == Hubbard ||
+           X->Def.iCalcModel == tJ ||
+           X->Def.iCalcModel == tJGC ||
+           X->Def.iCalcModel == Kondo ||
+           X->Def.iCalcModel == KondoGC) &&
+          X->Def.NNBodyInterAll_OffDiagonal > 0) {
         if (AddNBodyInterAllToHamHubbard(X) != 0) {
           return -1;
         }

--- a/src/mltplyHubbard.c
+++ b/src/mltplyHubbard.c
@@ -354,7 +354,12 @@ int mltplyHubbard(
   }/*for (i = 0; i < X->Def.NInterAll_OffDiagonal; i+=2)*/
   StopTimer(320);
 
-  if (X->Def.iCalcModel == Hubbard && X->Def.NNBodyInterAll_OffDiagonal > 0) {
+  if ((X->Def.iCalcModel == Hubbard ||
+       X->Def.iCalcModel == tJ ||
+       X->Def.iCalcModel == tJGC ||
+       X->Def.iCalcModel == Kondo ||
+       X->Def.iCalcModel == KondoGC) &&
+      X->Def.NNBodyInterAll_OffDiagonal > 0) {
     if (MultiplyNBodyInterAllHubbard(X, tmp_v0, tmp_v1) != 0) {
       return -1;
     }

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -104,14 +104,32 @@ static int nbodyg_is_hubbard_model(const struct DefineList *D)
   return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
 }
 
+static int nbodyg_is_tj_model(const struct DefineList *D)
+{
+  return D->iCalcModel == tJ || D->iCalcModel == tJGC;
+}
+
+static int nbodyg_is_kondo_model(const struct DefineList *D)
+{
+  return D->iCalcModel == Kondo || D->iCalcModel == KondoGC;
+}
+
 static int nbodyg_is_spinless_model(const struct DefineList *D)
 {
   return D->iCalcModel == SpinlessFermion || D->iCalcModel == SpinlessFermionGC;
 }
 
+static int nbodyg_is_spinful_raw_fermion_model(const struct DefineList *D)
+{
+  return nbodyg_is_hubbard_model(D) == TRUE ||
+         nbodyg_is_tj_model(D) == TRUE ||
+         nbodyg_is_kondo_model(D) == TRUE;
+}
+
 static int nbodyg_is_raw_fermion_model(const struct DefineList *D)
 {
-  return nbodyg_is_hubbard_model(D) == TRUE || nbodyg_is_spinless_model(D) == TRUE;
+  return nbodyg_is_spinful_raw_fermion_model(D) == TRUE ||
+         nbodyg_is_spinless_model(D) == TRUE;
 }
 
 static int nbodyg_is_supported_model(const struct DefineList *D)
@@ -120,6 +138,27 @@ static int nbodyg_is_supported_model(const struct DefineList *D)
   if (D->iCalcModel == Spin) return TRUE;
   if (nbodyg_is_raw_fermion_model(D) == TRUE) return TRUE;
   return FALSE;
+}
+
+static int nbodyg_uses_hubbard_list_path(const struct DefineList *D)
+{
+  return D->iCalcModel == Hubbard ||
+         D->iCalcModel == tJ ||
+         D->iCalcModel == tJGC ||
+         D->iCalcModel == Kondo ||
+         D->iCalcModel == KondoGC;
+}
+
+static int nbodyg_requires_spinful_conservation(const struct DefineList *D)
+{
+  return D->iCalcModel == Hubbard ||
+         D->iCalcModel == tJ ||
+         D->iCalcModel == Kondo;
+}
+
+static int nbodyg_is_unsupported_nconserved_model(const struct DefineList *D)
+{
+  return D->iCalcModel == tJNConserved || D->iCalcModel == KondoNConserved;
 }
 
 static int nbodyg_is_general_spin(const struct DefineList *D)
@@ -133,8 +172,27 @@ int ValidateNBodyGScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
   if (nbodyg_is_supported_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, Hubbard, SpinlessFermionGC, and SpinlessFermion.\n");
+    if (nbodyg_is_unsupported_nconserved_model(D) == TRUE) {
+      fprintf(stdoutMPI,
+              "Error: NBodyG does not support tJNConserved or KondoNConserved. "
+              "For tJ/Kondo standard input, define 2Sz to use the Sz-conserved model.\n");
+    }
+    else {
+      fprintf(stdoutMPI,
+              "Error: NBodyG is currently supported only for SpinGC, Spin, "
+              "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
+              "tJGC, tJ, KondoGC, and Kondo.\n");
+    }
     return -1;
+  }
+  if (nbodyg_is_kondo_model(D) == TRUE) {
+    unsigned int site;
+    for (site = 0; site < D->Nsite; site++) {
+      if (D->LocSpn[site] > LOCSPIN) {
+        fprintf(stdoutMPI, "Error: NBodyG does not support general-spin Kondo local spins.\n");
+        return -1;
+      }
+    }
   }
   for (t = 0; t < D->NNBodyG; t++) {
     const unsigned int off = D->NBodyG_Offset[t];
@@ -148,6 +206,12 @@ int ValidateNBodyGScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: NBodyG currently requires site_out == site_in for every factor.\n");
         return -1;
       }
+      if (nbodyg_is_kondo_model(D) == TRUE &&
+          (D->LocSpn[f[0]] != ITINERANT || D->LocSpn[f[2]] != ITINERANT) &&
+          f[0] != f[2]) {
+        fprintf(stdoutMPI, "Error: Kondo local-spin NBodyG factors require site_out == site_in.\n");
+        return -1;
+      }
       if (nbodyg_is_spinless_model(D) == TRUE) {
         if (f[1] != 0 || f[3] != 0) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
@@ -155,7 +219,7 @@ int ValidateNBodyGScope(const struct DefineList *D)
         }
       }
       else {
-        const int max_spin = (nbodyg_is_hubbard_model(D) == TRUE) ? 1 :
+        const int max_spin = (nbodyg_is_spinful_raw_fermion_model(D) == TRUE) ? 1 :
           (nbodyg_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyG is incorrect.\n");
@@ -308,7 +372,7 @@ int CheckNBodyGHubbardConservation(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
-  if (D->iCalcModel != Hubbard) return 0;
+  if (nbodyg_requires_spinful_conservation(D) == FALSE) return 0;
 
   for (t = 0; t < D->NNBodyG; t++) {
     const unsigned int n = D->NBodyG_CanonicalN[t];
@@ -1383,7 +1447,10 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
 
   if (X->Def.NNBodyG < 1) return 0;
   if (nbodyg_is_supported_model(&X->Def) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyG is currently supported only for SpinGC, Spin, HubbardGC, Hubbard, SpinlessFermionGC, and SpinlessFermion.\n");
+    fprintf(stdoutMPI,
+            "Error: NBodyG is currently supported only for SpinGC, Spin, "
+            "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
+            "tJGC, tJ, KondoGC, and Kondo.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;
@@ -1393,8 +1460,8 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
     double complex value = 0.0;
     if (X->Def.NBodyG_IsZero[t] == FALSE) {
       if (X->Def.iCalcModel == Spin) value = calc_nbodyg_term_spin(X, t, vec);
-      else if (X->Def.iCalcModel == Hubbard) value = calc_nbodyg_term_hubbard(X, t, vec);
       else if (X->Def.iCalcModel == HubbardGC) value = calc_nbodyg_term_hubbardgc(X, t, vec);
+      else if (nbodyg_uses_hubbard_list_path(&X->Def) == TRUE) value = calc_nbodyg_term_hubbard(X, t, vec);
       else if (X->Def.iCalcModel == SpinlessFermion) value = calc_nbodyg_term_spinless(X, t, vec);
       else if (X->Def.iCalcModel == SpinlessFermionGC) value = calc_nbodyg_term_spinlessgc(X, t, vec);
       else if (nbodyg_is_general_spin(&X->Def) == TRUE) {

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -136,14 +136,32 @@ static int nbody_is_hubbard_model(const struct DefineList *D)
   return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
 }
 
+static int nbody_is_tj_model(const struct DefineList *D)
+{
+  return D->iCalcModel == tJ || D->iCalcModel == tJGC;
+}
+
+static int nbody_is_kondo_model(const struct DefineList *D)
+{
+  return D->iCalcModel == Kondo || D->iCalcModel == KondoGC;
+}
+
 static int nbody_is_spinless_model(const struct DefineList *D)
 {
   return D->iCalcModel == SpinlessFermion || D->iCalcModel == SpinlessFermionGC;
 }
 
+static int nbody_is_spinful_raw_fermion_model(const struct DefineList *D)
+{
+  return nbody_is_hubbard_model(D) == TRUE ||
+         nbody_is_tj_model(D) == TRUE ||
+         nbody_is_kondo_model(D) == TRUE;
+}
+
 static int nbody_is_raw_fermion_model(const struct DefineList *D)
 {
-  return nbody_is_hubbard_model(D) == TRUE || nbody_is_spinless_model(D) == TRUE;
+  return nbody_is_spinful_raw_fermion_model(D) == TRUE ||
+         nbody_is_spinless_model(D) == TRUE;
 }
 
 static int nbody_is_supported_model(const struct DefineList *D)
@@ -152,6 +170,27 @@ static int nbody_is_supported_model(const struct DefineList *D)
   if (D->iCalcModel == Spin) return TRUE;
   if (nbody_is_raw_fermion_model(D) == TRUE) return TRUE;
   return FALSE;
+}
+
+static int nbody_uses_hubbard_list_path(const struct DefineList *D)
+{
+  return D->iCalcModel == Hubbard ||
+         D->iCalcModel == tJ ||
+         D->iCalcModel == tJGC ||
+         D->iCalcModel == Kondo ||
+         D->iCalcModel == KondoGC;
+}
+
+static int nbody_requires_spinful_conservation(const struct DefineList *D)
+{
+  return D->iCalcModel == Hubbard ||
+         D->iCalcModel == tJ ||
+         D->iCalcModel == Kondo;
+}
+
+static int nbody_is_unsupported_nconserved_model(const struct DefineList *D)
+{
+  return D->iCalcModel == tJNConserved || D->iCalcModel == KondoNConserved;
 }
 
 static int nbody_is_general_spin(const struct DefineList *D)
@@ -165,7 +204,17 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
   if (nbody_is_supported_model(D) == FALSE) {
-    fprintf(stdoutMPI, "Error: NBodyInterAll is currently supported only for SpinGC, Spin, HubbardGC, Hubbard, SpinlessFermionGC, and SpinlessFermion.\n");
+    if (nbody_is_unsupported_nconserved_model(D) == TRUE) {
+      fprintf(stdoutMPI,
+              "Error: NBodyInterAll does not support tJNConserved or KondoNConserved. "
+              "For tJ/Kondo standard input, define 2Sz to use the Sz-conserved model.\n");
+    }
+    else {
+      fprintf(stdoutMPI,
+              "Error: NBodyInterAll is currently supported only for SpinGC, Spin, "
+              "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
+              "tJGC, tJ, KondoGC, and Kondo.\n");
+    }
     return -1;
   }
   if (D->iCalcType == TimeEvolution) {
@@ -175,6 +224,15 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   if (nbody_is_spinless_model(D) == TRUE && D->iCalcType == FullDiag) {
     fprintf(stdoutMPI, "Error: NBodyInterAll is not yet supported in FullDiag for SpinlessFermion / SpinlessFermionGC.\n");
     return -1;
+  }
+  if (nbody_is_kondo_model(D) == TRUE) {
+    unsigned int site;
+    for (site = 0; site < D->Nsite; site++) {
+      if (D->LocSpn[site] > LOCSPIN) {
+        fprintf(stdoutMPI, "Error: NBodyInterAll does not support general-spin Kondo local spins.\n");
+        return -1;
+      }
+    }
   }
   for (t = 0; t < D->NNBodyInterAll; t++) {
     const unsigned int off = D->NBodyInterAll_Offset[t];
@@ -188,6 +246,12 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
         fprintf(stdoutMPI, "Error: NBodyInterAll currently requires site_out == site_in for every factor.\n");
         return -1;
       }
+      if (nbody_is_kondo_model(D) == TRUE &&
+          (D->LocSpn[f[0]] != ITINERANT || D->LocSpn[f[2]] != ITINERANT) &&
+          f[0] != f[2]) {
+        fprintf(stdoutMPI, "Error: Kondo local-spin NBodyInterAll factors require site_out == site_in.\n");
+        return -1;
+      }
       if (nbody_is_spinless_model(D) == TRUE) {
         if (f[1] != 0 || f[3] != 0) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
@@ -195,7 +259,7 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
         }
       }
       else {
-        const int max_spin = (nbody_is_hubbard_model(D) == TRUE) ? 1 :
+        const int max_spin = (nbody_is_spinful_raw_fermion_model(D) == TRUE) ? 1 :
           (nbody_is_general_spin(D) ? D->LocSpn[f[0]] : 1);
         if (max_spin < 1 || f[1] < 0 || f[1] > max_spin || f[3] < 0 || f[3] > max_spin) {
           fprintf(stdoutMPI, "Error: Spin index of NBodyInterAll is incorrect.\n");
@@ -339,7 +403,7 @@ int CheckNBodyInterAllHubbardConservation(const struct DefineList *D)
 {
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
-  if (D->iCalcModel != Hubbard) return 0;
+  if (nbody_requires_spinful_conservation(D) == FALSE) return 0;
 
   for (t = 0; t < D->NNBodyInterAll; t++) {
     const unsigned int n = D->NBodyInterAll_CanonicalN[t];
@@ -947,7 +1011,7 @@ int SetDiagonalNBodyInterAllHubbard(struct BindStruct *X)
 {
   unsigned int i;
   if (X->Def.NNBodyInterAll_Diagonal == 0) return 0;
-  if (X->Def.iCalcModel != Hubbard) return -1;
+  if (nbody_uses_hubbard_list_path(&X->Def) == FALSE) return -1;
 
   for (i = 0; i < X->Def.NNBodyInterAll_Diagonal; i++) {
     const unsigned int term = X->Def.NBodyInterAll_DiagonalIndex[i];
@@ -1680,7 +1744,7 @@ int MultiplyNBodyInterAllHubbard(
 ) {
   unsigned int p;
   if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
-  if (X->Def.iCalcModel != Hubbard) return -1;
+  if (nbody_uses_hubbard_list_path(&X->Def) == FALSE) return -1;
 
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
     const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];
@@ -1755,7 +1819,7 @@ int AddNBodyInterAllToHamHubbard(struct BindStruct *X)
   unsigned int p;
   unsigned long int j;
   if (X->Def.NNBodyInterAll_OffDiagonal == 0) return 0;
-  if (X->Def.iCalcModel != Hubbard) return -1;
+  if (nbody_uses_hubbard_list_path(&X->Def) == FALSE) return -1;
 
   for (p = 0; p < X->Def.NNBodyInterAll_OffDiagonal; p++) {
     const unsigned int term = X->Def.NBodyInterAll_OffDiagonalIndex[p];

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_hphi_test(lanczos_hubbardgc_nbodyg)
 add_hphi_test(lanczos_hubbard_nbody_interall)
 add_hphi_test(lanczos_hubbard_nbodyg)
 add_hphi_test(lanczos_kondogc_chain)
+add_hphi_test(lanczos_tj_kondo_nbody_interall)
 add_hphi_test(lanczos_spingc_honey)
 add_hphi_test(lanczos_spingc_hcor)
 add_hphi_test(lanczos_spingc_nbody_interall)
@@ -85,6 +86,7 @@ add_hphi_test(nbody_interall_validation)
 add_hphi_test(nbodyg_validation)
 add_hphi_test(nbody_hubbardgc_validation)
 add_hphi_test(nbody_hubbard_validation)
+add_hphi_test(nbody_tj_kondo_validation)
 add_hphi_test_with_srcdir(lanczos_spinless)
 add_hphi_test_with_srcdir(lanczos_spinless_GC)
 add_hphi_test_with_srcdir(lanczos_spinless_nbody_interall)
@@ -134,6 +136,9 @@ set_tests_properties(
     lanczos_tjgc_dimension lanczos_tjgc_exchange
     PROPERTIES LABELS "lanczos;tjgc")
 set_tests_properties(
+    lanczos_tj_kondo_nbody_interall
+    PROPERTIES LABELS "lanczos;tj;tjgc;kondo;nbody")
+set_tests_properties(
     lanczos_spinless lanczos_spinless_GC lanczos_spinless_calchs0
     PROPERTIES LABELS "lanczos;spinless")
 set_tests_properties(
@@ -148,6 +153,9 @@ set_tests_properties(
 set_tests_properties(
     nbody_hubbardgc_validation nbody_hubbard_validation
     PROPERTIES LABELS "hubbard;validation;nbody")
+set_tests_properties(
+    nbody_tj_kondo_validation
+    PROPERTIES LABELS "tj;tjgc;kondo;validation;nbody")
 set_tests_properties(
     nbody_spinless_validation
     PROPERTIES LABELS "spinless;validation;nbody")
@@ -228,6 +236,7 @@ add_hphi_test(fulldiag_hubbardgc_tri)
 add_hphi_test(fulldiag_hubbardgc_nbody_interall)
 add_hphi_test(fulldiag_hubbard_nbody_interall)
 add_hphi_test(fulldiag_tj_calchs1)
+add_hphi_test(fulldiag_tj_kondo_nbody_interall)
 add_hphi_test(fulldiag_kondogc_chain)
 add_hphi_test(fulldiag_spingc_tri)
 add_hphi_test(fulldiag_spingc_nbody_interall_compare)
@@ -245,6 +254,9 @@ set_tests_properties(
 set_tests_properties(
     fulldiag_tj_calchs1
     PROPERTIES LABELS "fulldiag;tj")
+set_tests_properties(
+    fulldiag_tj_kondo_nbody_interall
+    PROPERTIES LABELS "fulldiag;tj;tjgc;kondo;nbody")
 set_tests_properties(
     fulldiag_spin_tri fulldiag_spingc_tri
     PROPERTIES LABELS "fulldiag;spin")

--- a/test/fulldiag_tj_kondo_nbody_interall.sh
+++ b/test/fulldiag_tj_kondo_nbody_interall.sh
@@ -1,0 +1,279 @@
+#!/bin/sh
+set -e
+
+testname="fulldiag_tj_kondo_nbody_interall"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+hphi="$(pwd)/../../src/HPhi"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+make_tj_base() {
+  dir="$1"
+  calcmodel="$2"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > namelist.def <<EOF
+         ModPara  modpara.def
+         LocSpin  locspn.def
+           Trans  trans.def
+        InterAll  interall.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod.def
+EOF
+
+  cat > calcmod.def <<EOF
+CalcType        2
+CalcModel       ${calcmodel}
+ReStart         0
+CalcSpec        0
+CalcEigenVec    0
+InitialVecType  0
+InputEigenVec   0
+OutputEigenVec  0
+InputHam        0
+OutputHam       0
+OutputExVec     0
+EOF
+
+  {
+    printf -- "--------------------\n"
+    printf "Model_Parameters   0\n"
+    printf -- "--------------------\n"
+    printf "HPhi_Cal_Parameters\n"
+    printf -- "--------------------\n"
+    printf "CDataFileHead  zvo\n"
+    printf "CParaFileHead  zqp\n"
+    printf -- "--------------------\n"
+    printf "Nsite             4\n"
+    if [ "${calcmodel}" = "9" ]; then
+      printf "Ncond             2\n"
+      printf "2Sz               0\n"
+    fi
+    printf "Lanczos_max       120\n"
+    printf "initial_iv        1\n"
+    printf "exct              1\n"
+    printf "LanczosEps        12\n"
+    printf "LanczosTarget     2\n"
+    printf "LargeValue        12.0\n"
+    printf "NumAve            1\n"
+    printf "ExpecInterval     20\n"
+  } > modpara.def
+
+  cat > locspn.def <<EOF
+================================
+NlocalSpin     0
+================================
+========i_1LocSpn_0IteElc ======
+================================
+    0      0
+    1      0
+    2      0
+    3      0
+EOF
+
+  cat > trans.def <<EOF
+========================
+NTransfer      0
+========================
+========i_j_s_tijs======
+========================
+EOF
+  cat > interall.def <<EOF
+======================
+NInterAll      0
+======================
+========zInterAll=====
+======================
+EOF
+  printf "===========\nNCisAjs          0\n===========\n===========\n===========\n" > greenone.def
+  printf "===========\nNCisAjsCktAlt          0\n===========\n===========\n===========\n" > greentwo.def
+  cd ..
+}
+
+make_kondo_base() {
+  dir="$1"
+  model="$2"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "${model}"
+method = "FullDiag"
+lattice = "chain"
+L = 2
+t = 0.0
+J = 0.0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+  if [ "${model}" = "Kondo" ]; then
+    {
+      printf "nelec = 2\n"
+      printf "2Sz = 0\n"
+    } >> stan.in
+  fi
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  cd ..
+}
+
+write_tj_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+2 0 0 0 1 1 1 1 0 0.3700000000000000 0.1100000000000000
+2 1 0 1 1 0 1 0 0 0.3700000000000000 -0.1100000000000000
+1 0 0 0 0 0.1900000000000000 0.0000000000000000
+EOF
+}
+
+write_tj_interall() {
+  cat > interall.def <<EOF
+======================
+NInterAll      2
+======================
+========zInterAll=====
+======================
+0 0 0 1 1 1 1 0 0.3700000000000000 0.1100000000000000
+1 0 1 1 0 1 0 0 0.3700000000000000 -0.1100000000000000
+EOF
+}
+
+write_kondo_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 3
+========================
+========NBodyInterAll===
+========================
+2 2 0 2 1 0 1 0 0 0.2500000000000000 0.0700000000000000
+2 0 0 0 1 2 1 2 0 0.2500000000000000 -0.0700000000000000
+1 2 0 2 0 0.1900000000000000 0.0000000000000000
+EOF
+}
+
+write_kondo_interall() {
+  cat > interall.def <<EOF
+======================
+NInterAll      2
+======================
+========zInterAll=====
+======================
+2 0 2 1 0 1 0 0 0.2500000000000000 0.0700000000000000
+0 0 0 1 2 1 2 0 0.2500000000000000 -0.0700000000000000
+EOF
+}
+
+write_diag_transfer() {
+  site="$1"
+  spin="$2"
+  coeff="$3"
+  cat > trans.def <<EOF
+========================
+NTransfer       1
+========================
+========i_j_s_tijs======
+========================
+${site} ${spin} ${site} ${spin} ${coeff} 0.0000000000000000
+EOF
+}
+
+save_ground_energy() {
+  dst="$1"
+  if [ -f output/zvo_phys.dat ]; then
+    awk 'NR==2{print "Energy", $1; exit}' output/zvo_phys.dat > "${dst}"
+  else
+    awk 'NR==1{print "Energy", $2; exit}' output/Eigenvalue.dat > "${dst}"
+  fi
+}
+
+compare_case() {
+  label="$1"
+  diff=$(paste "${label}_nbody_energy.dat" "${label}_legacy_energy.dat" \
+    | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${label}: NBodyInterAll energy differs from legacy InterAll: max diff ${diff}"
+    paste "${label}_nbody_energy.dat" "${label}_legacy_energy.dat"
+    exit 1
+  }
+  awk '$1 == "Energy" {e=$2; if(e<0)e=-e; exit (e > 0.00000001) ? 0 : 1}' "${label}_nbody_energy.dat" || {
+    echo "${label}: NBodyInterAll ground-state energy is unexpectedly zero"
+    cat "${label}_nbody_energy.dat"
+    exit 1
+  }
+}
+
+run_tj_case() {
+  label="$1"
+  calcmodel="$2"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_tj_base nbody "${calcmodel}"
+  make_tj_base legacy "${calcmodel}"
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_tj_nbody
+  run_hphi log_nbody.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  write_diag_transfer 0 0 -0.1900000000000000
+  write_tj_interall
+  run_hphi log_legacy.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
+run_kondo_case() {
+  label="$1"
+  model="$2"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_kondo_base nbody "${model}"
+  make_kondo_base legacy "${model}"
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_kondo_nbody
+  run_hphi log_nbody.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  printf '        InterAll  interall.def\n' >> namelist.def
+  write_diag_transfer 2 0 -0.1900000000000000
+  write_kondo_interall
+  run_hphi log_legacy.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
+run_tj_case tj 9
+run_tj_case tjgc 10
+run_kondo_case kondo Kondo
+run_kondo_case kondogc KondoGC
+
+echo "tJ/tJGC/Kondo/KondoGC NBodyInterAll N=2 terms match legacy InterAll in FullDiag."

--- a/test/lanczos_tj_kondo_nbody_interall.sh
+++ b/test/lanczos_tj_kondo_nbody_interall.sh
@@ -1,0 +1,233 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_tj_kondo_nbody_interall"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+hphi="$(pwd)/../../src/HPhi"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+make_tj_base() {
+  dir="$1"
+  calcmodel="$2"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > namelist.def <<EOF
+         ModPara  modpara.def
+         LocSpin  locspn.def
+           Trans  trans.def
+        InterAll  interall.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod.def
+EOF
+  cat > calcmod.def <<EOF
+CalcType        0
+CalcModel       ${calcmodel}
+ReStart         0
+CalcSpec        0
+CalcEigenVec    0
+InitialVecType  0
+InputEigenVec   0
+OutputEigenVec  0
+InputHam        0
+OutputHam       0
+OutputExVec     0
+EOF
+  {
+    printf -- "--------------------\nModel_Parameters   0\n--------------------\n"
+    printf "HPhi_Cal_Parameters\n--------------------\n"
+    printf "CDataFileHead  zvo\nCParaFileHead  zqp\n--------------------\n"
+    printf "Nsite             4\n"
+    if [ "${calcmodel}" = "9" ]; then
+      printf "Ncond             2\n2Sz               0\n"
+    fi
+    printf "Lanczos_max       2000\ninitial_iv        1\nexct              1\n"
+    printf "LanczosEps        14\nLanczosTarget     2\nLargeValue        20.0\n"
+    printf "NumAve            1\nExpecInterval     20\n"
+  } > modpara.def
+  cat > locspn.def <<EOF
+================================
+NlocalSpin     0
+================================
+========i_1LocSpn_0IteElc ======
+================================
+    0      0
+    1      0
+    2      0
+    3      0
+EOF
+  {
+    printf "========================\nNTransfer      12\n========================\n"
+    printf "========i_j_s_tijs======\n========================\n"
+    for b in 0 1 2; do
+      j=$((b + 1))
+      for s in 0 1; do
+        printf "    %d     %d     %d     %d    1.000000000000000    0.0\n" "${b}" "${s}" "${j}" "${s}"
+        printf "    %d     %d     %d     %d    1.000000000000000    0.0\n" "${j}" "${s}" "${b}" "${s}"
+      done
+    done
+  } > trans.def
+  cat > interall.def <<EOF
+======================
+NInterAll      0
+======================
+========zInterAll=====
+======================
+EOF
+  printf "===========\nNCisAjs          0\n===========\n===========\n===========\n" > greenone.def
+  printf "===========\nNCisAjsCktAlt          0\n===========\n===========\n===========\n" > greentwo.def
+  cd ..
+}
+
+make_kondo_base() {
+  dir="$1"
+  model="$2"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "${model}"
+method = "Lanczos"
+lattice = "chain"
+L = 2
+t = 1.0
+J = 0.0
+Lanczos_max = 1000
+initial_iv = 1
+EOF
+  if [ "${model}" = "Kondo" ]; then
+    printf "nelec = 2\n2Sz = 0\n" >> stan.in
+  fi
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  cd ..
+}
+
+write_tj_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 0 0 0 1 1 1 1 0 0.1700000000000000 0.0300000000000000
+2 1 0 1 1 0 1 0 0 0.1700000000000000 -0.0300000000000000
+EOF
+}
+
+write_tj_interall() {
+  cat > interall.def <<EOF
+======================
+NInterAll      2
+======================
+========zInterAll=====
+======================
+0 0 0 1 1 1 1 0 0.1700000000000000 0.0300000000000000
+1 0 1 1 0 1 0 0 0.1700000000000000 -0.0300000000000000
+EOF
+}
+
+write_kondo_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 2 0 2 1 0 1 0 0 0.1700000000000000 0.0300000000000000
+2 0 0 0 1 2 1 2 0 0.1700000000000000 -0.0300000000000000
+EOF
+}
+
+write_kondo_interall() {
+  cat > interall.def <<EOF
+======================
+NInterAll      2
+======================
+========zInterAll=====
+======================
+2 0 2 1 0 1 0 0 0.1700000000000000 0.0300000000000000
+0 0 0 1 2 1 2 0 0.1700000000000000 -0.0300000000000000
+EOF
+}
+
+compare_case() {
+  label="$1"
+  diff=$(paste "${label}_nbody_energy.dat" "${label}_legacy_energy.dat" \
+    | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${label}: NBodyInterAll Lanczos energy differs from legacy InterAll: max diff ${diff}"
+    paste "${label}_nbody_energy.dat" "${label}_legacy_energy.dat"
+    exit 1
+  }
+}
+
+run_tj_case() {
+  label="$1"
+  calcmodel="$2"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_tj_base nbody "${calcmodel}"
+  make_tj_base legacy "${calcmodel}"
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_tj_nbody
+  run_hphi log_nbody.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  write_tj_interall
+  run_hphi log_legacy.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
+run_kondo_case() {
+  label="$1"
+  model="$2"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_kondo_base nbody "${model}"
+  make_kondo_base legacy "${model}"
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_kondo_nbody
+  run_hphi log_nbody.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  printf '        InterAll  interall.def\n' >> namelist.def
+  write_kondo_interall
+  run_hphi log_legacy.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
+run_tj_case tj 9
+run_tj_case tjgc 10
+run_kondo_case kondo Kondo
+run_kondo_case kondogc KondoGC
+
+echo "tJ/tJGC/Kondo/KondoGC NBodyInterAll mltply terms match legacy InterAll in Lanczos."

--- a/test/nbody_tj_kondo_validation.sh
+++ b/test/nbody_tj_kondo_validation.sh
@@ -1,0 +1,351 @@
+#!/bin/sh
+set -e
+
+testname="nbody_tj_kondo_validation"
+hphi="../../../src/HPhi"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+expect_fail() {
+  dir="$1"
+  pattern="$2"
+  cd "${dir}"
+  set +e
+  "${hphi}" -e namelist.def > log.txt 2>&1
+  rc=$?
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    echo "Expected ${dir} to fail, but it succeeded"
+    exit 1
+  fi
+  grep -q "${pattern}" log.txt || {
+    echo "Expected pattern '${pattern}' was not found in ${dir}/log.txt"
+    cat log.txt
+    exit 1
+  }
+  cd ..
+}
+
+check_nbodyg_output() {
+  dir="$1"
+  if ! ls "${dir}"/output/zvo_NBodyG*.dat >/dev/null 2>&1; then
+    echo "Expected ${dir} to write NBodyG output"
+    ls -R "${dir}"/output
+    exit 1
+  fi
+}
+
+make_tj_base() {
+  dir="$1"
+  calcmodel="$2"
+  write_2sz="$3"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > namelist.def <<EOF
+         ModPara  modpara.def
+         LocSpin  locspn.def
+           Trans  trans.def
+        InterAll  interall.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+   NBodyInterAll  nbodyinterall.def
+          NBodyG  nbodyg.def
+         CalcMod  calcmod.def
+EOF
+
+  cat > calcmod.def <<EOF
+CalcType        2
+CalcModel       ${calcmodel}
+ReStart         0
+CalcSpec        0
+CalcEigenVec    0
+InitialVecType  0
+InputEigenVec   0
+OutputEigenVec  0
+InputHam        0
+OutputHam       0
+OutputExVec     0
+EOF
+
+  {
+    printf -- "--------------------\n"
+    printf "Model_Parameters   0\n"
+    printf -- "--------------------\n"
+    printf "HPhi_Cal_Parameters\n"
+    printf -- "--------------------\n"
+    printf "CDataFileHead  zvo\n"
+    printf "CParaFileHead  zqp\n"
+    printf -- "--------------------\n"
+    printf "Nsite             4\n"
+    if [ "${calcmodel}" = "9" ]; then
+      printf "Ncond             2\n"
+      if [ "${write_2sz}" = "yes" ]; then
+        printf "2Sz               0\n"
+      fi
+    fi
+    printf "Lanczos_max       50\n"
+    printf "initial_iv        1\n"
+    printf "exct              1\n"
+    printf "LanczosEps        10\n"
+    printf "LanczosTarget     2\n"
+    printf "LargeValue        4.5\n"
+    printf "NumAve            1\n"
+    printf "ExpecInterval     20\n"
+  } > modpara.def
+
+  cat > locspn.def <<EOF
+================================
+NlocalSpin     0
+================================
+========i_1LocSpn_0IteElc ======
+================================
+    0      0
+    1      0
+    2      0
+    3      0
+EOF
+
+  cat > trans.def <<EOF
+========================
+NTransfer      0
+========================
+========i_j_s_tijs======
+========================
+EOF
+  cat > interall.def <<EOF
+======================
+NInterAll      0
+======================
+========zInterAll=====
+======================
+EOF
+  printf "===========\nNCisAjs          0\n===========\n===========\n===========\n" > greenone.def
+  printf "===========\nNCisAjsCktAlt          0\n===========\n===========\n===========\n" > greentwo.def
+  cd ..
+}
+
+make_kondo_base() {
+  dir="$1"
+  model="$2"
+  write_sector="$3"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "${model}"
+method = "FullDiag"
+lattice = "chain"
+L = 2
+t = 0.0
+J = 0.0
+Lanczos_max = 50
+initial_iv = 1
+EOF
+  if [ "${write_sector}" = "yes" ]; then
+    {
+      printf "nelec = 2\n"
+      printf "2Sz = 0\n"
+    } >> stan.in
+  elif [ "${write_sector}" = "ncond" ]; then
+    printf "nelec = 2\n" >> stan.in
+  fi
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  printf '          NBodyG  nbodyg.def\n' >> namelist.def
+  cd ..
+}
+
+rm -rf accept_tj accept_tjgc accept_kondo accept_kondogc \
+  bad_tj_particle bad_kondo_nbodyg_particle bad_tjn bad_kondon bad_kondo_local_cross
+
+make_tj_base accept_tj 9 yes
+cat > accept_tj/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > accept_tj/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 0
+EOF
+
+make_tj_base accept_tjgc 10 no
+cat > accept_tjgc/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 1 0 0 0 0.0500000000000000 0.0000000000000000
+1 0 0 1 0 0.0500000000000000 0.0000000000000000
+EOF
+cat > accept_tjgc/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 1 0 0 1
+EOF
+
+make_kondo_base accept_kondo Kondo yes
+cat > accept_kondo/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > accept_kondo/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 0
+EOF
+
+make_kondo_base accept_kondogc KondoGC no
+cat > accept_kondogc/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 2 0 2 1 0 1 0 0 0.1000000000000000 0.0000000000000000
+2 0 0 0 1 2 1 2 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > accept_kondogc/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 1 0 0
+EOF
+
+make_tj_base bad_tj_particle 9 yes
+cat > bad_tj_particle/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 1 0 1 1 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_tj_particle/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_kondo_base bad_kondo_nbodyg_particle Kondo yes
+cat > bad_kondo_nbodyg_particle/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > bad_kondo_nbodyg_particle/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 1 0 0
+EOF
+
+make_tj_base bad_tjn 9 no
+cat > bad_tjn/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_tjn/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_kondo_base bad_kondon Kondo ncond
+cat > bad_kondon/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_kondon/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_kondo_base bad_kondo_local_cross KondoGC no
+cat > bad_kondo_local_cross/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 1 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_kondo_local_cross/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+cd accept_tj
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+check_nbodyg_output accept_tj
+cd accept_tjgc
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+check_nbodyg_output accept_tjgc
+cd accept_kondo
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+check_nbodyg_output accept_kondo
+cd accept_kondogc
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+check_nbodyg_output accept_kondogc
+
+expect_fail bad_tj_particle "does not conserve particle numbers"
+expect_fail bad_kondo_nbodyg_particle "does not conserve particle numbers"
+expect_fail bad_tjn "NBodyInterAll does not support tJNConserved"
+expect_fail bad_kondon "NBodyInterAll does not support tJNConserved or KondoNConserved"
+expect_fail bad_kondo_local_cross "Kondo local-spin NBodyInterAll factors require site_out == site_in"
+
+echo "tJ/Kondo NBody validation accepts supported sectors and rejects unsupported N-conserved/local-spin cases."


### PR DESCRIPTION
## Summary

This PR extends NBody support to `tJ`, `tJGC`, `Kondo`, and `KondoGC` models.

It enables both `NBodyInterAll` and `NBodyG` for these models by routing them through the canonical Hubbard list-basis path, matching the design already used for spinful fermion models.

## Changes

- Enable `NBodyInterAll` for `tJ/tJGC/Kondo/KondoGC`.
- Enable `NBodyG` for `tJ/tJGC/Kondo/KondoGC`.
- Route tJ/Kondo NBody paths through the canonical Hubbard list helpers for:
  - matrix-vector multiplication
  - FullDiag Hamiltonian construction
  - diagonal contribution evaluation
  - NBody correlation evaluation
- Require spinful particle-number conservation for standard `tJ` and `Kondo`.
- Reject `tJNConserved` and `KondoNConserved` NBody use with guidance to define `2Sz`.
- Add Kondo-specific validation for local-spin factors.
- Add regression tests covering:
  - validation success/failure cases
  - Lanczos comparison against legacy `InterAll`
  - FullDiag comparison against legacy `InterAll` / diagonal `Trans`
  - diagonal N=1 NBody terms
  - `NBodyG` output generation

## Validation

```sh
ctest --test-dir build -R '^(lanczos_tj_kondo_nbody_interall|nbody_tj_kondo_validation|fulldiag_tj_kondo_nbody_interall|nbody_hubbard_validation|nbody_hubbardgc_validation|lanczos_hubbard_nbody_interall|lanczos_hubbard_nbodyg|nbody_spinless_validation)$' --output-on-failure\n```\n\nResult: all 8 tests passed.\n\n```sh\nMPIRUN='mpirun --oversubscribe -np 16' ctest --test-dir build -R '^lanczos_tj_kondo_nbody_interall$' --output-on-failure\n```\n\nResult: passed.\n\n```sh\ngit diff --check\n```\n\nResult: passed.