### PR TITLE
Add KondoNConserved regression tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -222,6 +222,7 @@ add_test(
     COMMAND ${CMAKE_SOURCE_DIR}/test/fulldiag_ham_io.sh
 )
 add_hphi_test(fulldiag_kondo_chain)
+add_hphi_test(kondo_nconserved_dimension)
 add_hphi_test(fulldiag_spin_tri)
 add_hphi_test(fulldiag_genspin_ladder)
 add_hphi_test(fulldiag_hubbardgc_tri)
@@ -242,6 +243,9 @@ set_tests_properties(
 set_tests_properties(
     fulldiag_kondo_chain fulldiag_kondogc_chain
     PROPERTIES LABELS "fulldiag;kondo")
+set_tests_properties(
+    kondo_nconserved_dimension
+    PROPERTIES LABELS "fulldiag;kondo;validation")
 set_tests_properties(
     fulldiag_tj_calchs1
     PROPERTIES LABELS "fulldiag;tj")
@@ -425,6 +429,7 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_consistency_spin min:2)
     add_hphi_mpi_test(mpi_consistency_spingc min:2)
     add_hphi_mpi_test(mpi_consistency_kondo min:2)
+    add_hphi_mpi_test(mpi_consistency_kondo_nconserved_cg exact:4)
     add_hphi_mpi_test(mpi_consistency_te_hubbard min:2)
     add_hphi_mpi_test(mpi_consistency_te_spin min:2)
     add_hphi_mpi_test_with_srcdir(mpi_consistency_spinless min:2)
@@ -494,7 +499,8 @@ if(MPI_FOUND)
         mpi_nbodyg_spin_spinone_np9
         PROPERTIES LABELS "mpi;consistency;genspin;spinone;nbody")
     set_tests_properties(
-        mpi_consistency_kondo mpi_consistency_te_kondo
+        mpi_consistency_kondo mpi_consistency_kondo_nconserved_cg
+        mpi_consistency_te_kondo
         PROPERTIES LABELS "mpi;consistency;kondo")
     set_tests_properties(
         mpi_consistency_spinless mpi_consistency_spinless_GC

--- a/test/kondo_nconserved_dimension.sh
+++ b/test/kondo_nconserved_dimension.sh
@@ -1,0 +1,117 @@
+#!/bin/sh -e
+
+# Regression test for Kondo + ncond without 2Sz.
+#
+# This standard input is internally promoted to KondoNConserved.  The test is
+# intentionally serial-only even when the surrounding CI job defines MPIRUN:
+# it verifies basis construction and CalcHS dispatch, not MPI decomposition.
+
+testname="kondo_nconserved_dimension"
+hphi="../../../src/HPhi"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+fail() {
+  echo "FAILED (${testname}): $1" >&2
+  exit 1
+}
+
+write_standard_input() {
+  ncond=$1
+  cat > stan.in <<EOF
+L = 4
+model = "Kondo"
+method = "FullDiag"
+lattice = "chain"
+t = 0.0
+J = 0.0
+ncond = ${ncond}
+exct = 1
+EOF
+}
+
+assert_dimension() {
+  label=$1
+  expected=$2
+  log=$3
+
+  if grep -q "Error: in sz" "${log}"; then
+    cat "${log}"
+    fail "${label}: sz() enumeration is inconsistent with idim_max"
+  fi
+
+  idim=$(sed -n 's/.*idim_max=[[:space:]]*\([0-9][0-9]*\).*/\1/p' "${log}" | tail -1)
+  total=$(sed -n 's/.*Total dimension[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "${log}" | tail -1)
+
+  [ "x${idim}" = "x${expected}" ] || {
+    cat "${log}"
+    fail "${label}: idim_max ${idim:-<missing>} != expected ${expected}"
+  }
+  [ "x${total}" = "x${expected}" ] || {
+    cat "${log}"
+    fail "${label}: total dimension ${total:-<missing>} != expected ${expected}"
+  }
+}
+
+run_standard_case() {
+  label=$1
+  calchs=$2
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  (
+    cd "${label}"
+    write_standard_input 2
+    "${hphi}" -sdry stan.in > gen.log 2>&1 || { cat gen.log; fail "${label}: standard input generation failed"; }
+    echo "CalcHS         ${calchs}" >> modpara.def
+
+    rm -rf output
+    mkdir -p output
+    "${hphi}" -e namelist.def > run.log 2>&1 || { cat run.log; fail "${label}: HPhi failed"; }
+    assert_dimension "${label}" 448 run.log
+  )
+}
+
+run_sparse_local_spin_case() {
+  label="sparse_local_spins"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  (
+    cd "${label}"
+    write_standard_input 3
+    "${hphi}" -sdry stan.in > gen.log 2>&1 || { cat gen.log; fail "${label}: standard input generation failed"; }
+
+    # Replace the all-local-spin standard Kondo layout by a dilute Kondo
+    # expert layout: Nsite=8, NlocalSpin=2, NsCond=6, ncond=3.
+    # Expected dimension: 2^2 * sum_k C(6,k) C(6,3-k) = 880.
+    cat > locspn.def <<EOF
+================================
+NlocalSpin     2
+================================
+========i_1LocSpn_0IteElc ======
+================================
+    0      1
+    1      1
+    2      0
+    3      0
+    4      0
+    5      0
+    6      0
+    7      0
+EOF
+    echo "CalcHS         1" >> modpara.def
+
+    rm -rf output
+    mkdir -p output
+    "${hphi}" -e namelist.def > run.log 2>&1 || { cat run.log; fail "${label}: HPhi failed"; }
+    assert_dimension "${label}" 880 run.log
+  )
+}
+
+run_standard_case standard_calchs0 0
+run_standard_case standard_calchs1 1
+run_sparse_local_spin_case
+
+echo "KondoNConserved dimension and CalcHS=0/1 checks passed."

--- a/test/mpi_consistency_kondo_nconserved_cg.sh
+++ b/test/mpi_consistency_kondo_nconserved_cg.sh
@@ -1,0 +1,81 @@
+#!/bin/sh -e
+
+# MPI consistency test for Kondo + ncond without 2Sz in CG mode.
+# The input is internally promoted to KondoNConserved.  Compare a serial run
+# against a 4-rank MPI run so the particle-number-conserved, Sz-unconserved
+# basis is exercised in the normal iterative-solver path, not only FullDiag.
+
+testname="mpi_consistency_kondo_nconserved_cg"
+tolerance="0.000001"
+
+if [ -z "${MPIRUN}" ]; then
+  echo "Error: MPIRUN is not set. Please set MPIRUN to run MPI tests."
+  exit 1
+fi
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+fail() {
+  echo "FAILED (${testname}): $1" >&2
+  exit 1
+}
+
+write_input() {
+  cat > stan.in <<EOF
+model = "Kondo"
+method = "CG"
+lattice = "chain"
+L = 4
+t = 1.0
+J = 4.0
+ncond = 2
+exct = 1
+EOF
+}
+
+extract_energy() {
+  awk '$1 == "Energy" { print $2; exit }' "$1"
+}
+
+assert_total_dimension() {
+  label=$1
+  log=$2
+  expected=$3
+
+  total=$(sed -n 's/.*Total dimension[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "${log}" | tail -1)
+  [ "x${total}" = "x${expected}" ] || {
+    cat "${log}"
+    fail "${label}: total dimension ${total:-<missing>} != expected ${expected}"
+  }
+}
+
+write_input
+
+rm -rf output
+../../src/HPhi -s stan.in > serial.log 2>&1 || { cat serial.log; fail "serial HPhi failed"; }
+assert_total_dimension serial serial.log 448
+serial_energy=$(extract_energy output/zvo_energy.dat)
+[ -n "${serial_energy}" ] || fail "serial energy was not written"
+
+rm -rf output
+${MPIRUN} ../../src/HPhi -s stan.in > mpi.log 2>&1 || { cat mpi.log; fail "MPI HPhi failed"; }
+assert_total_dimension mpi mpi.log 448
+mpi_energy=$(extract_energy output/zvo_energy.dat)
+[ -n "${mpi_energy}" ] || fail "MPI energy was not written"
+
+diff=$(awk -v a="${serial_energy}" -v b="${mpi_energy}" 'BEGIN {
+  d = a - b
+  if (d < 0) d = -d
+  printf "%.12f", d
+}')
+
+echo "KondoNConserved CG serial energy: ${serial_energy}"
+echo "KondoNConserved CG MPI energy:    ${mpi_energy}"
+echo "Energy difference: ${diff}"
+
+awk -v d="${diff}" -v t="${tolerance}" 'BEGIN { exit (d < t) ? 0 : 1 }' || {
+  fail "energy mismatch: |serial - MPI| = ${diff} >= ${tolerance}"
+}
+
+echo "KondoNConserved CG MPI consistency check passed."


### PR DESCRIPTION
## Summary

This PR adds regression coverage for the Kondo model with `ncond` specified and `2Sz` omitted, which is internally handled as `KondoNConserved`.

No production code is changed. This PR only adds tests.

## What is covered

- Adds `kondo_nconserved_dimension`
  - checks `Kondo + ncond + no 2Sz` in FullDiag mode
  - verifies `CalcHS=0` and `CalcHS=1` both produce dimension `448`
  - verifies a dilute local-spin layout produces dimension `880`
  - keeps this test serial-only because LAPACK FullDiag is only valid with one process

- Adds `mpi_consistency_kondo_nconserved_cg`
  - checks `Kondo + ncond + no 2Sz` in `method = "CG"`
  - compares serial and MPI results
  - runs only at `np=4` via `exact:4`

The dilute case uses `Nsite=8`, `NlocalSpin=2`, `NsCond=6`, `ncond=3`, and protects the dimension path where `2 * NsCond > Nsite`.

## Tests

```sh
ctest --test-dir build -R kondo_nconserved_dimension --output-on-failure
MPIRUN='mpiexec --oversubscribe -np 4' ctest --test-dir build -R '^mpi_consistency_kondo' --output-on-failure
MPIRUN='mpiexec --oversubscribe -np 16' ctest --test-dir build -R mpi_consistency_kondo_nconserved_cg --output-on-failure
MPIRUN='mpiexec --oversubscribe -np 16' ctest --test-dir build -R kondo_nconserved_dimension --output-on-failure
```

All passed as expected. The `np=16` run for `mpi_consistency_kondo_nconserved_cg` is skipped by the `exact:4` precheck.
