### PR TITLE
Support KondoNConserved NBody operators

### DIFF
--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -111,7 +111,9 @@ static int nbodyg_is_tj_model(const struct DefineList *D)
 
 static int nbodyg_is_kondo_model(const struct DefineList *D)
 {
-  return D->iCalcModel == Kondo || D->iCalcModel == KondoGC;
+  return D->iCalcModel == Kondo ||
+         D->iCalcModel == KondoGC ||
+         D->iCalcModel == KondoNConserved;
 }
 
 static int nbodyg_is_spinless_model(const struct DefineList *D)
@@ -146,7 +148,8 @@ static int nbodyg_uses_hubbard_list_path(const struct DefineList *D)
          D->iCalcModel == tJ ||
          D->iCalcModel == tJGC ||
          D->iCalcModel == Kondo ||
-         D->iCalcModel == KondoGC;
+         D->iCalcModel == KondoGC ||
+         D->iCalcModel == KondoNConserved;
 }
 
 static int nbodyg_requires_spinful_conservation(const struct DefineList *D)
@@ -158,7 +161,7 @@ static int nbodyg_requires_spinful_conservation(const struct DefineList *D)
 
 static int nbodyg_is_unsupported_nconserved_model(const struct DefineList *D)
 {
-  return D->iCalcModel == tJNConserved || D->iCalcModel == KondoNConserved;
+  return D->iCalcModel == tJNConserved;
 }
 
 static int nbodyg_is_general_spin(const struct DefineList *D)
@@ -174,14 +177,14 @@ int ValidateNBodyGScope(const struct DefineList *D)
   if (nbodyg_is_supported_model(D) == FALSE) {
     if (nbodyg_is_unsupported_nconserved_model(D) == TRUE) {
       fprintf(stdoutMPI,
-              "Error: NBodyG does not support tJNConserved or KondoNConserved. "
-              "For tJ/Kondo standard input, define 2Sz to use the Sz-conserved model.\n");
+              "Error: NBodyG does not support tJNConserved. "
+              "For tJ standard input, define 2Sz to use the Sz-conserved model.\n");
     }
     else {
       fprintf(stdoutMPI,
               "Error: NBodyG is currently supported only for SpinGC, Spin, "
               "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
-              "tJGC, tJ, KondoGC, and Kondo.\n");
+              "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
     }
     return -1;
   }
@@ -1450,7 +1453,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
     fprintf(stdoutMPI,
             "Error: NBodyG is currently supported only for SpinGC, Spin, "
             "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
-            "tJGC, tJ, KondoGC, and Kondo.\n");
+            "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;

--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -188,6 +188,10 @@ int ValidateNBodyGScope(const struct DefineList *D)
     }
     return -1;
   }
+  if (D->iCalcModel == KondoNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
+    fprintf(stdoutMPI, "Error: NBodyG does not support KondoNConserved with CalcSpec.\n");
+    return -1;
+  }
   if (nbodyg_is_kondo_model(D) == TRUE) {
     unsigned int site;
     for (site = 0; site < D->Nsite; site++) {

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -224,6 +224,10 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
     fprintf(stdoutMPI, "Error: NBodyInterAll is not yet supported in TimeEvolution.\n");
     return -1;
   }
+  if (D->iCalcModel == KondoNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
+    fprintf(stdoutMPI, "Error: NBodyInterAll does not support KondoNConserved with CalcSpec.\n");
+    return -1;
+  }
   if (nbody_is_spinless_model(D) == TRUE && D->iCalcType == FullDiag) {
     fprintf(stdoutMPI, "Error: NBodyInterAll is not yet supported in FullDiag for SpinlessFermion / SpinlessFermionGC.\n");
     return -1;

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -143,7 +143,9 @@ static int nbody_is_tj_model(const struct DefineList *D)
 
 static int nbody_is_kondo_model(const struct DefineList *D)
 {
-  return D->iCalcModel == Kondo || D->iCalcModel == KondoGC;
+  return D->iCalcModel == Kondo ||
+         D->iCalcModel == KondoGC ||
+         D->iCalcModel == KondoNConserved;
 }
 
 static int nbody_is_spinless_model(const struct DefineList *D)
@@ -178,7 +180,8 @@ static int nbody_uses_hubbard_list_path(const struct DefineList *D)
          D->iCalcModel == tJ ||
          D->iCalcModel == tJGC ||
          D->iCalcModel == Kondo ||
-         D->iCalcModel == KondoGC;
+         D->iCalcModel == KondoGC ||
+         D->iCalcModel == KondoNConserved;
 }
 
 static int nbody_requires_spinful_conservation(const struct DefineList *D)
@@ -190,7 +193,7 @@ static int nbody_requires_spinful_conservation(const struct DefineList *D)
 
 static int nbody_is_unsupported_nconserved_model(const struct DefineList *D)
 {
-  return D->iCalcModel == tJNConserved || D->iCalcModel == KondoNConserved;
+  return D->iCalcModel == tJNConserved;
 }
 
 static int nbody_is_general_spin(const struct DefineList *D)
@@ -206,14 +209,14 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   if (nbody_is_supported_model(D) == FALSE) {
     if (nbody_is_unsupported_nconserved_model(D) == TRUE) {
       fprintf(stdoutMPI,
-              "Error: NBodyInterAll does not support tJNConserved or KondoNConserved. "
-              "For tJ/Kondo standard input, define 2Sz to use the Sz-conserved model.\n");
+              "Error: NBodyInterAll does not support tJNConserved. "
+              "For tJ standard input, define 2Sz to use the Sz-conserved model.\n");
     }
     else {
       fprintf(stdoutMPI,
               "Error: NBodyInterAll is currently supported only for SpinGC, Spin, "
               "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
-              "tJGC, tJ, KondoGC, and Kondo.\n");
+              "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
     }
     return -1;
   }

--- a/src/sz.c
+++ b/src/sz.c
@@ -424,7 +424,6 @@ int sz(
                       for(ib=0;ib<X->Check.sdim;ib++){
                           icnt+=omp_sz_KondoNConserved(ib,ihfbit, X, list_1_, list_2_1_, list_2_2_, list_jb);
                       }
-                      BarrierMPI();
                       //printf("AAA icnt=%ld\n",icnt);
                       break;
                   case Kondo:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -459,6 +459,7 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_nbodyg_hubbardgc exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_hubbard exact:4)
     add_hphi_mpi_test(mpi_nbodyg_hubbard exact:4)
+    add_hphi_mpi_test(mpi_nbody_interall_kondo_nconserved exact:4)
     add_hphi_mpi_test_with_srcdir(mpi_nbody_interall_spinless exact:4)
     add_hphi_mpi_test_with_srcdir(mpi_nbodyg_spinless exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_spin exact:4)
@@ -508,6 +509,9 @@ if(MPI_FOUND)
     set_tests_properties(
         mpi_consistency_kondo mpi_consistency_te_kondo
         PROPERTIES LABELS "mpi;consistency;kondo")
+    set_tests_properties(
+        mpi_nbody_interall_kondo_nconserved
+        PROPERTIES LABELS "mpi;consistency;kondo;nbody")
     set_tests_properties(
         mpi_consistency_spinless mpi_consistency_spinless_GC
         PROPERTIES LABELS "mpi;consistency;spinless")

--- a/test/fulldiag_tj_kondo_nbody_interall.sh
+++ b/test/fulldiag_tj_kondo_nbody_interall.sh
@@ -125,6 +125,26 @@ EOF
   cd ..
 }
 
+make_kondon_base() {
+  dir="$1"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "Kondo"
+method = "FullDiag"
+lattice = "chain"
+L = 2
+t = 0.0
+J = 0.0
+ncond = 2
+Lanczos_max = 120
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  cd ..
+}
+
 write_tj_nbody() {
   cat > nbodyinterall.def <<EOF
 ========================
@@ -172,6 +192,30 @@ NInterAll      2
 ======================
 2 0 2 1 0 1 0 0 0.2500000000000000 0.0700000000000000
 0 0 0 1 2 1 2 0 0.2500000000000000 -0.0700000000000000
+EOF
+}
+
+write_kondon_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 1 0.2300000000000000 0.0500000000000000
+1 0 1 0 0 0.2300000000000000 -0.0500000000000000
+EOF
+}
+
+write_kondon_transfer() {
+  cat > trans.def <<EOF
+========================
+NTransfer      2
+========================
+========i_j_s_tijs======
+========================
+0 0 0 1 0.2300000000000000 0.0500000000000000
+0 1 0 0 0.2300000000000000 -0.0500000000000000
 EOF
 }
 
@@ -271,9 +315,36 @@ run_kondo_case() {
   cd ..
 }
 
+run_kondon_case() {
+  label="$1"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_kondon_base nbody
+  make_kondon_base legacy
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_kondon_nbody
+  run_hphi log_nbody.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  write_kondon_transfer
+  run_hphi log_legacy.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
 run_tj_case tj 9
 run_tj_case tjgc 10
 run_kondo_case kondo Kondo
 run_kondo_case kondogc KondoGC
+run_kondon_case kondon
 
-echo "tJ/tJGC/Kondo/KondoGC NBodyInterAll N=2 terms match legacy InterAll in FullDiag."
+echo "tJ/tJGC/Kondo/KondoGC/KondoNConserved NBodyInterAll terms match legacy operators in FullDiag."

--- a/test/lanczos_tj_kondo_nbody_interall.sh
+++ b/test/lanczos_tj_kondo_nbody_interall.sh
@@ -111,6 +111,26 @@ EOF
   cd ..
 }
 
+make_kondon_base() {
+  dir="$1"
+
+  mkdir -p "${dir}"
+  cd "${dir}"
+  cat > stan.in <<EOF
+model = "Kondo"
+method = "Lanczos"
+lattice = "chain"
+L = 2
+t = 0.0
+J = 0.0
+ncond = 2
+Lanczos_max = 1000
+initial_iv = 1
+EOF
+  run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+  cd ..
+}
+
 write_tj_nbody() {
   cat > nbodyinterall.def <<EOF
 ========================
@@ -156,6 +176,30 @@ NInterAll      2
 ======================
 2 0 2 1 0 1 0 0 0.1700000000000000 0.0300000000000000
 0 0 0 1 2 1 2 0 0.1700000000000000 -0.0300000000000000
+EOF
+}
+
+write_kondon_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 1 0.1300000000000000 0.0200000000000000
+1 0 1 0 0 0.1300000000000000 -0.0200000000000000
+EOF
+}
+
+write_kondon_transfer() {
+  cat > trans.def <<EOF
+========================
+NTransfer      2
+========================
+========i_j_s_tijs======
+========================
+0 0 0 1 0.1300000000000000 0.0200000000000000
+0 1 0 0 0.1300000000000000 -0.0200000000000000
 EOF
 }
 
@@ -225,9 +269,36 @@ run_kondo_case() {
   cd ..
 }
 
+run_kondon_case() {
+  label="$1"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_kondon_base nbody
+  make_kondon_base legacy
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_kondon_nbody
+  run_hphi log_nbody.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  write_kondon_transfer
+  run_hphi log_legacy.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
 run_tj_case tj 9
 run_tj_case tjgc 10
 run_kondo_case kondo Kondo
 run_kondo_case kondogc KondoGC
+run_kondon_case kondon
 
-echo "tJ/tJGC/Kondo/KondoGC NBodyInterAll mltply terms match legacy InterAll in Lanczos."
+echo "tJ/tJGC/Kondo/KondoGC/KondoNConserved NBodyInterAll mltply terms match legacy operators in Lanczos."

--- a/test/mpi_nbody_interall_kondo_nconserved.sh
+++ b/test/mpi_nbody_interall_kondo_nconserved.sh
@@ -20,10 +20,10 @@ model = "Kondo"
 method = "Lanczos"
 lattice = "chain"
 L = 4
-t = 0.0
-J = 0.0
+t = 1.0
+J = 0.5
 ncond = 2
-Lanczos_max = 1000
+Lanczos_max = 2000
 initial_iv = 1
 EOF
 }
@@ -35,9 +35,24 @@ NNBodyInterAll 2
 ========================
 ========NBodyInterAll===
 ========================
-1 0 0 0 1 0.1300000000000000 0.0200000000000000
-1 0 1 0 0 0.1300000000000000 -0.0200000000000000
+1 7 0 7 1 0.3000000000000000 0.1000000000000000
+1 7 1 7 0 0.3000000000000000 -0.1000000000000000
 EOF
+}
+
+append_transfer_reference() {
+  awk '
+    $1 == "NTransfer" {
+      printf "%s      %d\n", $1, $2 + 2
+      next
+    }
+    { print }
+    END {
+      printf "7 0 7 1 0.3000000000000000 0.1000000000000000\n"
+      printf "7 1 7 0 0.3000000000000000 -0.1000000000000000\n"
+    }
+  ' trans.def > trans.def.tmp
+  mv trans.def.tmp trans.def
 }
 
 assert_total_dimension() {
@@ -52,8 +67,21 @@ assert_total_dimension() {
   }
 }
 
-rm -rf serial mpi
-mkdir -p serial mpi
+compare_energy() {
+  label="$1"
+  lhs="$2"
+  rhs="$3"
+  diff=$(paste "${lhs}" "${rhs}" \
+    | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${label}: energy mismatch: max diff ${diff}"
+    paste "${lhs}" "${rhs}"
+    exit 1
+  }
+}
+
+rm -rf serial mpi legacy
+mkdir -p serial mpi legacy
 
 cd serial
 write_input
@@ -65,6 +93,15 @@ assert_total_dimension serial log_serial.txt 448
 cp output/zvo_energy.dat ../energy_serial.dat
 cd ..
 
+cd legacy
+write_input
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+append_transfer_reference
+run_hphi log_legacy.txt "${hphi}" -e namelist.def
+assert_total_dimension legacy log_legacy.txt 448
+cp output/zvo_energy.dat ../energy_legacy.dat
+cd ..
+
 cp serial/*.def mpi/
 cd mpi
 run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
@@ -72,12 +109,13 @@ assert_total_dimension mpi log_mpi.txt 448
 cp output/zvo_energy.dat ../energy_mpi.dat
 cd ..
 
-diff=$(paste energy_serial.dat energy_mpi.dat \
-  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
-awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
-  echo "Serial/MPI KondoNConserved NBodyInterAll energy mismatch: max diff ${diff}"
-  paste energy_serial.dat energy_mpi.dat
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
   exit 1
 }
 
-echo "KondoNConserved NBodyInterAll MPI energy matches serial energy."
+compare_energy "KondoNConserved NBodyInterAll serial vs legacy Trans" energy_serial.dat energy_legacy.dat
+compare_energy "KondoNConserved NBodyInterAll serial vs MPI" energy_serial.dat energy_mpi.dat
+
+echo "KondoNConserved inter-process NBodyInterAll MPI energy matches serial and legacy Trans."

--- a/test/mpi_nbody_interall_kondo_nconserved.sh
+++ b/test/mpi_nbody_interall_kondo_nconserved.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+set -e
+
+testname="mpi_nbody_interall_kondo_nconserved"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+write_input() {
+  cat > stan.in <<EOF
+model = "Kondo"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 0.0
+J = 0.0
+ncond = 2
+Lanczos_max = 1000
+initial_iv = 1
+EOF
+}
+
+write_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 1 0.1300000000000000 0.0200000000000000
+1 0 1 0 0 0.1300000000000000 -0.0200000000000000
+EOF
+}
+
+assert_total_dimension() {
+  label="$1"
+  log="$2"
+  expected="$3"
+  total=$(sed -n 's/.*Total dimension[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "${log}" | tail -1)
+  [ "x${total}" = "x${expected}" ] || {
+    echo "${label}: total dimension ${total:-<missing>} != expected ${expected}"
+    cat "${log}"
+    exit 1
+  }
+}
+
+rm -rf serial mpi
+mkdir -p serial mpi
+
+cd serial
+write_input
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+write_nbody
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+assert_total_dimension serial log_serial.txt 448
+cp output/zvo_energy.dat ../energy_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+assert_total_dimension mpi log_mpi.txt 448
+cp output/zvo_energy.dat ../energy_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "Serial/MPI KondoNConserved NBodyInterAll energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+echo "KondoNConserved NBodyInterAll MPI energy matches serial energy."

--- a/test/nbody_tj_kondo_validation.sh
+++ b/test/nbody_tj_kondo_validation.sh
@@ -155,7 +155,7 @@ EOF
       printf "2Sz = 0\n"
     } >> stan.in
   elif [ "${write_sector}" = "ncond" ]; then
-    printf "nelec = 2\n" >> stan.in
+    printf "ncond = 2\n" >> stan.in
   fi
   run_hphi log_sdry.txt "${hphi}" -sdry stan.in
   printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
@@ -163,8 +163,8 @@ EOF
   cd ..
 }
 
-rm -rf accept_tj accept_tjgc accept_kondo accept_kondogc \
-  bad_tj_particle bad_kondo_nbodyg_particle bad_tjn bad_kondon bad_kondo_local_cross
+rm -rf accept_tj accept_tjgc accept_kondo accept_kondogc accept_kondon \
+  bad_tj_particle bad_kondo_nbodyg_particle bad_tjn bad_kondo_local_cross
 
 make_tj_base accept_tj 9 yes
 cat > accept_tj/nbodyinterall.def <<EOF
@@ -240,6 +240,25 @@ NNBodyG 1
 1 0 1 0 0
 EOF
 
+make_kondo_base accept_kondon Kondo ncond
+cat > accept_kondon/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 1 0.1000000000000000 0.0200000000000000
+1 0 1 0 0 0.1000000000000000 -0.0200000000000000
+EOF
+cat > accept_kondon/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 1
+EOF
+
 make_tj_base bad_tj_particle 9 yes
 cat > bad_tj_particle/nbodyinterall.def <<EOF
 ========================
@@ -291,23 +310,6 @@ NNBodyG 0
 ========================
 EOF
 
-make_kondo_base bad_kondon Kondo ncond
-cat > bad_kondon/nbodyinterall.def <<EOF
-========================
-NNBodyInterAll 1
-========================
-========NBodyInterAll===
-========================
-1 0 0 0 0 0.1000000000000000 0.0000000000000000
-EOF
-cat > bad_kondon/nbodyg.def <<EOF
-========================
-NNBodyG 0
-========================
-========NBodyG==========
-========================
-EOF
-
 make_kondo_base bad_kondo_local_cross KondoGC no
 cat > bad_kondo_local_cross/nbodyinterall.def <<EOF
 ========================
@@ -341,11 +343,14 @@ cd accept_kondogc
 run_hphi log_accept.txt "${hphi}" -e namelist.def
 cd ..
 check_nbodyg_output accept_kondogc
+cd accept_kondon
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+check_nbodyg_output accept_kondon
 
 expect_fail bad_tj_particle "does not conserve particle numbers"
 expect_fail bad_kondo_nbodyg_particle "does not conserve particle numbers"
 expect_fail bad_tjn "NBodyInterAll does not support tJNConserved"
-expect_fail bad_kondon "NBodyInterAll does not support tJNConserved or KondoNConserved"
 expect_fail bad_kondo_local_cross "Kondo local-spin NBodyInterAll factors require site_out == site_in"
 
-echo "tJ/Kondo NBody validation accepts supported sectors and rejects unsupported N-conserved/local-spin cases."
+echo "tJ/Kondo NBody validation accepts supported sectors and rejects unsupported tJ N-conserved/local-spin cases."

--- a/test/nbody_tj_kondo_validation.sh
+++ b/test/nbody_tj_kondo_validation.sh
@@ -163,8 +163,22 @@ EOF
   cd ..
 }
 
+set_calcspec() {
+  dir="$1"
+  value="$2"
+  awk -v value="${value}" '
+    $1 == "CalcSpec" {
+      printf "CalcSpec        %s\n", value
+      next
+    }
+    { print }
+  ' "${dir}/calcmod.def" > "${dir}/calcmod.def.tmp"
+  mv "${dir}/calcmod.def.tmp" "${dir}/calcmod.def"
+}
+
 rm -rf accept_tj accept_tjgc accept_kondo accept_kondogc accept_kondon \
-  bad_tj_particle bad_kondo_nbodyg_particle bad_tjn bad_kondo_local_cross
+  bad_tj_particle bad_kondo_nbodyg_particle bad_tjn bad_kondo_local_cross \
+  bad_kondon_spectrum_interall bad_kondon_spectrum_nbodyg
 
 make_tj_base accept_tj 9 yes
 cat > accept_tj/nbodyinterall.def <<EOF
@@ -327,6 +341,42 @@ NNBodyG 0
 ========================
 EOF
 
+make_kondo_base bad_kondon_spectrum_interall Kondo ncond
+set_calcspec bad_kondon_spectrum_interall 1
+cat > bad_kondon_spectrum_interall/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 1 0.1000000000000000 0.0200000000000000
+EOF
+cat > bad_kondon_spectrum_interall/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_kondo_base bad_kondon_spectrum_nbodyg Kondo ncond
+set_calcspec bad_kondon_spectrum_nbodyg 1
+cat > bad_kondon_spectrum_nbodyg/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > bad_kondon_spectrum_nbodyg/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 1
+EOF
+
 cd accept_tj
 run_hphi log_accept.txt "${hphi}" -e namelist.def
 cd ..
@@ -352,5 +402,7 @@ expect_fail bad_tj_particle "does not conserve particle numbers"
 expect_fail bad_kondo_nbodyg_particle "does not conserve particle numbers"
 expect_fail bad_tjn "NBodyInterAll does not support tJNConserved"
 expect_fail bad_kondo_local_cross "Kondo local-spin NBodyInterAll factors require site_out == site_in"
+expect_fail bad_kondon_spectrum_interall "NBodyInterAll does not support KondoNConserved with CalcSpec"
+expect_fail bad_kondon_spectrum_nbodyg "NBodyG does not support KondoNConserved with CalcSpec"
 
-echo "tJ/Kondo NBody validation accepts supported sectors and rejects unsupported tJ N-conserved/local-spin cases."
+echo "tJ/Kondo NBody validation accepts supported sectors and rejects unsupported tJ N-conserved/local-spin/CalcSpec cases."


### PR DESCRIPTION
## Summary

This PR enables `NBodyInterAll` / `NBodyG` for `KondoNConserved` (`model = Kondo` with `ncond` and without `2Sz`).

Changes:
- Allow `KondoNConserved` in the Kondo NBody validation/classification paths.
- Treat `KondoNConserved` as the existing spinful Kondo/Hubbard list path for NBody execution.
- Do not apply per-spin `Nup`/`Ndown` conservation checks to `KondoNConserved`, so Sz-changing NBody terms are accepted.
- Keep the existing Kondo local-spin constraints for NBody operators.
- Explicitly reject `KondoNConserved + CalcSpec + NBodyInterAll/NBodyG`, because the `sz()` remap to `Kondo` is not applied in CalcSpec mode.
- Add validation and regression coverage, including serial/MPI/legacy `Trans` comparison.

## Relation to other PRs

This PR is stacked on top of #247, which adds the common tJ/Kondo NBody support.

#248 adds regression coverage for existing `KondoNConserved` basis/dimension behavior. It does not implement NBody support. This PR complements #248 by enabling and testing NBody operators for `KondoNConserved`.

## Testing

Passed locally:

```sh
cmake --build build -j2

ctest --test-dir build -R '^(nbody_tj_kondo_validation|lanczos_tj_kondo_nbody_interall|fulldiag_tj_kondo_nbody_interall)$' --output-on-failure

MPIRUN='mpirun --oversubscribe -np 4' \
  ctest --test-dir build -R '^mpi_nbody_interall_kondo_nconserved$' --output-on-failure

MPIRUN='mpirun --oversubscribe -np 4' \
  ctest --test-dir build -L nbody --output-on-failure

MPIRUN='mpirun --oversubscribe -np 4' \
  ctest --test-dir build -L kondo --output-on-failure
```

Results:
- targeted NBody/KondoNConserved tests: pass
- `nbody` label: 22 pass / 8 skip / 0 fail
- `kondo` label: 17/17 pass
