### PR TITLE
Support HubbardNConserved NBody operators

### DIFF
--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -101,7 +101,9 @@ int ParseNBodyGLine(
 
 static int nbodyg_is_hubbard_model(const struct DefineList *D)
 {
-  return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
+  return D->iCalcModel == Hubbard ||
+         D->iCalcModel == HubbardGC ||
+         D->iCalcModel == HubbardNConserved;
 }
 
 static int nbodyg_is_tj_model(const struct DefineList *D)
@@ -145,6 +147,7 @@ static int nbodyg_is_supported_model(const struct DefineList *D)
 static int nbodyg_uses_hubbard_list_path(const struct DefineList *D)
 {
   return D->iCalcModel == Hubbard ||
+         D->iCalcModel == HubbardNConserved ||
          D->iCalcModel == tJ ||
          D->iCalcModel == tJGC ||
          D->iCalcModel == Kondo ||
@@ -183,13 +186,17 @@ int ValidateNBodyGScope(const struct DefineList *D)
     else {
       fprintf(stdoutMPI,
               "Error: NBodyG is currently supported only for SpinGC, Spin, "
-              "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
+              "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
               "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
     }
     return -1;
   }
   if (D->iCalcModel == KondoNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
     fprintf(stdoutMPI, "Error: NBodyG does not support KondoNConserved with CalcSpec.\n");
+    return -1;
+  }
+  if (D->iCalcModel == HubbardNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
+    fprintf(stdoutMPI, "Error: NBodyG does not support HubbardNConserved with CalcSpec.\n");
     return -1;
   }
   if (nbodyg_is_kondo_model(D) == TRUE) {
@@ -1456,7 +1463,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
   if (nbodyg_is_supported_model(&X->Def) == FALSE) {
     fprintf(stdoutMPI,
             "Error: NBodyG is currently supported only for SpinGC, Spin, "
-            "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
+            "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
             "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
     return -1;
   }

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -133,7 +133,9 @@ static int nbody_is_supported_spin_model(const struct DefineList *D)
 
 static int nbody_is_hubbard_model(const struct DefineList *D)
 {
-  return D->iCalcModel == Hubbard || D->iCalcModel == HubbardGC;
+  return D->iCalcModel == Hubbard ||
+         D->iCalcModel == HubbardGC ||
+         D->iCalcModel == HubbardNConserved;
 }
 
 static int nbody_is_tj_model(const struct DefineList *D)
@@ -177,6 +179,7 @@ static int nbody_is_supported_model(const struct DefineList *D)
 static int nbody_uses_hubbard_list_path(const struct DefineList *D)
 {
   return D->iCalcModel == Hubbard ||
+         D->iCalcModel == HubbardNConserved ||
          D->iCalcModel == tJ ||
          D->iCalcModel == tJGC ||
          D->iCalcModel == Kondo ||
@@ -215,7 +218,7 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
     else {
       fprintf(stdoutMPI,
               "Error: NBodyInterAll is currently supported only for SpinGC, Spin, "
-              "HubbardGC, Hubbard, SpinlessFermionGC, SpinlessFermion, "
+              "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
               "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
     }
     return -1;
@@ -226,6 +229,10 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   }
   if (D->iCalcModel == KondoNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
     fprintf(stdoutMPI, "Error: NBodyInterAll does not support KondoNConserved with CalcSpec.\n");
+    return -1;
+  }
+  if (D->iCalcModel == HubbardNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
+    fprintf(stdoutMPI, "Error: NBodyInterAll does not support HubbardNConserved with CalcSpec.\n");
     return -1;
   }
   if (nbody_is_spinless_model(D) == TRUE && D->iCalcType == FullDiag) {

--- a/test/fulldiag_hubbard_nbody_interall.sh
+++ b/test/fulldiag_hubbard_nbody_interall.sh
@@ -14,6 +14,17 @@ run_hphi() {
   "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
 }
 
+compare_scalar() {
+  label="$1"
+  left="$2"
+  right="$3"
+  diff=$(awk -v a="${left}" -v b="${right}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.12g", d}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${label}: ${left} vs ${right}"
+    exit 1
+  }
+}
+
 cat > stan.in <<EOF
 model = "Hubbard"
 method = "Lanczos"
@@ -56,11 +67,7 @@ else
   e_fulldiag=$(awk 'NR==1{print $2; exit}' output/Eigenvalue.dat)
 fi
 
-diff=$(awk -v a="${e_lanczos}" -v b="${e_fulldiag}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.12g", d}')
-awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
-  echo "Hubbard NBodyInterAll Lanczos/FullDiag energy mismatch: ${e_lanczos} vs ${e_fulldiag}"
-  exit 1
-}
+compare_scalar "Hubbard NBodyInterAll Lanczos/FullDiag energy mismatch" "${e_lanczos}" "${e_fulldiag}"
 
 sed -e 's/^OutputHam.*/OutputHam   1/' calcmod.def > calcmod.outputham
 mv calcmod.outputham calcmod.def
@@ -83,4 +90,46 @@ awk 'NR>2 && $1 == $2 {
   exit 1
 }
 
-echo "Hubbard NBodyInterAll Lanczos, FullDiag, and OutputHam checks passed."
+cat > stan_ncond.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 0.0
+ncond = 4
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_ncond_sdry.txt "${hphi}" -sdry stan_ncond.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 0 0 0 1 1 1 1 0 0.1700000000000000 0.0300000000000000
+2 1 0 1 1 0 1 0 0 0.1700000000000000 -0.0300000000000000
+EOF
+
+run_hphi log_ncond_lanczos.txt "${hphi}" -e namelist.def
+e_ncond_lanczos=$(awk '/^Energy/{print $2; exit}' output/zvo_energy.dat)
+
+sed -e 's/^CalcType.*/CalcType   2/' -e 's/^OutputHam.*/OutputHam   0/' calcmod.def > calcmod.ncond.fulldiag
+mv calcmod.def calcmod.ncond.lanczos
+mv calcmod.ncond.fulldiag calcmod.def
+rm -rf output
+run_hphi log_ncond_fulldiag.txt "${hphi}" -e namelist.def
+if [ -f output/zvo_phys.dat ]; then
+  e_ncond_fulldiag=$(awk 'NR==2{print $1; exit}' output/zvo_phys.dat)
+else
+  e_ncond_fulldiag=$(awk 'NR==1{print $2; exit}' output/Eigenvalue.dat)
+fi
+
+compare_scalar "HubbardNConserved NBodyInterAll Lanczos/FullDiag energy mismatch" \
+  "${e_ncond_lanczos}" "${e_ncond_fulldiag}"
+
+echo "Hubbard and HubbardNConserved NBodyInterAll Lanczos, FullDiag, and OutputHam checks passed."

--- a/test/lanczos_hubbard_nbody_interall.sh
+++ b/test/lanczos_hubbard_nbody_interall.sh
@@ -16,6 +16,7 @@ run_hphi() {
 
 make_base() {
   dir="$1"
+  sector="${2:-fixed}"
   mkdir -p "${dir}"
   cd "${dir}"
   cat > stan.in <<EOF
@@ -25,16 +26,32 @@ lattice = "chain"
 L = 4
 t = 1.0
 U = 0.0
-nelec = 4
-2Sz = 0
 Lanczos_max = 120
 initial_iv = 1
 EOF
+  if [ "${sector}" = "ncond" ]; then
+    printf "ncond = 4\n" >> stan.in
+  else
+    printf "nelec = 4\n2Sz = 0\n" >> stan.in
+  fi
   run_hphi log_sdry.txt "${hphi}" -sdry stan.in
   cd ..
 }
 
-rm -rf nbody legacy
+compare_energy() {
+  label="$1"
+  left="$2"
+  right="$3"
+  diff=$(paste "${left}" "${right}" \
+    | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${label}: max diff ${diff}"
+    paste "${left}" "${right}"
+    exit 1
+  }
+}
+
+rm -rf nbody legacy nbody_ncond legacy_ncond
 make_base nbody
 make_base legacy
 
@@ -68,12 +85,43 @@ run_hphi log_legacy.txt "${hphi}" -e namelist.def
 cp output/zvo_energy.dat ../energy_legacy.dat
 cd ..
 
-diff=$(paste energy_nbody.dat energy_legacy.dat \
-  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
-awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
-  echo "Hubbard NBodyInterAll N=2 energy differs from legacy InterAll: max diff ${diff}"
-  paste energy_nbody.dat energy_legacy.dat
-  exit 1
-}
+compare_energy "Hubbard NBodyInterAll N=2 energy differs from legacy InterAll" \
+  energy_nbody.dat energy_legacy.dat
 
-echo "Hubbard NBodyInterAll N=2 matches legacy InterAll in Lanczos."
+make_base nbody_ncond ncond
+make_base legacy_ncond ncond
+
+cd nbody_ncond
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 0 0 0 1 1 1 1 0 0.1700000000000000 0.0300000000000000
+2 1 0 1 1 0 1 0 0 0.1700000000000000 -0.0300000000000000
+EOF
+run_hphi log_nbody_ncond.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_nbody_ncond.dat
+cd ..
+
+cd legacy_ncond
+printf '    InterAll  interall.def\n' >> namelist.def
+cat > interall.def <<EOF
+========================
+NInterAll 2
+========================
+========zInterAll=======
+========================
+0 0 0 1 1 1 1 0 0.1700000000000000 0.0300000000000000
+1 0 1 1 0 1 0 0 0.1700000000000000 -0.0300000000000000
+EOF
+run_hphi log_legacy_ncond.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_legacy_ncond.dat
+cd ..
+
+compare_energy "HubbardNConserved spin-flip NBodyInterAll energy differs from legacy InterAll" \
+  energy_nbody_ncond.dat energy_legacy_ncond.dat
+
+echo "Hubbard and HubbardNConserved NBodyInterAll terms match legacy InterAll in Lanczos."

--- a/test/lanczos_hubbard_nbodyg.sh
+++ b/test/lanczos_hubbard_nbodyg.sh
@@ -142,3 +142,75 @@ awk -v t="${tol}" '
 }
 
 echo "Hubbard NBodyG number, hopping, and two-body checks passed."
+
+cat > stan_ncond.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 2.0
+ncond = 4
+Lanczos_max = 120
+initial_iv = 1
+EOF
+
+rm -rf output
+run_hphi log_ncond_sdry.txt "${hphi}" -sdry stan_ncond.in
+printf '    NBodyG  nbodyg.def\n' >> namelist.def
+
+cat > greenone.def <<EOF
+========================
+NCisAjs 1
+========================
+========GreenOne========
+========================
+0 0 0 1
+EOF
+
+cat > greentwo.def <<EOF
+========================
+NCisAjsCktAlt 0
+========================
+========GreenTwo========
+========================
+EOF
+
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 1
+EOF
+
+run_hphi log_ncond_lanczos.txt "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated for HubbardNConserved"; exit 1; }
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 0 && $2 == 0 && $3 == 0 && $4 == 1) {
+      ref_re = $5;
+      ref_im = $6;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 1 && $2 == 0 && $3 == 0 && $4 == 0 && $5 == 1 {
+    dr = $6 - ref_re;
+    di = $7 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajs.dat output/zvo_NBodyG.dat || {
+  echo "HubbardNConserved spin-flip NBodyG does not match cisajs"
+  cat output/zvo_cisajs.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+echo "HubbardNConserved spin-flip NBodyG matches cisajs."

--- a/test/mpi_nbody_interall_hubbard.sh
+++ b/test/mpi_nbody_interall_hubbard.sh
@@ -14,8 +14,21 @@ run_hphi() {
   "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
 }
 
-rm -rf serial mpi
-mkdir -p serial mpi
+compare_energy() {
+  label="$1"
+  left="$2"
+  right="$3"
+  diff=$(paste "${left}" "${right}" \
+    | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+  awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+    echo "${label}: max diff ${diff}"
+    paste "${left}" "${right}"
+    exit 1
+  }
+}
+
+rm -rf serial mpi ncond_serial ncond_mpi
+mkdir -p serial mpi ncond_serial ncond_mpi
 
 cd serial
 cat > stan.in <<EOF
@@ -52,13 +65,7 @@ run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
 cp output/zvo_energy.dat ../energy_mpi.dat
 cd ..
 
-diff=$(paste energy_serial.dat energy_mpi.dat \
-  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
-awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
-  echo "Serial/MPI Hubbard NBodyInterAll energy mismatch: max diff ${diff}"
-  paste energy_serial.dat energy_mpi.dat
-  exit 1
-}
+compare_energy "Serial/MPI Hubbard NBodyInterAll energy mismatch" energy_serial.dat energy_mpi.dat
 
 grep -q "INTER process site" mpi/log_mpi.txt || {
   echo "MPI run did not print an inter-process site summary"
@@ -66,4 +73,46 @@ grep -q "INTER process site" mpi/log_mpi.txt || {
   exit 1
 }
 
-echo "Hubbard NBodyInterAll MPI np=4 matches serial energy."
+cd ncond_serial
+cat > stan.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 0.0
+ncond = 4
+Lanczos_max = 120
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+2 3 0 3 1 0 1 0 0 0.2300000000000000 0.0700000000000000
+2 0 0 0 1 3 1 3 0 0.2300000000000000 -0.0700000000000000
+EOF
+run_hphi log_ncond_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_ncond_serial.dat
+cd ..
+
+cp ncond_serial/*.def ncond_mpi/
+cd ncond_mpi
+run_hphi log_ncond_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_ncond_mpi.dat
+cd ..
+
+compare_energy "Serial/MPI HubbardNConserved NBodyInterAll energy mismatch" \
+  energy_ncond_serial.dat energy_ncond_mpi.dat
+
+grep -q "INTER process site" ncond_mpi/log_ncond_mpi.txt || {
+  echo "HubbardNConserved MPI run did not print an inter-process site summary"
+  cat ncond_mpi/log_ncond_mpi.txt
+  exit 1
+}
+
+echo "Hubbard and HubbardNConserved NBodyInterAll MPI np=4 match serial energies."

--- a/test/nbody_hubbard_validation.sh
+++ b/test/nbody_hubbard_validation.sh
@@ -33,8 +33,31 @@ expect_fail() {
   cd ..
 }
 
+check_nbodyg_output() {
+  dir="$1"
+  if ! ls "${dir}"/output/zvo_NBodyG*.dat >/dev/null 2>&1; then
+    echo "Expected ${dir} to write NBodyG output"
+    ls -R "${dir}"/output
+    exit 1
+  fi
+}
+
+set_calcspec() {
+  dir="$1"
+  value="$2"
+  awk -v value="${value}" '
+    $1 == "CalcSpec" {
+      printf "CalcSpec        %s\n", value
+      next
+    }
+    { print }
+  ' "${dir}/calcmod.def" > "${dir}/calcmod.def.tmp"
+  mv "${dir}/calcmod.def.tmp" "${dir}/calcmod.def"
+}
+
 make_hubbard_base() {
   dir="$1"
+  sector="${2:-fixed}"
   mkdir -p "${dir}"
   cd "${dir}"
   cat > stan.in <<EOF
@@ -44,18 +67,23 @@ lattice = "chain"
 L = 4
 t = 1.0
 U = 0.0
-nelec = 4
-2Sz = 0
 Lanczos_max = 50
 initial_iv = 1
 EOF
+  if [ "${sector}" = "ncond" ]; then
+    printf "ncond = 4\n" >> stan.in
+  else
+    printf "nelec = 4\n2Sz = 0\n" >> stan.in
+  fi
   run_hphi log_sdry.txt "${hphi}" -sdry stan.in
   printf '    NBodyInterAll  nbodyinterall.def\n' >> namelist.def
   printf '    NBodyG  nbodyg.def\n' >> namelist.def
   cd ..
 }
 
-rm -rf accept bad_interall_particle bad_nbodyg_particle bad_spin_interall bad_pair diag_im
+rm -rf accept accept_ncond bad_interall_particle bad_nbodyg_particle \
+  bad_spin_interall bad_pair diag_im bad_ncond_calcspec_interall \
+  bad_ncond_calcspec_nbodyg
 
 make_hubbard_base accept
 cat > accept/nbodyinterall.def <<EOF
@@ -73,6 +101,25 @@ NNBodyG 1
 ========NBodyG==========
 ========================
 1 1 0 0 0
+EOF
+
+make_hubbard_base accept_ncond ncond
+cat > accept_ncond/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 1 0.0500000000000000 0.0000000000000000
+1 0 1 0 0 0.0500000000000000 0.0000000000000000
+EOF
+cat > accept_ncond/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 1
 EOF
 
 make_hubbard_base bad_interall_particle
@@ -160,14 +207,56 @@ NNBodyG 0
 ========================
 EOF
 
+make_hubbard_base bad_ncond_calcspec_interall ncond
+set_calcspec bad_ncond_calcspec_interall 1
+cat > bad_ncond_calcspec_interall/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 1
+========================
+========NBodyInterAll===
+========================
+1 0 0 0 0 0.1000000000000000 0.0000000000000000
+EOF
+cat > bad_ncond_calcspec_interall/nbodyg.def <<EOF
+========================
+NNBodyG 0
+========================
+========NBodyG==========
+========================
+EOF
+
+make_hubbard_base bad_ncond_calcspec_nbodyg ncond
+set_calcspec bad_ncond_calcspec_nbodyg 1
+cat > bad_ncond_calcspec_nbodyg/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > bad_ncond_calcspec_nbodyg/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 0
+EOF
+
 cd accept
 run_hphi log_accept.txt "${hphi}" -e namelist.def
 cd ..
+cd accept_ncond
+run_hphi log_accept_ncond.txt "${hphi}" -e namelist.def
+cd ..
+check_nbodyg_output accept_ncond
 
 expect_fail bad_interall_particle "does not conserve particle numbers"
 expect_fail bad_nbodyg_particle "does not conserve particle numbers"
 expect_fail bad_spin_interall "Spin index of NBodyInterAll is incorrect"
 expect_fail bad_pair "Off-diagonal NBodyInterAll terms must appear as adjacent Hermite pairs"
 expect_fail diag_im "Diagonal NBodyInterAll term has a finite imaginary part"
+expect_fail bad_ncond_calcspec_interall "NBodyInterAll does not support HubbardNConserved with CalcSpec"
+expect_fail bad_ncond_calcspec_nbodyg "NBodyG does not support HubbardNConserved with CalcSpec"
 
-echo "canonical Hubbard NBody validation rejects malformed and nonconserving inputs."
+echo "canonical and NConserved Hubbard NBody validation rejects malformed and unsupported inputs."


### PR DESCRIPTION
## Summary

This PR enables `NBodyInterAll` and `NBodyG` for `HubbardNConserved`.

The implementation follows the same pattern as the existing `KondoNConserved` support:

- add `HubbardNConserved` to the supported Hubbard model predicates
- route `HubbardNConserved` through the Hubbard list path
- keep the per-spin conservation check disabled for `HubbardNConserved`, allowing spin-flip N-body terms in total-`N` sectors
- explicitly reject `HubbardNConserved + CalcSpec` for this PR scope

`CalcSpec` support is intentionally left for a separate change.

## Tests

- `cmake --build build -j2`
- `ctest --test-dir build -R '^(nbody_hubbard_validation|lanczos_hubbard_nbody_interall|lanczos_hubbard_nbodyg|fulldiag_hubbard_nbody_interall)$' --output-on-failure`
- `MPIRUN='mpirun --oversubscribe -np 4' ctest --test-dir build -R '^mpi_nbody_interall_hubbard$' --output-on-failure`
- `MPIRUN='mpirun --oversubscribe -np 4' ctest --test-dir build -L nbody --output-on-failure`
- `MPIRUN='mpirun --oversubscribe -np 4' ctest --test-dir build -L hubbard --output-on-failure`

The `hubbard` label passed after rerunning the NumPy-dependent time-evolution tests in a Python environment with NumPy available.

Additional numerical check:

- isolated spin-flip term `c = 0.17 + 0.04i`, `t = U = 0`, `ncond = 2`
- ground-state energy matched `-|c| = -0.1746424919657298`
- nonzero spin-flip `NBodyG` values matched `cisajs` including sign and phase
