### PR TITLE
Support tJNConserved NBodyInterAll and NBodyG

### DIFF
--- a/src/nbody_correlation.c
+++ b/src/nbody_correlation.c
@@ -108,7 +108,9 @@ static int nbodyg_is_hubbard_model(const struct DefineList *D)
 
 static int nbodyg_is_tj_model(const struct DefineList *D)
 {
-  return D->iCalcModel == tJ || D->iCalcModel == tJGC;
+  return D->iCalcModel == tJ ||
+         D->iCalcModel == tJGC ||
+         D->iCalcModel == tJNConserved;
 }
 
 static int nbodyg_is_kondo_model(const struct DefineList *D)
@@ -150,6 +152,7 @@ static int nbodyg_uses_hubbard_list_path(const struct DefineList *D)
          D->iCalcModel == HubbardNConserved ||
          D->iCalcModel == tJ ||
          D->iCalcModel == tJGC ||
+         D->iCalcModel == tJNConserved ||
          D->iCalcModel == Kondo ||
          D->iCalcModel == KondoGC ||
          D->iCalcModel == KondoNConserved;
@@ -160,11 +163,6 @@ static int nbodyg_requires_spinful_conservation(const struct DefineList *D)
   return D->iCalcModel == Hubbard ||
          D->iCalcModel == tJ ||
          D->iCalcModel == Kondo;
-}
-
-static int nbodyg_is_unsupported_nconserved_model(const struct DefineList *D)
-{
-  return D->iCalcModel == tJNConserved;
 }
 
 static int nbodyg_is_general_spin(const struct DefineList *D)
@@ -178,17 +176,10 @@ int ValidateNBodyGScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyG == 0) return 0;
   if (nbodyg_is_supported_model(D) == FALSE) {
-    if (nbodyg_is_unsupported_nconserved_model(D) == TRUE) {
-      fprintf(stdoutMPI,
-              "Error: NBodyG does not support tJNConserved. "
-              "For tJ standard input, define 2Sz to use the Sz-conserved model.\n");
-    }
-    else {
-      fprintf(stdoutMPI,
-              "Error: NBodyG is currently supported only for SpinGC, Spin, "
-              "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
-              "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
-    }
+    fprintf(stdoutMPI,
+            "Error: NBodyG is currently supported only for SpinGC, Spin, "
+            "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
+            "tJGC, tJ, tJNConserved, KondoGC, Kondo, and KondoNConserved.\n");
     return -1;
   }
   if (D->iCalcModel == KondoNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
@@ -197,6 +188,10 @@ int ValidateNBodyGScope(const struct DefineList *D)
   }
   if (D->iCalcModel == HubbardNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
     fprintf(stdoutMPI, "Error: NBodyG does not support HubbardNConserved with CalcSpec.\n");
+    return -1;
+  }
+  if (D->iCalcModel == tJNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
+    fprintf(stdoutMPI, "Error: NBodyG does not support tJNConserved with CalcSpec.\n");
     return -1;
   }
   if (nbodyg_is_kondo_model(D) == TRUE) {
@@ -1464,7 +1459,7 @@ int expec_nbodyg(struct BindStruct *X, double complex *vec)
     fprintf(stdoutMPI,
             "Error: NBodyG is currently supported only for SpinGC, Spin, "
             "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
-            "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
+            "tJGC, tJ, tJNConserved, KondoGC, Kondo, and KondoNConserved.\n");
     return -1;
   }
   if (get_nbodyg_filename(X, sdt) != 0) return -1;

--- a/src/nbody_interall.c
+++ b/src/nbody_interall.c
@@ -140,7 +140,9 @@ static int nbody_is_hubbard_model(const struct DefineList *D)
 
 static int nbody_is_tj_model(const struct DefineList *D)
 {
-  return D->iCalcModel == tJ || D->iCalcModel == tJGC;
+  return D->iCalcModel == tJ ||
+         D->iCalcModel == tJGC ||
+         D->iCalcModel == tJNConserved;
 }
 
 static int nbody_is_kondo_model(const struct DefineList *D)
@@ -182,6 +184,7 @@ static int nbody_uses_hubbard_list_path(const struct DefineList *D)
          D->iCalcModel == HubbardNConserved ||
          D->iCalcModel == tJ ||
          D->iCalcModel == tJGC ||
+         D->iCalcModel == tJNConserved ||
          D->iCalcModel == Kondo ||
          D->iCalcModel == KondoGC ||
          D->iCalcModel == KondoNConserved;
@@ -192,11 +195,6 @@ static int nbody_requires_spinful_conservation(const struct DefineList *D)
   return D->iCalcModel == Hubbard ||
          D->iCalcModel == tJ ||
          D->iCalcModel == Kondo;
-}
-
-static int nbody_is_unsupported_nconserved_model(const struct DefineList *D)
-{
-  return D->iCalcModel == tJNConserved;
 }
 
 static int nbody_is_general_spin(const struct DefineList *D)
@@ -210,17 +208,10 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   unsigned int t, k;
   if (D->NNBodyInterAll == 0) return 0;
   if (nbody_is_supported_model(D) == FALSE) {
-    if (nbody_is_unsupported_nconserved_model(D) == TRUE) {
-      fprintf(stdoutMPI,
-              "Error: NBodyInterAll does not support tJNConserved. "
-              "For tJ standard input, define 2Sz to use the Sz-conserved model.\n");
-    }
-    else {
-      fprintf(stdoutMPI,
-              "Error: NBodyInterAll is currently supported only for SpinGC, Spin, "
-              "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
-              "tJGC, tJ, KondoGC, Kondo, and KondoNConserved.\n");
-    }
+    fprintf(stdoutMPI,
+            "Error: NBodyInterAll is currently supported only for SpinGC, Spin, "
+            "HubbardGC, Hubbard, HubbardNConserved, SpinlessFermionGC, SpinlessFermion, "
+            "tJGC, tJ, tJNConserved, KondoGC, Kondo, and KondoNConserved.\n");
     return -1;
   }
   if (D->iCalcType == TimeEvolution) {
@@ -233,6 +224,10 @@ int ValidateNBodyInterAllScope(const struct DefineList *D)
   }
   if (D->iCalcModel == HubbardNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
     fprintf(stdoutMPI, "Error: NBodyInterAll does not support HubbardNConserved with CalcSpec.\n");
+    return -1;
+  }
+  if (D->iCalcModel == tJNConserved && D->iFlgCalcSpec != CALCSPEC_NOT) {
+    fprintf(stdoutMPI, "Error: NBodyInterAll does not support tJNConserved with CalcSpec.\n");
     return -1;
   }
   if (nbody_is_spinless_model(D) == TRUE && D->iCalcType == FullDiag) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,7 @@ add_hphi_test(lanczos_hubbard_nbody_interall)
 add_hphi_test(lanczos_hubbard_nbodyg)
 add_hphi_test(lanczos_kondogc_chain)
 add_hphi_test(lanczos_tj_kondo_nbody_interall)
+add_hphi_test(lanczos_tj_nconserved_nbodyg)
 add_hphi_test(lanczos_spingc_honey)
 add_hphi_test(lanczos_spingc_hcor)
 add_hphi_test(lanczos_spingc_nbody_interall)
@@ -138,6 +139,9 @@ set_tests_properties(
 set_tests_properties(
     lanczos_tj_kondo_nbody_interall
     PROPERTIES LABELS "lanczos;tj;tjgc;kondo;nbody")
+set_tests_properties(
+    lanczos_tj_nconserved_nbodyg
+    PROPERTIES LABELS "lanczos;tj;nbody")
 set_tests_properties(
     lanczos_spinless lanczos_spinless_GC lanczos_spinless_calchs0
     PROPERTIES LABELS "lanczos;spinless")

--- a/test/fulldiag_tj_kondo_nbody_interall.sh
+++ b/test/fulldiag_tj_kondo_nbody_interall.sh
@@ -17,6 +17,7 @@ run_hphi() {
 make_tj_base() {
   dir="$1"
   calcmodel="$2"
+  write_2sz="${3:-yes}"
 
   mkdir -p "${dir}"
   cd "${dir}"
@@ -56,7 +57,9 @@ EOF
     printf "Nsite             4\n"
     if [ "${calcmodel}" = "9" ]; then
       printf "Ncond             2\n"
-      printf "2Sz               0\n"
+      if [ "${write_2sz}" = "yes" ]; then
+        printf "2Sz               0\n"
+      fi
     fi
     printf "Lanczos_max       120\n"
     printf "initial_iv        1\n"
@@ -181,6 +184,33 @@ NNBodyInterAll 3
 2 0 0 0 1 2 1 2 0 0.2500000000000000 -0.0700000000000000
 1 2 0 2 0 0.1900000000000000 0.0000000000000000
 EOF
+}
+
+write_tjn_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 2 0 2 1 0.2300000000000000 0.0500000000000000
+1 2 1 2 0 0.2300000000000000 -0.0500000000000000
+EOF
+}
+
+append_tjn_transfer() {
+  awk '
+    $1 == "NTransfer" {
+      printf "%s      %d\n", $1, $2 + 2
+      next
+    }
+    { print }
+    END {
+      printf "2 0 2 1 0.2300000000000000 0.0500000000000000\n"
+      printf "2 1 2 0 0.2300000000000000 -0.0500000000000000\n"
+    }
+  ' trans.def > trans.def.tmp
+  mv trans.def.tmp trans.def
 }
 
 write_kondo_interall() {
@@ -315,6 +345,32 @@ run_kondo_case() {
   cd ..
 }
 
+run_tjn_case() {
+  label="$1"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_tj_base nbody 9 no
+  make_tj_base legacy 9 no
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_tjn_nbody
+  run_hphi log_nbody.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  append_tjn_transfer
+  run_hphi log_legacy.txt "${hphi}" -e namelist.def
+  save_ground_energy "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
 run_kondon_case() {
   label="$1"
 
@@ -342,9 +398,10 @@ run_kondon_case() {
 }
 
 run_tj_case tj 9
+run_tjn_case tjn
 run_tj_case tjgc 10
 run_kondo_case kondo Kondo
 run_kondo_case kondogc KondoGC
 run_kondon_case kondon
 
-echo "tJ/tJGC/Kondo/KondoGC/KondoNConserved NBodyInterAll terms match legacy operators in FullDiag."
+echo "tJ/tJNConserved/tJGC/Kondo/KondoGC/KondoNConserved NBodyInterAll terms match legacy operators in FullDiag."

--- a/test/lanczos_tj_kondo_nbody_interall.sh
+++ b/test/lanczos_tj_kondo_nbody_interall.sh
@@ -17,6 +17,7 @@ run_hphi() {
 make_tj_base() {
   dir="$1"
   calcmodel="$2"
+  write_2sz="${3:-yes}"
 
   mkdir -p "${dir}"
   cd "${dir}"
@@ -48,7 +49,10 @@ EOF
     printf "CDataFileHead  zvo\nCParaFileHead  zqp\n--------------------\n"
     printf "Nsite             4\n"
     if [ "${calcmodel}" = "9" ]; then
-      printf "Ncond             2\n2Sz               0\n"
+      printf "Ncond             2\n"
+      if [ "${write_2sz}" = "yes" ]; then
+        printf "2Sz               0\n"
+      fi
     fi
     printf "Lanczos_max       2000\ninitial_iv        1\nexct              1\n"
     printf "LanczosEps        14\nLanczosTarget     2\nLargeValue        20.0\n"
@@ -167,6 +171,33 @@ NNBodyInterAll 2
 EOF
 }
 
+write_tjn_nbody() {
+  cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 2 0 2 1 0.1300000000000000 0.0200000000000000
+1 2 1 2 0 0.1300000000000000 -0.0200000000000000
+EOF
+}
+
+append_tjn_transfer() {
+  awk '
+    $1 == "NTransfer" {
+      printf "%s      %d\n", $1, $2 + 2
+      next
+    }
+    { print }
+    END {
+      printf "2 0 2 1 0.1300000000000000 0.0200000000000000\n"
+      printf "2 1 2 0 0.1300000000000000 -0.0200000000000000\n"
+    }
+  ' trans.def > trans.def.tmp
+  mv trans.def.tmp trans.def
+}
+
 write_kondo_interall() {
   cat > interall.def <<EOF
 ======================
@@ -269,6 +300,32 @@ run_kondo_case() {
   cd ..
 }
 
+run_tjn_case() {
+  label="$1"
+
+  rm -rf "${label}"
+  mkdir -p "${label}"
+  cd "${label}"
+  make_tj_base nbody 9 no
+  make_tj_base legacy 9 no
+
+  cd nbody
+  printf '   NBodyInterAll  nbodyinterall.def\n' >> namelist.def
+  write_tjn_nbody
+  run_hphi log_nbody.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_nbody_energy.dat"
+  cd ..
+
+  cd legacy
+  append_tjn_transfer
+  run_hphi log_legacy.txt ${MPIRUN} "${hphi}" -e namelist.def
+  cp output/zvo_energy.dat "../${label}_legacy_energy.dat"
+  cd ..
+
+  compare_case "${label}"
+  cd ..
+}
+
 run_kondon_case() {
   label="$1"
 
@@ -296,9 +353,10 @@ run_kondon_case() {
 }
 
 run_tj_case tj 9
+run_tjn_case tjn
 run_tj_case tjgc 10
 run_kondo_case kondo Kondo
 run_kondo_case kondogc KondoGC
 run_kondon_case kondon
 
-echo "tJ/tJGC/Kondo/KondoGC/KondoNConserved NBodyInterAll mltply terms match legacy operators in Lanczos."
+echo "tJ/tJNConserved/tJGC/Kondo/KondoGC/KondoNConserved NBodyInterAll mltply terms match legacy operators in Lanczos."

--- a/test/lanczos_tj_nconserved_nbodyg.sh
+++ b/test/lanczos_tj_nconserved_nbodyg.sh
@@ -1,0 +1,195 @@
+#!/bin/sh
+set -e
+
+testname="lanczos_tj_nconserved_nbodyg"
+hphi="../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+cat > namelist.def <<EOF
+       ModPara  modpara.def
+       LocSpin  locspn.def
+         Trans  trans.def
+      InterAll  interall.def
+      OneBodyG  greenone.def
+      TwoBodyG  greentwo.def
+ NBodyInterAll  nbodyinterall.def
+        NBodyG  nbodyg.def
+       CalcMod  calcmod.def
+EOF
+
+cat > calcmod.def <<EOF
+CalcType        0
+CalcModel       9
+ReStart         0
+CalcSpec        0
+CalcEigenVec    0
+InitialVecType  0
+InputEigenVec   0
+OutputEigenVec  0
+InputHam        0
+OutputHam       0
+OutputExVec     0
+EOF
+
+cat > modpara.def <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite             4
+Ncond             2
+Lanczos_max       2000
+initial_iv        1
+exct              1
+LanczosEps        14
+LanczosTarget     2
+LargeValue        20.0
+NumAve            1
+ExpecInterval     20
+EOF
+
+cat > locspn.def <<EOF
+================================
+NlocalSpin     0
+================================
+========i_1LocSpn_0IteElc ======
+================================
+    0      0
+    1      0
+    2      0
+    3      0
+EOF
+
+cat > trans.def <<EOF
+========================
+NTransfer      12
+========================
+========i_j_s_tijs======
+========================
+0 0 1 0 1.0000000000000000 0.0000000000000000
+1 0 0 0 1.0000000000000000 0.0000000000000000
+0 1 1 1 1.0000000000000000 0.0000000000000000
+1 1 0 1 1.0000000000000000 0.0000000000000000
+1 0 2 0 1.0000000000000000 0.0000000000000000
+2 0 1 0 1.0000000000000000 0.0000000000000000
+1 1 2 1 1.0000000000000000 0.0000000000000000
+2 1 1 1 1.0000000000000000 0.0000000000000000
+2 0 3 0 1.0000000000000000 0.0000000000000000
+3 0 2 0 1.0000000000000000 0.0000000000000000
+2 1 3 1 1.0000000000000000 0.0000000000000000
+3 1 2 1 1.0000000000000000 0.0000000000000000
+EOF
+
+cat > interall.def <<EOF
+======================
+NInterAll      0
+======================
+========zInterAll=====
+======================
+EOF
+
+cat > greenone.def <<EOF
+========================
+NCisAjs 2
+========================
+========GreenOne========
+========================
+2 0 2 1
+2 1 2 0
+EOF
+
+cat > greentwo.def <<EOF
+========================
+NCisAjsCktAlt 0
+========================
+========GreenTwo========
+========================
+EOF
+
+cat > nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 2 0 2 1 0.1300000000000000 0.0200000000000000
+1 2 1 2 0 0.1300000000000000 -0.0200000000000000
+EOF
+
+cat > nbodyg.def <<EOF
+========================
+NNBodyG 2
+========================
+========NBodyG==========
+========================
+1 2 0 2 1
+1 2 1 2 0
+EOF
+
+run_hphi log_lanczos.txt ${MPIRUN} "${hphi}" -e namelist.def
+test -f output/zvo_NBodyG.dat || { echo "zvo_NBodyG.dat was not generated"; exit 1; }
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 2 && $2 == 0 && $3 == 2 && $4 == 1) {
+      ref_re = $5;
+      ref_im = $6;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 1 && $2 == 2 && $3 == 0 && $4 == 2 && $5 == 1 {
+    dr = $6 - ref_re;
+    di = $7 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajs.dat output/zvo_NBodyG.dat || {
+  echo "tJNConserved spin-flip NBodyG does not match cisajs"
+  cat output/zvo_cisajs.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+awk -v t="${tol}" '
+  NR == FNR {
+    if ($1 == 2 && $2 == 1 && $3 == 2 && $4 == 0) {
+      ref_re = $5;
+      ref_im = $6;
+      found_ref = 1;
+    }
+    next;
+  }
+  $1 == 1 && $2 == 2 && $3 == 1 && $4 == 2 && $5 == 0 {
+    dr = $6 - ref_re;
+    di = $7 - ref_im;
+    if (dr < 0) dr = -dr;
+    if (di < 0) di = -di;
+    found_nbody = 1;
+    ok = (found_ref && dr < t && di < t);
+  }
+  END { exit (found_ref && found_nbody && ok) ? 0 : 1; }
+' output/zvo_cisajs.dat output/zvo_NBodyG.dat || {
+  echo "tJNConserved conjugate spin-flip NBodyG does not match cisajs"
+  cat output/zvo_cisajs.dat
+  cat output/zvo_NBodyG.dat
+  exit 1
+}
+
+echo "tJNConserved spin-flip NBodyG matches cisajs."

--- a/test/nbody_tj_kondo_validation.sh
+++ b/test/nbody_tj_kondo_validation.sh
@@ -176,8 +176,9 @@ set_calcspec() {
   mv "${dir}/calcmod.def.tmp" "${dir}/calcmod.def"
 }
 
-rm -rf accept_tj accept_tjgc accept_kondo accept_kondogc accept_kondon \
-  bad_tj_particle bad_kondo_nbodyg_particle bad_tjn bad_kondo_local_cross \
+rm -rf accept_tj accept_tjgc accept_tjn accept_kondo accept_kondogc accept_kondon \
+  bad_tj_particle bad_kondo_nbodyg_particle bad_kondo_local_cross \
+  bad_tjn_spectrum_interall bad_tjn_spectrum_nbodyg \
   bad_kondon_spectrum_interall bad_kondon_spectrum_nbodyg
 
 make_tj_base accept_tj 9 yes
@@ -215,6 +216,25 @@ NNBodyG 1
 ========NBodyG==========
 ========================
 1 1 0 0 1
+EOF
+
+make_tj_base accept_tjn 9 no
+cat > accept_tjn/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 2
+========================
+========NBodyInterAll===
+========================
+1 2 0 2 1 0.1000000000000000 0.0200000000000000
+1 2 1 2 0 0.1000000000000000 -0.0200000000000000
+EOF
+cat > accept_tjn/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 2 0 2 1
 EOF
 
 make_kondo_base accept_kondo Kondo yes
@@ -307,8 +327,9 @@ NNBodyG 1
 1 0 1 0 0
 EOF
 
-make_tj_base bad_tjn 9 no
-cat > bad_tjn/nbodyinterall.def <<EOF
+make_tj_base bad_tjn_spectrum_interall 9 no
+set_calcspec bad_tjn_spectrum_interall 1
+cat > bad_tjn_spectrum_interall/nbodyinterall.def <<EOF
 ========================
 NNBodyInterAll 1
 ========================
@@ -316,12 +337,30 @@ NNBodyInterAll 1
 ========================
 1 0 0 0 0 0.1000000000000000 0.0000000000000000
 EOF
-cat > bad_tjn/nbodyg.def <<EOF
+cat > bad_tjn_spectrum_interall/nbodyg.def <<EOF
 ========================
 NNBodyG 0
 ========================
 ========NBodyG==========
 ========================
+EOF
+
+make_tj_base bad_tjn_spectrum_nbodyg 9 no
+set_calcspec bad_tjn_spectrum_nbodyg 1
+cat > bad_tjn_spectrum_nbodyg/nbodyinterall.def <<EOF
+========================
+NNBodyInterAll 0
+========================
+========NBodyInterAll===
+========================
+EOF
+cat > bad_tjn_spectrum_nbodyg/nbodyg.def <<EOF
+========================
+NNBodyG 1
+========================
+========NBodyG==========
+========================
+1 0 0 0 0
 EOF
 
 make_kondo_base bad_kondo_local_cross KondoGC no
@@ -385,6 +424,10 @@ cd accept_tjgc
 run_hphi log_accept.txt "${hphi}" -e namelist.def
 cd ..
 check_nbodyg_output accept_tjgc
+cd accept_tjn
+run_hphi log_accept.txt "${hphi}" -e namelist.def
+cd ..
+check_nbodyg_output accept_tjn
 cd accept_kondo
 run_hphi log_accept.txt "${hphi}" -e namelist.def
 cd ..
@@ -400,9 +443,10 @@ check_nbodyg_output accept_kondon
 
 expect_fail bad_tj_particle "does not conserve particle numbers"
 expect_fail bad_kondo_nbodyg_particle "does not conserve particle numbers"
-expect_fail bad_tjn "NBodyInterAll does not support tJNConserved"
 expect_fail bad_kondo_local_cross "Kondo local-spin NBodyInterAll factors require site_out == site_in"
+expect_fail bad_tjn_spectrum_interall "NBodyInterAll does not support tJNConserved with CalcSpec"
+expect_fail bad_tjn_spectrum_nbodyg "NBodyG does not support tJNConserved with CalcSpec"
 expect_fail bad_kondon_spectrum_interall "NBodyInterAll does not support KondoNConserved with CalcSpec"
 expect_fail bad_kondon_spectrum_nbodyg "NBodyG does not support KondoNConserved with CalcSpec"
 
-echo "tJ/Kondo NBody validation accepts supported sectors and rejects unsupported tJ N-conserved/local-spin/CalcSpec cases."
+echo "tJ/tJNConserved/Kondo NBody validation accepts supported sectors and rejects unsupported local-spin/CalcSpec cases."


### PR DESCRIPTION
## Summary

This PR enables `NBodyInterAll` and `NBodyG` for normal-calculation `tJNConserved`.

The implementation follows the existing N-conserved NBody support pattern:
- Accept `tJNConserved` in normal `NBodyInterAll` / `NBodyG` validation.
- Route `tJNConserved` through the fermionic Hubbard-list path.
- Keep `tJNConserved + CalcSpec + NBodyInterAll/NBodyG` explicitly unsupported.
- Preserve fixed-Sz `tJ` spin-conservation validation; only `tJNConserved` allows spin-flip NBody terms.

This PR intentionally does not add `CalcSpectrum.c` remapping or `mltply.c` dispatch support for `tJNConserved + CalcSpec`.

## Tests

- `cmake --build build -j2`
- `ctest --test-dir build -R '^nbody_tj_kondo_validation$' --output-on-failure`
- `ctest --test-dir build -R '^(lanczos_tj_kondo_nbody_interall|fulldiag_tj_kondo_nbody_interall|lanczos_tj_nconserved_nbodyg)$' --output-on-failure`
- `MPIRUN='mpirun --oversubscribe -np 4' ctest --test-dir build -R '^(lanczos_tj_kondo_nbody_interall|lanczos_tj_nconserved_nbodyg|nbody_tj_kondo_validation)$' --output-on-failure`
- `MPIRUN='mpirun --oversubscribe -np 16' ctest --test-dir build -R '^(lanczos_tj_kondo_nbody_interall|lanczos_tj_nconserved_nbodyg|nbody_tj_kondo_validation)$' --output-on-failure`
- `MPIRUN='mpirun --oversubscribe -np 16' ctest --test-dir build -R '^fulldiag_tj_kondo_nbody_interall$' --output-on-failure`
