### PR TITLE
Support HubbardGC anomalous pair operators under MPI

### DIFF
--- a/doc/en/source/filespecification/expertmode_en/AnomalousG_file_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/AnomalousG_file_en.rst
@@ -80,7 +80,9 @@ Use rules
 
 *  This file is currently supported only for HubbardGC calculations.
 
-*  MPI execution is not supported for ``AnomalousG``.
+*  MPI execution is supported for Lanczos, CG, TPQ, cTPQ, and time evolution
+   calculations. MPI execution with the FullDiag method is not supported for
+   ``AnomalousG``.
 
 *  ``AnomalousG`` is not supported for ``CalcSpec`` calculations.
 

--- a/doc/en/source/filespecification/expertmode_en/AnomalousTerm_file_en.rst
+++ b/doc/en/source/filespecification/expertmode_en/AnomalousTerm_file_en.rst
@@ -88,7 +88,9 @@ Use rules
 
 *  This file is currently supported only for HubbardGC calculations.
 
-*  MPI execution is not supported for ``AnomalousTerm``.
+*  MPI execution is supported for Lanczos, CG, TPQ, and cTPQ calculations.
+   MPI execution with the FullDiag method is not supported for
+   ``AnomalousTerm``.
 
 *  ``AnomalousTerm`` is not supported for time evolution calculations or
    ``CalcSpec`` calculations.

--- a/doc/ja/source/filespecification/expertmode_ja/AnomalousG_file_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/AnomalousG_file_ja.rst
@@ -80,7 +80,8 @@ HubbardGC計算で出力する異常ペアグリーン関数を指定します�
 
 -  現在はHubbardGC計算でのみ使用できます。
 
--  ``AnomalousG`` はMPI実行では使用できません。
+-  ``AnomalousG`` はLanczos法、CG法、TPQ法、cTPQ法、実時間発展法のMPI実行で使用できます。
+   FullDiag法のMPI実行では使用できません。
 
 -  ``AnomalousG`` は ``CalcSpec`` 計算では使用できません。
 

--- a/doc/ja/source/filespecification/expertmode_ja/AnomalousTerm_file_ja.rst
+++ b/doc/ja/source/filespecification/expertmode_ja/AnomalousTerm_file_ja.rst
@@ -87,7 +87,8 @@ HubbardGC計算で用いる異常ペアのハミルトニアン項を指定し�
 
 -  現在はHubbardGC計算でのみ使用できます。
 
--  ``AnomalousTerm`` はMPI実行では使用できません。
+-  ``AnomalousTerm`` はLanczos法、CG法、TPQ法、cTPQ法のMPI実行で使用できます。
+   FullDiag法のMPI実行では使用できません。
 
 -  ``AnomalousTerm`` は時間発展計算および ``CalcSpec`` 計算では使用できません。
 

--- a/src/CalcByCanonicalTPQ.c
+++ b/src/CalcByCanonicalTPQ.c
@@ -180,9 +180,9 @@ int CalcByCanonicalTPQ(
     }else{
         if (X->Bind.Def.Param.ExpandCoef==0){
             X->Bind.Def.Param.ExpandCoef=10;   
-            fprintf(stdout, "In cTPQ calc., the default value of ExpandCoef (=10) is used. \n");
+            fprintf(stdoutMPI, "In cTPQ calc., the default value of ExpandCoef (=10) is used. \n");
         }else{
-            fprintf(stdout, "In cTPQ calc., ExpandCoef is specified as %d. \n",X->Bind.Def.Param.ExpandCoef);
+            fprintf(stdoutMPI, "In cTPQ calc., ExpandCoef is specified as %d. \n",X->Bind.Def.Param.ExpandCoef);
         }
     }
     X->Bind.Def.St=0;
@@ -214,28 +214,30 @@ int CalcByCanonicalTPQ(
             sprintf(sdt, cFileNameInputVector, rand_i, myrank);
             childfopenALL(sdt, "rb", &fp);
             if(fp==NULL){
-                fprintf(stdout, "A file of Inputvector does not exist.\n");
-                fprintf(stdout, "Start to calculate in normal procedure.\n");
+                fprintf(stdoutMPI, "A file of Inputvector does not exist.\n");
+                fprintf(stdoutMPI, "Start to calculate in normal procedure.\n");
                 iret=1;
+                StopTimer(3600);
+            }else{
+                byte_size = fread(&step_i, sizeof(step_i), 1, fp);
+                byte_size = fread(&i_max, sizeof(long int), 1, fp);
+                if(i_max != X->Bind.Check.idim_max){
+                    fprintf(stderr, "Error: A file of Inputvector is incorrect.\n");
+                    exitMPI(-1);
+                }
+                byte_size = fread(v0, sizeof(complex double), X->Bind.Check.idim_max+1, fp);
+                TimeKeeperWithRandAndStep(&(X->Bind), cFileNameTPQStep, cOutputVecFinish, "a", rand_i, step_i);
+                fprintf(stdoutMPI, "%s", cLogInputVecFinish);
+                fclose(fp);
+                StopTimer(3600);
+                X->Bind.Def.istep=step_i;
+                StartTimer(3200);
+                iret=expec_energy_flct(&(X->Bind)); //v1 <- v0 and v0 = H*v1
+                StopTimer(3200);
+                if(iret != 0) return -1;
+                step_iO = step_i-1;
+                if (byte_size == 0) printf("byte_size: %d \n", (int)byte_size);
             }
-            byte_size = fread(&step_i, sizeof(step_i), 1, fp);
-            byte_size = fread(&i_max, sizeof(long int), 1, fp);
-            if(i_max != X->Bind.Check.idim_max){
-                fprintf(stderr, "Error: A file of Inputvector is incorrect.\n");
-                exitMPI(-1);
-            }
-            byte_size = fread(v0, sizeof(complex double), X->Bind.Check.idim_max+1, fp);
-            TimeKeeperWithRandAndStep(&(X->Bind), cFileNameTPQStep, cOutputVecFinish, "a", rand_i, step_i);
-            fprintf(stdoutMPI, "%s", cLogInputVecFinish);
-            fclose(fp);
-            StopTimer(3600);
-            X->Bind.Def.istep=step_i;
-            StartTimer(3200);
-            iret=expec_energy_flct(&(X->Bind)); //v1 <- v0 and v0 = H*v1
-            StopTimer(3200);
-            if(iret != 0) return -1;
-            step_iO = step_i-1;
-            if (byte_size == 0) printf("byte_size: %d \n", (int)byte_size);
         }
         if(X->Bind.Def.iReStart==RESTART_NOT || X->Bind.Def.iReStart==RESTART_OUT || iret ==1) {
             StartTimer(3600);

--- a/src/CalcByCanonicalTPQ.c
+++ b/src/CalcByCanonicalTPQ.c
@@ -214,9 +214,16 @@ int CalcByCanonicalTPQ(
             sprintf(sdt, cFileNameInputVector, rand_i, myrank);
             childfopenALL(sdt, "rb", &fp);
             if(fp==NULL){
-                fprintf(stdoutMPI, "A file of Inputvector does not exist.\n");
-                fprintf(stdoutMPI, "Start to calculate in normal procedure.\n");
+                fprintf(stderr, "A file of Inputvector does not exist (rank %d).\n", myrank);
                 iret=1;
+            }
+            /* All ranks must agree on the fallback: tmpvec files are per-rank and a
+               partially missing set would otherwise split ranks across the restart
+               and fresh-start branches, whose MPI collectives do not match. */
+            iret = (int)MaxMPI_li((unsigned long int)iret);
+            if(iret==1){
+                if(fp != NULL) fclose(fp);
+                fprintf(stdoutMPI, "Start to calculate in normal procedure.\n");
                 StopTimer(3600);
             }else{
                 byte_size = fread(&step_i, sizeof(step_i), 1, fp);

--- a/src/CalcByLOBPCG.c
+++ b/src/CalcByLOBPCG.c
@@ -208,8 +208,8 @@ static void Initialize_wave(
       sprintf(sdt, cFileNameInputVector, ie, myrank);
       childfopenALL(sdt, "rb", &fp);
       if (fp == NULL) {
-        fprintf(stdout, "Restart file is not found.\n");
-        fprintf(stdout, "Start from scratch.\n");
+        fprintf(stdoutMPI, "Restart file is not found.\n");
+        fprintf(stdoutMPI, "Start from scratch.\n");
         ierr = 1;
         break;
       }

--- a/src/CalcByLOBPCG.c
+++ b/src/CalcByLOBPCG.c
@@ -208,8 +208,7 @@ static void Initialize_wave(
       sprintf(sdt, cFileNameInputVector, ie, myrank);
       childfopenALL(sdt, "rb", &fp);
       if (fp == NULL) {
-        fprintf(stdoutMPI, "Restart file is not found.\n");
-        fprintf(stdoutMPI, "Start from scratch.\n");
+        fprintf(stderr, "Restart file is not found (rank %d).\n", myrank);
         ierr = 1;
         break;
       }
@@ -225,6 +224,12 @@ static void Initialize_wave(
         fclose(fp);
       }
     }/*for (ie = 0; ie < X->Def.k_exct; ie++)*/
+
+    /* All ranks must agree on the fallback: restart files are per-rank and a
+       partially missing set would otherwise let some ranks return early while
+       others enter the scratch path, whose MPI collectives do not match. */
+    ierr = (int)MaxMPI_li((unsigned long int)ierr);
+    if (ierr != 0) fprintf(stdoutMPI, "Start from scratch.\n");
 
     if (ierr == 0) {
       //TimeKeeperWithRandAndStep(X, cFileNameTPQStep, cOutputVecFinish, "a", rand_i, step_i);

--- a/src/CalcByTPQ.c
+++ b/src/CalcByTPQ.c
@@ -138,9 +138,16 @@ int CalcByTPQ(
       sprintf(sdt, cFileNameInputVector, rand_i, myrank);
       childfopenALL(sdt, "rb", &fp);
       if(fp==NULL){
-        fprintf(stdoutMPI, "A file of Inputvector does not exist.\n");
-        fprintf(stdoutMPI, "Start to calculate in normal procedure.\n");
+        fprintf(stderr, "A file of Inputvector does not exist (rank %d).\n", myrank);
         iret=1;
+      }
+      /* All ranks must agree on the fallback: tmpvec files are per-rank and a
+         partially missing set would otherwise split ranks across the restart
+         and fresh-start branches, whose MPI collectives do not match. */
+      iret = (int)MaxMPI_li((unsigned long int)iret);
+      if(iret==1){
+        if(fp != NULL) fclose(fp);
+        fprintf(stdoutMPI, "Start to calculate in normal procedure.\n");
         StopTimer(3600);
       }else{
         byte_size = fread(&step_i, sizeof(step_i), 1, fp);

--- a/src/CalcByTPQ.c
+++ b/src/CalcByTPQ.c
@@ -138,29 +138,31 @@ int CalcByTPQ(
       sprintf(sdt, cFileNameInputVector, rand_i, myrank);
       childfopenALL(sdt, "rb", &fp);
       if(fp==NULL){
-        fprintf(stdout, "A file of Inputvector does not exist.\n");
-        fprintf(stdout, "Start to calculate in normal procedure.\n");
+        fprintf(stdoutMPI, "A file of Inputvector does not exist.\n");
+        fprintf(stdoutMPI, "Start to calculate in normal procedure.\n");
         iret=1;
-      }
-      byte_size = fread(&step_i, sizeof(step_i), 1, fp);
-      byte_size = fread(&i_max, sizeof(long int), 1, fp);
-      if(i_max != X->Bind.Check.idim_max){
-        fprintf(stderr, "Error: A file of Inputvector is incorrect.\n");
-        exitMPI(-1);
-      }
-      byte_size = fread(v0, sizeof(complex double), X->Bind.Check.idim_max+1, fp);
-      TimeKeeperWithRandAndStep(&(X->Bind), cFileNameTPQStep, cOutputVecFinish, "a", rand_i, step_i);
-      fprintf(stdoutMPI, "%s", cLogInputVecFinish);
-      fclose(fp);
-      StopTimer(3600);
-      X->Bind.Def.istep=step_i;
-      StartTimer(3200);
-      iret=expec_energy_flct(&(X->Bind));
-      StopTimer(3200);
-      if(iret != 0) return -1;
+        StopTimer(3600);
+      }else{
+        byte_size = fread(&step_i, sizeof(step_i), 1, fp);
+        byte_size = fread(&i_max, sizeof(long int), 1, fp);
+        if(i_max != X->Bind.Check.idim_max){
+          fprintf(stderr, "Error: A file of Inputvector is incorrect.\n");
+          exitMPI(-1);
+        }
+        byte_size = fread(v0, sizeof(complex double), X->Bind.Check.idim_max+1, fp);
+        TimeKeeperWithRandAndStep(&(X->Bind), cFileNameTPQStep, cOutputVecFinish, "a", rand_i, step_i);
+        fprintf(stdoutMPI, "%s", cLogInputVecFinish);
+        fclose(fp);
+        StopTimer(3600);
+        X->Bind.Def.istep=step_i;
+        StartTimer(3200);
+        iret=expec_energy_flct(&(X->Bind));
+        StopTimer(3200);
+        if(iret != 0) return -1;
 
-      step_iO=step_i-1;
-      if (byte_size == 0) printf("byte_size: %d \n", (int)byte_size);
+        step_iO=step_i-1;
+        if (byte_size == 0) printf("byte_size: %d \n", (int)byte_size);
+      }
     }
     
     if(X->Bind.Def.iReStart==RESTART_NOT || X->Bind.Def.iReStart==RESTART_OUT || iret ==1) {

--- a/src/anomalous_pair.c
+++ b/src/anomalous_pair.c
@@ -6,6 +6,9 @@
 /* the Free Software Foundation, either version 3 of the License, or */
 /* (at your option) any later version. */
 
+#ifdef MPI
+#include <mpi.h>
+#endif
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
@@ -138,8 +141,8 @@ static int validate_anomalous_scope_common(const struct DefineList *D, unsigned 
     fprintf(stdoutMPI, "Error: %s does not support CalcSpec.\n", name);
     return -1;
   }
-  if (nproc > 1) {
-    fprintf(stdoutMPI, "Error: %s MPI support is not yet implemented.\n", name);
+  if (nproc > 1 && D->iCalcType == FullDiag) {
+    fprintf(stdoutMPI, "Error: %s does not support MPI FullDiag.\n", name);
     return -1;
   }
   for (t = 0; t < n; t++) {
@@ -214,6 +217,89 @@ static unsigned long int get_hubbardgc_local_block(const struct DefineList *D)
   return D->OrgTpow[2 * D->Nsite - 1] * 2;
 }
 
+static int apply_anomalous_rank_annihilate(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned int spin,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[2 * site + spin];
+  if ((*rank_state & mask) == 0) return 0;
+  *rank_state &= ~mask;
+  return 1;
+}
+
+static int apply_anomalous_rank_create(
+  const struct DefineList *D,
+  unsigned int site,
+  unsigned int spin,
+  unsigned long int *rank_state
+) {
+  unsigned long int mask;
+  if (site < D->Nsite) return 1;
+  mask = D->Tpow[2 * site + spin];
+  if ((*rank_state & mask) != 0) return 0;
+  *rank_state |= mask;
+  return 1;
+}
+
+static int apply_anomalous_rank_term(
+  const struct DefineList *D,
+  const int term[5],
+  unsigned long int *rank_state
+) {
+  const int type = term[0];
+  const unsigned int site1 = (unsigned int)term[1];
+  const unsigned int spin1 = (unsigned int)term[2];
+  const unsigned int site2 = (unsigned int)term[3];
+  const unsigned int spin2 = (unsigned int)term[4];
+
+  if (type == 1) {
+    if (apply_anomalous_rank_create(D, site2, spin2, rank_state) == 0) return 0;
+    if (apply_anomalous_rank_create(D, site1, spin1, rank_state) == 0) return 0;
+  }
+  else {
+    if (apply_anomalous_rank_annihilate(D, site2, spin2, rank_state) == 0) return 0;
+    if (apply_anomalous_rank_annihilate(D, site1, spin1, rank_state) == 0) return 0;
+  }
+  return 1;
+}
+
+static int anomalous_hubbardgc_partner_rank(
+  const struct DefineList *D,
+  const int term[5],
+  int current_rank,
+  int *partner_rank,
+  int *active
+) {
+  int dagger_term[5];
+  unsigned long int rank_state = (unsigned long int)current_rank;
+
+  if (apply_anomalous_rank_term(D, term, &rank_state) == 1) {
+    *active = TRUE;
+    *partner_rank = (int)rank_state;
+    return 0;
+  }
+
+  dagger_term[0] = 1 - term[0];
+  dagger_term[1] = term[3];
+  dagger_term[2] = term[4];
+  dagger_term[3] = term[1];
+  dagger_term[4] = term[2];
+  rank_state = (unsigned long int)current_rank;
+  if (apply_anomalous_rank_term(D, dagger_term, &rank_state) == 1) {
+    *active = TRUE;
+    *partner_rank = (int)rank_state;
+    return 0;
+  }
+
+  *active = FALSE;
+  *partner_rank = current_rank;
+  return 0;
+}
+
 int ApplyAnomalousPairHubbardGC(
   const struct DefineList *D,
   const int term[5],
@@ -248,31 +334,76 @@ int ApplyAnomalousPairHubbardGC(
   return 1;
 }
 
+static double complex apply_anomalous_term_to_rank(
+  struct BindStruct *X,
+  unsigned int term,
+  double complex *tmp_v0,
+  const double complex *src_v1,
+  double complex *cur_v1,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex dam_pr = 0.0;
+  const int do_update = (X->Large.mode == M_MLTPLY || X->Large.mode == M_CALCSPEC);
+
+#pragma omp parallel for default(none) reduction(+:dam_pr) \
+  shared(X, tmp_v0, src_v1, cur_v1) \
+  firstprivate(src_i_max, term, rank_in, do_update, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = ApplyAnomalousPairHubbardGC(
+      &X->Def, X->Def.AnomalousTerm[term], j - 1, rank_in, &local_out, &rank_out, &sign);
+    if (ret == 1 && rank_out == myrank) {
+      const double complex dmv = X->Def.ParaAnomalousTerm[term] * sign * src_v1[j];
+      if (do_update) tmp_v0[local_out + 1] += dmv;
+      dam_pr += conj(cur_v1[local_out + 1]) * dmv;
+    }
+  }
+  return dam_pr;
+}
+
 static double complex multiply_anomalous_term(
   struct BindStruct *X,
   unsigned int term,
   double complex *tmp_v0,
   double complex *tmp_v1
 ) {
-  unsigned long int j;
+  int partner = myrank;
+  int active = TRUE;
   double complex dam_pr = 0.0;
-  const unsigned long int i_max = X->Check.idim_max;
-  const int do_update = (X->Large.mode == M_MLTPLY || X->Large.mode == M_CALCSPEC);
 
-#pragma omp parallel for default(none) reduction(+:dam_pr) \
-  shared(X, tmp_v0, tmp_v1) firstprivate(i_max, term, do_update, myrank) private(j)
-  for (j = 1; j <= i_max; j++) {
-    unsigned long int local_out = 0;
-    int rank_out = 0;
-    int sign = 1;
-    int ret = ApplyAnomalousPairHubbardGC(
-      &X->Def, X->Def.AnomalousTerm[term], j - 1, myrank, &local_out, &rank_out, &sign);
-    if (ret == 1 && rank_out == myrank) {
-      const double complex dmv = X->Def.ParaAnomalousTerm[term] * sign * tmp_v1[j];
-      if (do_update) tmp_v0[local_out + 1] += dmv;
-      dam_pr += conj(tmp_v1[local_out + 1]) * dmv;
-    }
+  if (anomalous_hubbardgc_partner_rank(&X->Def, X->Def.AnomalousTerm[term],
+                                       myrank, &partner, &active) != 0) {
+    return 0.0;
   }
+  if (active == FALSE) return 0.0;
+  if (partner == myrank) {
+    return apply_anomalous_term_to_rank(
+      X, term, tmp_v0, tmp_v1, tmp_v1, X->Check.idim_max, myrank);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, partner, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, partner, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(tmp_v1, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, partner, 0,
+                        v1buf,  idim_max_buf + 1, MPI_DOUBLE_COMPLEX, partner, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    dam_pr = apply_anomalous_term_to_rank(
+      X, term, tmp_v0, v1buf, tmp_v1, idim_max_buf, partner);
+  }
+#else
+  fprintf(stdoutMPI, "Error: AnomalousTerm reached an MPI-only rank flip path without MPI.\n");
+  return 0.0;
+#endif
   return dam_pr;
 }
 
@@ -317,27 +448,73 @@ int AddAnomalousTermToHamHubbardGC(struct BindStruct *X)
   return 0;
 }
 
+static double complex calc_anomalousg_term_hubbardgc_rank(
+  struct BindStruct *X,
+  unsigned int term,
+  const double complex *src_vec,
+  const double complex *cur_vec,
+  unsigned long int src_i_max,
+  int rank_in
+) {
+  unsigned long int j;
+  double complex value = 0.0;
+
+#pragma omp parallel for default(none) reduction(+:value) \
+  shared(X, src_vec, cur_vec) firstprivate(src_i_max, term, rank_in, myrank) private(j)
+  for (j = 1; j <= src_i_max; j++) {
+    unsigned long int local_out = 0;
+    int rank_out = 0;
+    int sign = 1;
+    int ret = ApplyAnomalousPairHubbardGC(
+      &X->Def, X->Def.AnomalousG[term], j - 1, rank_in, &local_out, &rank_out, &sign);
+    if (ret == 1 && rank_out == myrank) {
+      value += conj(cur_vec[local_out + 1]) * sign * src_vec[j];
+    }
+  }
+  return value;
+}
+
 static double complex calc_anomalousg_term_hubbardgc(
   struct BindStruct *X,
   unsigned int term,
   double complex *vec
 ) {
-  unsigned long int j;
+  int partner = myrank;
+  int active = TRUE;
   double complex value = 0.0;
-  const unsigned long int i_max = X->Check.idim_max;
 
-#pragma omp parallel for default(none) reduction(+:value) \
-  shared(X, vec) firstprivate(i_max, term, myrank) private(j)
-  for (j = 1; j <= i_max; j++) {
-    unsigned long int local_out = 0;
-    int rank_out = 0;
-    int sign = 1;
-    int ret = ApplyAnomalousPairHubbardGC(
-      &X->Def, X->Def.AnomalousG[term], j - 1, myrank, &local_out, &rank_out, &sign);
-    if (ret == 1 && rank_out == myrank) {
-      value += conj(vec[local_out + 1]) * sign * vec[j];
-    }
+  if (anomalous_hubbardgc_partner_rank(&X->Def, X->Def.AnomalousG[term],
+                                       myrank, &partner, &active) != 0) {
+    return SumMPI_dc(0.0);
   }
+  if (active == FALSE) {
+    return SumMPI_dc(0.0);
+  }
+  if (partner == myrank) {
+    value = calc_anomalousg_term_hubbardgc_rank(
+      X, term, vec, vec, X->Check.idim_max, myrank);
+    return SumMPI_dc(value);
+  }
+
+#ifdef MPI
+  {
+    MPI_Status statusMPI;
+    unsigned long int idim_max_buf = 0;
+    int ierr = MPI_Sendrecv(&X->Check.idim_max, 1, MPI_UNSIGNED_LONG, partner, 0,
+                            &idim_max_buf,      1, MPI_UNSIGNED_LONG, partner, 0,
+                            MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    ierr = MPI_Sendrecv(vec, X->Check.idim_max + 1, MPI_DOUBLE_COMPLEX, partner, 0,
+                        v1buf, idim_max_buf + 1, MPI_DOUBLE_COMPLEX, partner, 0,
+                        MPI_COMM_WORLD, &statusMPI);
+    if (ierr != 0) exitMPI(-1);
+    value = calc_anomalousg_term_hubbardgc_rank(
+      X, term, v1buf, vec, idim_max_buf, partner);
+  }
+#else
+  fprintf(stdoutMPI, "Error: AnomalousG reached an MPI-only rank flip path without MPI.\n");
+  return SumMPI_dc(0.0);
+#endif
   return SumMPI_dc(value);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -482,6 +482,7 @@ if(MPI_FOUND)
     add_hphi_mpi_test(mpi_nbodyg_spingc exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_hubbardgc exact:4)
     add_hphi_mpi_test(mpi_nbodyg_hubbardgc exact:4)
+    add_hphi_mpi_test(mpi_anomalous_hubbardgc exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_hubbard exact:4)
     add_hphi_mpi_test(mpi_nbodyg_hubbard exact:4)
     add_hphi_mpi_test(mpi_nbody_interall_kondo_nconserved exact:4)
@@ -511,6 +512,7 @@ if(MPI_FOUND)
         mpi_consistency_hubbard mpi_consistency_hubbardgc mpi_consistency_te_hubbard
         mpi_consistency_te_hubbardgc_twobody mpi_consistency_te_hubbard_twobody
         mpi_nbody_interall_hubbardgc mpi_nbodyg_hubbardgc
+        mpi_anomalous_hubbardgc
         mpi_nbody_interall_hubbard mpi_nbodyg_hubbard
         PROPERTIES LABELS "mpi;consistency;hubbard")
     set_tests_properties(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -390,6 +390,7 @@ set_tests_properties(
 add_hphi_test_with_srcdir(tpq_spin_kagome)
 add_hphi_test_with_srcdir(tpq_spin_kagome_randomsphere)
 add_hphi_test(tpq_small_lanczos_max)
+add_hphi_test(tpq_restart_missing_vector_fallback)
 
 set_tests_properties(
     tpq_spin_kagome tpq_spin_kagome_randomsphere
@@ -397,6 +398,9 @@ set_tests_properties(
 set_tests_properties(
     tpq_small_lanczos_max
     PROPERTIES LABELS "tpq;validation")
+set_tests_properties(
+    tpq_restart_missing_vector_fallback
+    PROPERTIES LABELS "tpq;ctpq;validation")
 
 #
 # cTPQ

--- a/test/mpi_anomalous_hubbardgc.sh
+++ b/test/mpi_anomalous_hubbardgc.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+set -e
+
+testname="mpi_anomalous_hubbardgc"
+hphi="../../../src/HPhi"
+tol="0.00000001"
+
+mkdir -p "${testname}"
+cd "${testname}"
+
+run_hphi() {
+  log="$1"
+  shift
+  "$@" > "${log}" 2>&1 || { cat "${log}"; exit 1; }
+}
+
+expect_mpi_fail() {
+  dir="$1"
+  pattern="$2"
+  cd "${dir}"
+  set +e
+  ${MPIRUN} "${hphi}" -e namelist.def > log_mpi.txt 2>&1
+  rc=$?
+  set -e
+  if [ "${rc}" -eq 0 ]; then
+    echo "Expected ${dir} to fail, but it succeeded"
+    exit 1
+  fi
+  grep -q "${pattern}" log_mpi.txt || {
+    echo "Expected pattern '${pattern}' was not found in ${dir}/log_mpi.txt"
+    cat log_mpi.txt
+    exit 1
+  }
+  cd ..
+}
+
+compare_anomalousg() {
+  awk -v t="${tol}" '
+    function prefix(line, out) {
+      out = line;
+      sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]+[-+0-9.eE]+$/, "", out);
+      return out;
+    }
+    NR == FNR {
+      s_prefix[NR] = prefix($0);
+      s_re[NR] = $(NF - 1);
+      s_im[NR] = $NF;
+      n = NR;
+      next;
+    }
+    {
+      m = FNR;
+      if (prefix($0) != s_prefix[m]) bad = 1;
+      dr = $(NF - 1) - s_re[m];
+      di = $NF - s_im[m];
+      if (dr < 0) dr = -dr;
+      if (di < 0) di = -di;
+      if (dr >= t || di >= t) bad = 1;
+    }
+    END { exit (n == m && bad != 1) ? 0 : 1; }
+  ' "$@"
+}
+
+write_anomalous_term() {
+  dir="$1"
+  printf '    AnomalousTerm  anomalousterm.def\n' >> "${dir}/namelist.def"
+  cat > "${dir}/anomalousterm.def" <<EOF
+========================
+NAnomalousTerm 4
+========================
+========AnomalousTerm===
+========================
+1 3 0 0 1  0.2100000000000000  0.1300000000000000
+0 0 1 3 0  0.2100000000000000 -0.1300000000000000
+1 3 0 3 1  0.0700000000000000 -0.0400000000000000
+0 3 1 3 0  0.0700000000000000  0.0400000000000000
+EOF
+}
+
+write_anomalousg() {
+  dir="$1"
+  printf '    AnomalousG     anomalousg.def\n' >> "${dir}/namelist.def"
+  cat > "${dir}/anomalousg.def" <<EOF
+========================
+NAnomalousG 4
+========================
+========AnomalousG=======
+========================
+1 3 0 0 1
+0 0 1 3 0
+1 3 0 3 1
+0 3 1 3 0
+EOF
+}
+
+rm -rf serial mpi fulldiag_term fulldiag_g
+mkdir -p serial mpi fulldiag_term fulldiag_g
+
+cd serial
+cat > stan.in <<EOF
+model = "HubbardGC"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 2.0
+Lanczos_max = 120
+initial_iv = 1
+EOF
+run_hphi log_sdry.txt "${hphi}" -sdry stan.in
+cd ..
+write_anomalous_term serial
+write_anomalousg serial
+
+cd serial
+run_hphi log_serial.txt "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_serial.dat
+cp output/zvo_AnomalousG.dat ../anomalousg_serial.dat
+cd ..
+
+cp serial/*.def mpi/
+cd mpi
+run_hphi log_mpi.txt ${MPIRUN} "${hphi}" -e namelist.def
+cp output/zvo_energy.dat ../energy_mpi.dat
+cp output/zvo_AnomalousG.dat ../anomalousg_mpi.dat
+cd ..
+
+diff=$(paste energy_serial.dat energy_mpi.dat \
+  | awk '$1 == "Energy" && $3 == "Energy" {d=$2-$4; if(d<0)d=-d; if(d>m)m=d} END{printf "%.12g", m+0}')
+awk -v d="${diff}" -v t="${tol}" 'BEGIN{exit (d < t) ? 0 : 1}' || {
+  echo "Serial/MPI HubbardGC AnomalousTerm energy mismatch: max diff ${diff}"
+  paste energy_serial.dat energy_mpi.dat
+  exit 1
+}
+
+compare_anomalousg anomalousg_serial.dat anomalousg_mpi.dat || {
+  echo "Serial/MPI HubbardGC AnomalousG output mismatch"
+  paste anomalousg_serial.dat anomalousg_mpi.dat
+  exit 1
+}
+
+grep -q "INTER process site" mpi/log_mpi.txt || {
+  echo "MPI run did not print an inter-process site summary"
+  cat mpi/log_mpi.txt
+  exit 1
+}
+
+awk -v t="${tol}" '
+  $1 == 1 && $2 == 3 && $3 == 0 && $4 == 3 && $5 == 1 {
+    re = $6; im = $7;
+    if (re < 0) re = -re;
+    if (im < 0) im = -im;
+    found = (re > t || im > t);
+  }
+  END { exit found ? 0 : 1; }
+' anomalousg_mpi.dat || {
+  echo "Two-rank-bit HubbardGC AnomalousG operator was zero or missing"
+  cat anomalousg_mpi.dat
+  exit 1
+}
+
+cp serial/*.def fulldiag_term/
+sed -e 's/^CalcType.*/CalcType   2/' fulldiag_term/calcmod.def > fulldiag_term/calcmod.tmp
+mv fulldiag_term/calcmod.tmp fulldiag_term/calcmod.def
+
+cp serial/*.def fulldiag_g/
+rm -f fulldiag_g/anomalousterm.def
+grep -v 'AnomalousTerm' fulldiag_g/namelist.def > fulldiag_g/namelist.tmp
+mv fulldiag_g/namelist.tmp fulldiag_g/namelist.def
+sed -e 's/^CalcType.*/CalcType   2/' fulldiag_g/calcmod.def > fulldiag_g/calcmod.tmp
+mv fulldiag_g/calcmod.tmp fulldiag_g/calcmod.def
+
+expect_mpi_fail fulldiag_term "AnomalousTerm does not support MPI FullDiag"
+expect_mpi_fail fulldiag_g "AnomalousG does not support MPI FullDiag"
+
+echo "HubbardGC AnomalousTerm/AnomalousG MPI np=4 matches serial and rejects MPI FullDiag."

--- a/test/mpi_anomalous_hubbardgc.sh
+++ b/test/mpi_anomalous_hubbardgc.sh
@@ -173,4 +173,4 @@ mv fulldiag_g/calcmod.tmp fulldiag_g/calcmod.def
 expect_mpi_fail fulldiag_term "AnomalousTerm does not support MPI FullDiag"
 expect_mpi_fail fulldiag_g "AnomalousG does not support MPI FullDiag"
 
-echo "HubbardGC AnomalousTerm/AnomalousG MPI np=4 matches serial and rejects MPI FullDiag."
+echo "HubbardGC AnomalousTerm/AnomalousG MPI run matches serial and rejects MPI FullDiag."

--- a/test/tpq_restart_missing_vector_fallback.sh
+++ b/test/tpq_restart_missing_vector_fallback.sh
@@ -1,0 +1,93 @@
+#!/bin/sh -e
+# Regression test for missing restart-vector fallback in mTPQ and cTPQ.
+#
+# Restart_in without tmpvec_set*_rank_*.dat should fall back to a fresh random
+# initial vector.  This used to dereference a NULL FILE pointer in the TPQ
+# restart path.
+
+if [ -z "${MPIRUN}" ]; then
+    MPIRUN=""
+fi
+
+testname="tpq_restart_missing_vector_fallback"
+rm -rf "${testname}"
+mkdir -p "${testname}"
+cd "${testname}"
+hphi="$(pwd)/../../src/HPhi"
+
+run_mtpq_missing_restart() {
+    mkdir -p mtpq
+    cd mtpq
+
+    cat > stan.in <<EOF
+L = 8
+model = "Spin"
+method = "TPQ"
+lattice = "chain"
+J = 1.0
+2Sz = 0
+Lanczos_max = 3
+LargeValue = 5
+NumAve = 1
+Restart = "Restart_in"
+outputmode = "None"
+EOF
+
+    if ! ${MPIRUN} "${hphi}" -s stan.in > run.log 2>&1; then
+        echo "ERROR: mTPQ missing restart-vector fallback failed" >&2
+        tail -40 run.log >&2
+        exit 1
+    fi
+    grep -q "Start to calculate in normal procedure." run.log
+    test "$(wc -l < output/Norm_rand0.dat)" -gt 1
+
+    cd ..
+}
+
+run_ctpq_missing_restart() {
+    mkdir -p ctpq
+    cd ctpq
+
+    cat > stan.in <<EOF
+L = 8
+model = "SpinGC"
+method = "TPQ"
+lattice = "chain"
+J = 1.0
+NumAve = 1
+Lanczos_max = 3
+LargeValue = 5
+outputmode = "None"
+EOF
+
+    "${hphi}" -sdry stan.in > gen.log 2>&1
+
+    cat > calcmod.def <<EOF
+CalcType   5
+CalcModel   4
+ReStart   3
+CalcSpec   0
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   0
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+
+    if ! ${MPIRUN} "${hphi}" -e namelist.def > run.log 2>&1; then
+        echo "ERROR: cTPQ missing restart-vector fallback failed" >&2
+        tail -40 run.log >&2
+        exit 1
+    fi
+    grep -q "Start to calculate in normal procedure." run.log
+    test "$(wc -l < output/Norm_rand0.dat)" -gt 1
+
+    cd ..
+}
+
+run_mtpq_missing_restart
+run_ctpq_missing_restart
+
+echo "mTPQ/cTPQ missing restart-vector fallback completes: OK"


### PR DESCRIPTION
## Summary

This PR adds MPI support for the HubbardGC anomalous pair operators introduced in #253.

- Support `AnomalousTerm` in MPI matvec for HubbardGC calculations.
- Support `AnomalousG` expectation values under MPI.
- Handle anomalous pair operators whose fermion bits cross MPI rank boundaries.
- Keep the existing scope restrictions:
  - HubbardGC only
  - no `CalcSpec`
  - no MPI `FullDiag`
  - no `AnomalousTerm` in time evolution
- Add an MPI regression test comparing serial and MPI results for:
  - `zvo_energy.dat`
  - `zvo_AnomalousG.dat`
  - one-rank-bit and two-rank-bit anomalous pairs
- Add negative tests for MPI `FullDiag` with `AnomalousTerm` and `AnomalousG`.
- Update the English and Japanese manuals to describe the MPI-supported methods and the MPI `FullDiag` limitation.

## Validation

```bash
cmake -S . -B build
cmake --build build -j2
ctest --test-dir build -R '^(lanczos_hubbardgc_anomalous_pair|anomalous_hubbardgc_validation)$' --output-on-failure
MPIRUN='mpirun --oversubscribe -np 4' ctest --test-dir build -R '^(mpi_anomalous_hubbardgc|mpi_nbody_interall_hubbardgc|mpi_nbodyg_hubbardgc)$' --output-on-failure
MPIRUN='mpirun --oversubscribe -np 16' test/mpi_anomalous_hubbardgc.sh
cmake -S . -B build-nompi -DENABLE_MPI=OFF
cmake --build build-nompi -j2
python3 -m sphinx -M html source build  # doc/en
python3 -m sphinx -M html source build  # doc/ja
git diff --check
```

The Sphinx builds completed successfully; the remaining warnings are from existing pages outside the updated anomalous-pair manual entries.