### PR TITLE
Reject non-converged BiCG spectrum runs

### DIFF
--- a/src/CalcSpectrumByBiCG.c
+++ b/src/CalcSpectrumByBiCG.c
@@ -227,6 +227,9 @@ int CalcSpectrumByBiCG(
   double complex *v12, *v14, *res_proj;
   int stp, status[3], iomega;
   double *resz;
+  int ran_bicg_loop = FALSE;
+  int bicg_failed = FALSE;
+  double max_residual = 0.0;
 
   fprintf(stdoutMPI, "#####  Spectrum calculation with BiCG  #####\n\n");
   /* Defense in depth (independent of the top-level SpectrumNumBra validation): the
@@ -313,6 +316,7 @@ int CalcSpectrumByBiCG(
   childfopenMPI("residual.dat", "w", &fp);
 
   for (stp = 1; stp <= X->Bind.Def.Lanczos_max; stp++) {
+    ran_bicg_loop = TRUE;
     /**
     <li>@f${\bf v}_{2}={\hat H}{\bf v}_{12}, {\bf v}_{4}={\hat H}{\bf v}_{14}@f$,
     where @f${\bf v}_{12}, {\bf v}_{14}@f$ are old (shadow) residual vector.</li>
@@ -357,6 +361,14 @@ int CalcSpectrumByBiCG(
     if (status[0] < 0) break;
   }/*for (stp = 0; stp <= X->Bind.Def.Lanczos_max; stp++)*/
   fclose(fp);
+  if (ran_bicg_loop == TRUE && (status[0] >= 0 || status[1] != 0)) {
+    bicg_failed = TRUE;
+    max_residual = 0.0;
+    komega_bicg_getresidual(resz);
+    for (iomega = 0; iomega < Nomega; iomega++) {
+      if (resz[iomega] > max_residual) max_residual = resz[iomega];
+    }
+  }
   /**
   </ul>
   <li>@b END @b DO BiCG loop</li>
@@ -398,6 +410,19 @@ int CalcSpectrumByBiCG(
     fprintf(stdoutMPI, "    End:   Output vectors for recalculation.\n");
     TimeKeeper(&(X->Bind), cFileNameTimeKeep, c_OutputSpectrumRecalcvecEnd, "a");
   }/*if (X->Bind.Def.iFlgCalcSpec > RECALC_FROM_TMComponents)*/
+
+  if (bicg_failed == TRUE) {
+    fprintf(stderr,
+      "Error: BiCG spectrum did not finish successfully within Lanczos_max=%u "
+      "(last iteration=%d, status=%d, seed=%d, max residual=%25.15e).\n",
+      X->Bind.Def.Lanczos_max, abs(status[0]), status[1], status[2], max_residual);
+    komega_bicg_finalize();
+    free(resz);
+    free(res_proj);
+    free(v12);
+    free(v14);
+    return FALSE;
+  }
 
   komega_bicg_finalize();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -298,6 +298,7 @@ add_hphi_test(spectrum_hubbard_offdiag_pair_density)
 add_hphi_test(spectrum_spin_offdiag_szsz)
 add_hphi_test(spectrum_spingc_offdiag_szsz)
 add_hphi_test(spectrum_offdiag_invalid_reject)
+add_hphi_test(spectrum_bicg_nonconvergence_reject)
 add_hphi_test(spectrum_loop_multiop_reader_validation)
 add_hphi_test(spectrum_hubbard_nconserved_calchs2_boundary)
 
@@ -314,6 +315,9 @@ set_tests_properties(
 set_tests_properties(
     spectrum_offdiag_invalid_reject
     PROPERTIES LABELS "spectrum;offdiag;validation")
+set_tests_properties(
+    spectrum_bicg_nonconvergence_reject
+    PROPERTIES LABELS "spectrum;hubbard;offdiag;validation")
 set_tests_properties(
     spectrum_loop_multiop_reader_validation
     PROPERTIES LABELS "spectrum;hubbard;validation")

--- a/test/spectrum_bicg_nonconvergence_reject.sh
+++ b/test/spectrum_bicg_nonconvergence_reject.sh
@@ -1,0 +1,150 @@
+#!/bin/sh -e
+
+# Regression test for BiCG spectrum non-convergence handling.
+# A deliberately tiny Lanczos_max must fail clearly instead of writing a
+# near-zero DynamicalGreen file and returning success.
+
+HPHI=../../src/HPhi
+
+rm -rf spectrum_bicg_nonconvergence_reject/
+mkdir -p spectrum_bicg_nonconvergence_reject/
+cd spectrum_bicg_nonconvergence_reject
+
+cat > stan_gs.in <<EOF
+model = "Hubbard"
+method = "CG"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+nelec = 4
+2Sz = 0
+EigenVecIO = "out"
+EOF
+
+${HPHI} -s stan_gs.in > gs.log 2>&1
+
+cat > calcmod_cg.def <<EOF
+CalcType   3
+CalcModel   0
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   1
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+EOF
+
+cat > SpectrumModpara <<EOF
+--------------------
+Model_Parameters   0
+--------------------
+HPhi_Cal_Parameters
+--------------------
+CDataFileHead  zvo
+CParaFileHead  zqp
+--------------------
+Nsite          4
+2Sz            0
+Ncond          4
+Lanczos_max    1
+initial_iv     -1
+exct           1
+LanczosEps     14
+LanczosTarget  2
+LargeValue     8.0
+NumAve         5
+ExpecInterval  20
+NOmega         5
+OmegaOrg       -2.1027484834620633
+OmegaMin       0.0
+OmegaMax       0.5
+OmegaIm        0.1
+EOF
+
+cat > singleexcitation.def <<EOF
+=============================================
+NSingleExcitation 1
+=============================================
+======== Single Excitation ==================
+=============================================
+1 0 0         1.000000000000000         0.000000000000000
+EOF
+
+cat > singleexcitationbra.def <<EOF
+=============================================
+NSingleExcitationBra 1
+=============================================
+======== Single Excitation Bra ==============
+=============================================
+0 0 0         1.000000000000000         0.000000000000000
+EOF
+
+cat > namelist_cg.def <<EOF
+         ModPara  SpectrumModpara
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombIntra  coulombintra.def
+        OneBodyG  greenone.def
+        TwoBodyG  greentwo.def
+         CalcMod  calcmod_cg.def
+  SingleExcitation  singleexcitation.def
+  SingleExcitationBra  singleexcitationbra.def
+     SpectrumVec  zvo_eigenvec_0
+EOF
+
+set +e
+${HPHI} -e namelist_cg.def > run.log 2>&1
+rc=$?
+set -e
+
+if [ "${rc}" = "0" ]; then
+    echo "ERROR: BiCG spectrum run succeeded but was expected to fail" >&2
+    tail -40 run.log >&2
+    exit 1
+fi
+
+grep -q "BiCG spectrum did not finish successfully" run.log
+
+if [ -e output/zvo_DynamicalGreen.dat ]; then
+    echo "ERROR: non-converged BiCG spectrum wrote DynamicalGreen output" >&2
+    cat output/zvo_DynamicalGreen.dat >&2
+    exit 1
+fi
+
+rm -f output/zvo_TMComponents.dat output/zvo_DynamicalGreen.dat
+
+sed -e 's/^CalcSpec.*/CalcSpec   3/' calcmod_cg.def > calcmod_restart_out.def
+sed -e 's/CalcMod  calcmod_cg.def/CalcMod  calcmod_restart_out.def/' \
+    -e '/SingleExcitationBra/d' \
+    namelist_cg.def > namelist_restart_out.def
+
+set +e
+${HPHI} -e namelist_restart_out.def > restart_out.log 2>&1
+rc=$?
+set -e
+
+if [ "${rc}" = "0" ]; then
+    echo "ERROR: BiCG spectrum restart_out run succeeded but was expected to fail" >&2
+    tail -40 restart_out.log >&2
+    exit 1
+fi
+
+grep -q "BiCG spectrum did not finish successfully" restart_out.log
+
+if [ ! -s output/zvo_TMComponents.dat ]; then
+    echo "ERROR: non-converged CalcSpec=restart_out did not save TMComponents" >&2
+    tail -40 restart_out.log >&2
+    exit 1
+fi
+
+if [ -e output/zvo_DynamicalGreen.dat ]; then
+    echo "ERROR: non-converged BiCG restart_out wrote DynamicalGreen output" >&2
+    cat output/zvo_DynamicalGreen.dat >&2
+    exit 1
+fi
+
+echo "BiCG spectrum non-convergence is rejected: OK"


### PR DESCRIPTION
## Summary

This PR makes shifted-BiCG spectrum calculations fail explicitly when the BiCG solve does not converge or exits with a Komega breakdown status.

Previously, an itermax non-converged BiCG run could still return success and let HPhi write `*_DynamicalGreen.dat`, even though the spectrum values were not reliable. The new check preserves normal converged runs, rejects non-converged/breakdown statuses, and avoids writing final spectrum output on failure.

Restart/save workflows are kept usable: for `CalcSpec=restart_out` / restart-save modes, HPhi saves the BiCG restart data first, then returns failure.

## Changes

- Detect failed shifted-BiCG completion using Komega status:
  - `status[1] != 0` catches itermax non-convergence and breakdown statuses.
  - A loop guard avoids reading uninitialized status values for no-iteration restart paths.
- Return failure before final dynamical Green output is written.
- Preserve `TMComponents` / restart-vector save behavior before returning failure.
- Add regression test `spectrum_bicg_nonconvergence_reject`.

## Tests

- `cmake --build build -j 8`
- `ctest --test-dir build -R '^spectrum_bicg_nonconvergence_reject$' --output-on-failure`
- `ctest --test-dir build -L spectrum --output-on-failure`
- `MPIRUN="mpirun --oversubscribe -np 4" ctest --test-dir build -R '^spectrum_hubbard_offdiag_single_mpi$' --output-on-failure`
- `git diff --check`
