### PR TITLE
Fix zero-size setmemory allocations

### DIFF
--- a/src/common/setmemory.c
+++ b/src/common/setmemory.c
@@ -21,6 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "setmemory.h"
 
+static long unsigned int nonzero_count(const long unsigned int n) {
+    return n > 0 ? n : 1;
+}
+
 ///
 /// \brief Allocation for A[N]
 /// \param N [in] The size of the array A
@@ -87,8 +91,8 @@ void free_li_1d_allocate(long int *A){
 long int **li_2d_allocate(const long unsigned int N, const long unsigned int M) {
     long int **A;
     long unsigned int int_i;
-    A = (long int **) calloc((N) , sizeof(long int *));
-    A[0] = (long int *) calloc((M * N) ,sizeof(long int));
+    A = (long int **) calloc(nonzero_count(N) , sizeof(long int *));
+    A[0] = (long int *) calloc(nonzero_count(M * N) ,sizeof(long int));
     for (int_i = 0; int_i < N; int_i++) {
         A[int_i] = A[0] + int_i * M;
     }
@@ -134,8 +138,8 @@ void free_i_1d_allocate(int *A){
 int **i_2d_allocate(const long unsigned int N, const long unsigned int M) {
     int **A;
     long unsigned int int_i;
-    A = (int **) calloc((N) , sizeof(int *));
-    A[0] = (int *) calloc((M * N) , sizeof(int));
+    A = (int **) calloc(nonzero_count(N) , sizeof(int *));
+    A[0] = (int *) calloc(nonzero_count(M * N) , sizeof(int));
     for (int_i = 0; int_i < N; int_i++) {
         A[int_i] = A[0] + int_i * M;
     }
@@ -158,9 +162,9 @@ void free_i_2d_allocate(int **A){
 int***i_3d_allocate(const long unsigned int N, const long unsigned int M, const long unsigned int L){
     long unsigned int int_i, int_j;
     int*** A;
-    A     = (int***)calloc((N),sizeof(int**));
-    A[0]  = (int**)calloc((M*N),sizeof(int*));
-    A[0][0] = (int*)calloc((L*M*N),sizeof(int));
+    A     = (int***)calloc(nonzero_count(N),sizeof(int**));
+    A[0]  = (int**)calloc(nonzero_count(M*N),sizeof(int*));
+    A[0][0] = (int*)calloc(nonzero_count(L*M*N),sizeof(int));
     for(int_i=0;int_i<N; int_i++) {
         A[int_i] = A[0] + int_i*M;
         for(int_j = 0; int_j<M; int_j++){
@@ -207,8 +211,8 @@ void free_d_1d_allocate(double *A){
 double **d_2d_allocate(const long unsigned int N, const long unsigned int M){
     long unsigned int int_i;
     double **A;
-    A     = (double**)calloc((N),sizeof(double*));
-    A[0]  = (double*)calloc((M*N),sizeof(double));
+    A     = (double**)calloc(nonzero_count(N),sizeof(double*));
+    A[0]  = (double*)calloc(nonzero_count(M*N),sizeof(double));
     for(int_i=0;int_i<N;int_i++){
         A[int_i] = A[0] + int_i*M;
     }
@@ -251,8 +255,8 @@ void free_cd_1d_allocate(double complex *A){
 complex double **cd_2d_allocate(const long unsigned int N, const long unsigned int M){
     long unsigned int int_i;
     complex double **A;
-    A     = (complex double**)calloc((N),sizeof(complex double));
-    A[0]  = (complex double*)calloc((M*N),sizeof(complex double));
+    A     = (complex double**)calloc(nonzero_count(N),sizeof(complex double*));
+    A[0]  = (complex double*)calloc(nonzero_count(M*N),sizeof(complex double));
     for(int_i=0;int_i<N;int_i++){
         A[int_i] = A[0]+int_i*M;
     }
@@ -275,9 +279,9 @@ void free_cd_2d_allocate(double complex**A){
 double complex***cd_3d_allocate(const long unsigned int N, const long unsigned int M, const long unsigned int L){
     long unsigned int int_i, int_j;
     double complex***A;
-    A     = (double complex***)calloc((N),sizeof(double complex**));
-    A[0]  = (double complex**)calloc((M*N),sizeof(double complex*));
-    A[0][0] = (double complex*)calloc((L*M*N),sizeof(double complex));
+    A     = (double complex***)calloc(nonzero_count(N),sizeof(double complex**));
+    A[0]  = (double complex**)calloc(nonzero_count(M*N),sizeof(double complex*));
+    A[0][0] = (double complex*)calloc(nonzero_count(L*M*N),sizeof(double complex));
     for(int_i=0;int_i<N; int_i++) {
         A[int_i] = A[0] + int_i*M;
         for(int_j = 0; int_j<M; int_j++){

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -337,6 +337,17 @@ add_test(NAME unittest_excitation_sector_shift
 set_tests_properties(unittest_excitation_sector_shift
     PROPERTIES LABELS "unit;offdiag")
 
+# Unit test: zero-size 2d/3d setmemory allocations
+add_executable(unittest_setmemory_zero_size_common
+    ${CMAKE_SOURCE_DIR}/test/unittest_setmemory_zero_size.c
+    ${CMAKE_SOURCE_DIR}/src/common/setmemory.c)
+target_include_directories(unittest_setmemory_zero_size_common
+    PRIVATE ${CMAKE_SOURCE_DIR}/src/common)
+add_test(NAME unittest_setmemory_zero_size_common
+    COMMAND unittest_setmemory_zero_size_common)
+set_tests_properties(unittest_setmemory_zero_size_common
+    PROPERTIES LABELS "unit;setmemory")
+
 # MPI consistency for the off-diagonal spectrum (4-site Hubbard needs np=4)
 add_hphi_mpi_test(spectrum_hubbard_offdiag_single_mpi exact:4)
 set_tests_properties(spectrum_hubbard_offdiag_single_mpi

--- a/test/unittest_setmemory_zero_size.c
+++ b/test/unittest_setmemory_zero_size.c
@@ -1,0 +1,78 @@
+/* Unit test for zero-size 2d/3d setmemory allocators.
+ * ASan catches the pre-fix A[0] / A[0][0] writes into calloc(0) storage. */
+#include "setmemory.h"
+#include <stdio.h>
+
+static int g_failed = 0;
+
+static void check_ptr(const char *name, const void *ptr) {
+  if (ptr == NULL) {
+    printf("%s : NULL\n", name);
+    g_failed = 1;
+  }
+}
+
+static void check_li_2d(unsigned long n, unsigned long m) {
+  long int **a = li_2d_allocate(n, m);
+  check_ptr("li_2d A", a);
+  if (a != NULL) check_ptr("li_2d A[0]", a[0]);
+  if (a != NULL && a[0] != NULL) free_li_2d_allocate(a);
+}
+
+static void check_i_2d(unsigned long n, unsigned long m) {
+  int **a = i_2d_allocate(n, m);
+  check_ptr("i_2d A", a);
+  if (a != NULL) check_ptr("i_2d A[0]", a[0]);
+  if (a != NULL && a[0] != NULL) free_i_2d_allocate(a);
+}
+
+static void check_d_2d(unsigned long n, unsigned long m) {
+  double **a = d_2d_allocate(n, m);
+  check_ptr("d_2d A", a);
+  if (a != NULL) check_ptr("d_2d A[0]", a[0]);
+  if (a != NULL && a[0] != NULL) free_d_2d_allocate(a);
+}
+
+static void check_cd_2d(unsigned long n, unsigned long m) {
+  double complex **a = cd_2d_allocate(n, m);
+  check_ptr("cd_2d A", a);
+  if (a != NULL) check_ptr("cd_2d A[0]", a[0]);
+  if (a != NULL && a[0] != NULL) free_cd_2d_allocate(a);
+}
+
+static void check_i_3d(unsigned long n, unsigned long m, unsigned long l) {
+  int ***a = i_3d_allocate(n, m, l);
+  check_ptr("i_3d A", a);
+  if (a != NULL) check_ptr("i_3d A[0]", a[0]);
+  if (a != NULL && a[0] != NULL) check_ptr("i_3d A[0][0]", a[0][0]);
+  if (a != NULL && a[0] != NULL && a[0][0] != NULL) free_i_3d_allocate(a);
+}
+
+static void check_cd_3d(unsigned long n, unsigned long m, unsigned long l) {
+  double complex ***a = cd_3d_allocate(n, m, l);
+  check_ptr("cd_3d A", a);
+  if (a != NULL) check_ptr("cd_3d A[0]", a[0]);
+  if (a != NULL && a[0] != NULL) check_ptr("cd_3d A[0][0]", a[0][0]);
+  if (a != NULL && a[0] != NULL && a[0][0] != NULL) free_cd_3d_allocate(a);
+}
+
+int main(void) {
+  check_li_2d(0, 2);
+  check_li_2d(2, 0);
+  check_i_2d(0, 2);
+  check_i_2d(2, 0);
+  check_d_2d(0, 2);
+  check_d_2d(2, 0);
+  check_cd_2d(0, 2);
+  check_cd_2d(2, 0);
+
+  check_i_3d(0, 2, 3);
+  check_i_3d(2, 0, 3);
+  check_i_3d(2, 3, 0);
+  check_cd_3d(0, 2, 3);
+  check_cd_3d(2, 0, 3);
+  check_cd_3d(2, 3, 0);
+
+  printf("\n%s\n", g_failed ? "UNIT TEST FAILED" : "UNIT TEST PASSED");
+  return g_failed;
+}


### PR DESCRIPTION
## Summary
- Clamp common 2D/3D setmemory allocator table and data allocations to at least one element for empty tables.
- Preserve the existing free helpers' assumption that A[0] / A[0][0] are valid.
- Add a unit test that exercises zero-size dimensions directly.

## Notes
- This fixes an ASan-detected undefined behavior in empty optional interaction tables.
- The StdFace copy has the same pattern, but HPhi tracks StdFace as a submodule, so that should be handled separately upstream.
- Also corrects the row-pointer element size in `cd_2d_allocate` (it previously over-allocated with `sizeof(complex double)`).

## Testing
- `cmake --build <build-dir> -j4`
- `ctest --output-on-failure -L 'unit|setmemory'`
- `OMP_NUM_THREADS=1 MPIRUN='mpiexec --oversubscribe -np 4' ctest --output-on-failure -R '^spectrum_hubbard_offdiag_single_mpi$'`
- ASan build: `ctest --output-on-failure -R '^unittest_setmemory_zero_size_common$'`
- ASan build: `OMP_NUM_THREADS=1 MPIRUN='mpiexec --oversubscribe -np 4' ctest --output-on-failure -R '^spectrum_hubbard_offdiag_single_mpi$'`