### PR TITLE
Add BiCG non-finite diagnostics

### DIFF
--- a/src/CalcSpectrumByBiCG.c
+++ b/src/CalcSpectrumByBiCG.c
@@ -25,9 +25,87 @@
 #include "common/setmemory.h"
 #include "komega/komega.h"
 #include "mltply.h"
+#include <math.h>
 #ifdef MPI
 #include <mpi.h>
 #endif
+
+#define BICG_STATUS_NONFINITE 5
+#define BICG_DIAG_SAMPLES 3
+
+typedef struct {
+  double sum2;
+  unsigned long nbad;
+  int nsample;
+  unsigned long sample_index[BICG_DIAG_SAMPLES];
+  double sample_real[BICG_DIAG_SAMPLES];
+  double sample_imag[BICG_DIAG_SAMPLES];
+} BiCGVectorDiag;
+
+static int IsFiniteComplex(double complex z) {
+  return isfinite(creal(z)) && isfinite(cimag(z));
+}
+
+static void AnalyzeBiCGVector(const double complex *v, unsigned long n, BiCGVectorDiag *diag) {
+  unsigned long i;
+  diag->sum2 = 0.0;
+  diag->nbad = 0;
+  diag->nsample = 0;
+  for (i = 0; i < n; i++) {
+    const double real = creal(v[i]);
+    const double imag = cimag(v[i]);
+    if (IsFiniteComplex(v[i])) {
+      diag->sum2 += real * real + imag * imag;
+    } else {
+      if (diag->nsample < BICG_DIAG_SAMPLES) {
+        diag->sample_index[diag->nsample] = i + 1;
+        diag->sample_real[diag->nsample] = real;
+        diag->sample_imag[diag->nsample] = imag;
+        diag->nsample++;
+      }
+      diag->nbad++;
+    }
+  }
+}
+
+static void PrintBiCGVectorDiag(const char *name, const BiCGVectorDiag *diag) {
+  int i;
+  fprintf(stderr, "%s_sum2=%25.17e %s_nbad=%lu", name, diag->sum2, name, diag->nbad);
+  for (i = 0; i < diag->nsample; i++) {
+    fprintf(stderr, " %s_bad[%d]=(idx=%lu,value=%25.17e,%25.17e)",
+            name, i, diag->sample_index[i], diag->sample_real[i], diag->sample_imag[i]);
+  }
+}
+
+static const char *BiCGStatusReason(int status) {
+  switch (status) {
+    case 0: return "converged";
+    case 1: return "not converged";
+    case 2: return "alpha breakdown";
+    case 3: return "pi breakdown";
+    case 4: return "rho breakdown";
+    case BICG_STATUS_NONFINITE: return "non-finite detected";
+    default: return "unknown";
+  }
+}
+
+static void PrintBiCGIteration1Diag(
+  const BiCGVectorDiag *v2_diag,
+  const BiCGVectorDiag *v12_diag,
+  int status0,
+  int status1,
+  int status2,
+  double residual
+) {
+  fprintf(stderr,
+          "BiCG iteration-1 diagnostic: rank=%d status=(%d,%d,%d) residual=%25.17e ",
+          myrank, status0, status1, status2, residual);
+  PrintBiCGVectorDiag("v2", v2_diag);
+  fprintf(stderr, " ");
+  PrintBiCGVectorDiag("Hv2", v12_diag);
+  fprintf(stderr, "\n");
+  fflush(stderr);
+}
 /**@brief
 Read @f$\alpha, \beta@f$, projected residual for restart
 */
@@ -230,8 +308,13 @@ int CalcSpectrumByBiCG(
   int ran_bicg_loop = FALSE;
   int bicg_failed = FALSE;
   double max_residual = 0.0;
+  BiCGVectorDiag iter1_v2_diag, iter1_v12_diag;
+  int have_iter1_diag = FALSE;
 
   fprintf(stdoutMPI, "#####  Spectrum calculation with BiCG  #####\n\n");
+  status[0] = 0;
+  status[1] = 0;
+  status[2] = 0;
   /* Defense in depth (independent of the top-level SpectrumNumBra validation): the
      tridiagonal-component restart format stores ONE projected residual stream per BiCG step,
      so multi-bra (nBra>1) is only valid for CalcSpec=Normal. Fail hard before touching any
@@ -333,6 +416,12 @@ int CalcSpectrumByBiCG(
     iret = mltply(&X->Bind, v14, v4);
     if (iret == -1) return FALSE;
 
+    if (stp == 1) {
+      AnalyzeBiCGVector(&v2[1], X->Bind.Check.idim_max, &iter1_v2_diag);
+      AnalyzeBiCGVector(&v12[1], X->Bind.Check.idim_max, &iter1_v12_diag);
+      have_iter1_diag = TRUE;
+    }
+
     for (ibra = 0; ibra < nBra; ibra++)
       res_proj[ibra] = VecProdMPI(X->Bind.Check.idim_max, vlhs_Bra[ibra], v2);
     /**
@@ -340,6 +429,14 @@ int CalcSpectrumByBiCG(
     */
 
     komega_bicg_update(&v12[1], &v2[1], &v14[1], &v4[1], dcSpectrum, res_proj, status);
+
+    if (stp == 1 && have_iter1_diag == TRUE &&
+        (status[1] == BICG_STATUS_NONFINITE || IsFiniteComplex(v12[1]) == FALSE)) {
+      if (status[0] >= 0) status[0] = -stp;
+      if (status[1] == 0) status[1] = BICG_STATUS_NONFINITE;
+      PrintBiCGIteration1Diag(&iter1_v2_diag, &iter1_v12_diag,
+        status[0], status[1], status[2], creal(v12[1]));
+    }
 
     /**
     <li>Output residuals at each frequency for some analysis</li>
@@ -363,10 +460,18 @@ int CalcSpectrumByBiCG(
   fclose(fp);
   if (ran_bicg_loop == TRUE && (status[0] >= 0 || status[1] != 0)) {
     bicg_failed = TRUE;
-    max_residual = 0.0;
-    komega_bicg_getresidual(resz);
-    for (iomega = 0; iomega < Nomega; iomega++) {
-      if (resz[iomega] > max_residual) max_residual = resz[iomega];
+    if (status[1] >= 2) {
+      max_residual = NAN;
+    } else {
+      max_residual = 0.0;
+      komega_bicg_getresidual(resz);
+      for (iomega = 0; iomega < Nomega; iomega++) {
+        if (isfinite(resz[iomega]) == FALSE) {
+          max_residual = resz[iomega];
+          break;
+        }
+        if (resz[iomega] > max_residual) max_residual = resz[iomega];
+      }
     }
   }
   /**
@@ -375,6 +480,21 @@ int CalcSpectrumByBiCG(
   */
   fprintf(stdoutMPI, "    End:   Calculate tridiagonal matrix components.\n\n");
   TimeKeeper(&(X->Bind), cFileNameTimeKeep, c_GetTridiagonalEnd, "a");
+
+  if (bicg_failed == TRUE && status[1] >= 2) {
+    fprintf(stderr,
+      "Error: BiCG spectrum did not finish successfully within Lanczos_max=%u "
+      "(last iteration=%d, status=%d [%s], seed=%d, max residual=%25.15e).\n",
+      X->Bind.Def.Lanczos_max, abs(status[0]), status[1],
+      BiCGStatusReason(status[1]), status[2], max_residual);
+    komega_bicg_finalize();
+    free(resz);
+    free(res_proj);
+    free(v12);
+    free(v14);
+    return FALSE;
+  }
+
   /**
   <li>Save @f$\alpha, \beta@f$, projected residual</li>
   */
@@ -414,8 +534,9 @@ int CalcSpectrumByBiCG(
   if (bicg_failed == TRUE) {
     fprintf(stderr,
       "Error: BiCG spectrum did not finish successfully within Lanczos_max=%u "
-      "(last iteration=%d, status=%d, seed=%d, max residual=%25.15e).\n",
-      X->Bind.Def.Lanczos_max, abs(status[0]), status[1], status[2], max_residual);
+      "(last iteration=%d, status=%d [%s], seed=%d, max residual=%25.15e).\n",
+      X->Bind.Def.Lanczos_max, abs(status[0]), status[1],
+      BiCGStatusReason(status[1]), status[2], max_residual);
     komega_bicg_finalize();
     free(resz);
     free(res_proj);

--- a/src/komega/komega_bicg.F90
+++ b/src/komega/komega_bicg.F90
@@ -81,6 +81,114 @@ MODULE komega_bicg
   !
 CONTAINS
 !>
+!! Non-finite checks.  These avoid compiler-dependent IEEE module support and
+!! follow the existing ABS-based breakdown style in this bundled Komega source.
+!!
+LOGICAL FUNCTION komega_BICG_isfinite_c(val)
+  !
+  IMPLICIT NONE
+  !
+  COMPLEX(8),INTENT(IN) :: val
+  !
+  komega_BICG_isfinite_c = ABS(val) < HUGE(0d0)
+  !
+END FUNCTION komega_BICG_isfinite_c
+!
+LOGICAL FUNCTION komega_BICG_isfinite_r(val)
+  !
+  IMPLICIT NONE
+  !
+  REAL(8),INTENT(IN) :: val
+  !
+  komega_BICG_isfinite_r = ABS(val) < HUGE(0d0)
+  !
+END FUNCTION komega_BICG_isfinite_r
+!
+SUBROUTINE komega_BICG_set_failure(status, code)
+  !
+  USE komega_parameter, ONLY : iter, iz_seed
+  !
+  IMPLICIT NONE
+  !
+  INTEGER,INTENT(INOUT) :: status(3)
+  INTEGER,INTENT(IN) :: code
+  !
+  status(1) = -iter
+  status(2) = code
+  IF(status(3) == 0) status(3) = iz_seed
+  !
+END SUBROUTINE komega_BICG_set_failure
+!
+SUBROUTINE komega_BICG_check_projection(r_l, status)
+  !
+  USE komega_parameter, ONLY : nl
+  !
+  IMPLICIT NONE
+  !
+  COMPLEX(8),INTENT(IN) :: r_l(nl)
+  INTEGER,INTENT(INOUT) :: status(3)
+  !
+  INTEGER :: il
+  !
+  DO il = 1, nl
+     IF(.NOT. komega_BICG_isfinite_c(r_l(il))) THEN
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+  END DO
+  !
+END SUBROUTINE komega_BICG_check_projection
+!
+SUBROUTINE komega_BICG_check_shiftedeqn(status)
+  !
+  USE komega_parameter, ONLY : nz, almost0, lz_conv
+  USE komega_vals_c, ONLY : alpha, alpha_old, beta, pi, pi_old, z, z_seed
+  !
+  IMPLICIT NONE
+  !
+  INTEGER,INTENT(INOUT) :: status(3)
+  !
+  INTEGER :: iz
+  COMPLEX(8) :: pi_new
+  !
+  IF(.NOT. komega_BICG_isfinite_c(alpha) .OR. &
+  &  .NOT. komega_BICG_isfinite_c(alpha_old) .OR. &
+  &  .NOT. komega_BICG_isfinite_c(beta)) THEN
+     CALL komega_BICG_set_failure(status, 5)
+     RETURN
+  END IF
+  IF(ABS(alpha_old) < almost0) THEN
+     CALL komega_BICG_set_failure(status, 2)
+     RETURN
+  END IF
+  DO iz = 1, nz
+     IF(lz_conv(iz)) cycle
+     IF(.NOT. komega_BICG_isfinite_c(pi(iz)) .OR. &
+     &  .NOT. komega_BICG_isfinite_c(pi_old(iz))) THEN
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+     IF(ABS(pi(iz)) < almost0) THEN
+        status(3) = iz
+        CALL komega_BICG_set_failure(status, 3)
+        RETURN
+     END IF
+     pi_new = (1d0 + alpha * (z(iz) - z_seed)) * pi(iz) &
+     &      - alpha * beta / alpha_old * (pi_old(iz) - pi(iz))
+     IF(.NOT. komega_BICG_isfinite_c(pi_new)) THEN
+        status(3) = iz
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+     IF(ABS(pi_new) < almost0) THEN
+        status(3) = iz
+        CALL komega_BICG_set_failure(status, 3)
+        RETURN
+     END IF
+  END DO
+  !
+END SUBROUTINE komega_BICG_check_shiftedeqn
+!>
 !! Shifted Part
 !!
 SUBROUTINE komega_BICG_shiftedeqn(r_l, x)
@@ -131,22 +239,74 @@ SUBROUTINE komega_BICG_seed_switch(v2, v4, status)
   COMPLEX(8),INTENT(INOUT) :: v2(ndim), v4(ndim)
   INTEGER,INTENT(INOUT) :: status(3)
   !
-  INTEGER :: jter
-  COMPLEX(8) :: scale
+  INTEGER :: iz, jter, new_seed
+  COMPLEX(8) :: scale, alpha_new, rho_new
   !
-  status(3) = MINLOC(ABS(pi(1:nz)), 1, .NOT. lz_conv(1:nz))
-  !
-  IF(ABS(pi(status(3))) < almost0) THEN
-     status(2) = 3
+  IF(ALL(lz_conv(1:nz))) THEN
+     status(3) = iz_seed
+     RETURN
   END IF
   !
-  IF(status(3) /= iz_seed) THEN
+  DO iz = 1, nz
+     IF(lz_conv(iz)) cycle
+     IF(.NOT. komega_BICG_isfinite_c(pi(iz)) .OR. &
+     &  .NOT. komega_BICG_isfinite_c(pi_old(iz))) THEN
+        status(3) = iz
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+  END DO
+  !
+  new_seed = MINLOC(ABS(pi(1:nz)), 1, .NOT. lz_conv(1:nz))
+  status(3) = new_seed
+  !
+  IF(ABS(pi(new_seed)) < almost0) THEN
+     CALL komega_BICG_set_failure(status, 3)
+     RETURN
+  END IF
+  !
+  IF(new_seed /= iz_seed) THEN
      !
-     iz_seed = status(3)
+     IF(.NOT. komega_BICG_isfinite_c(alpha) .OR. &
+     &  .NOT. komega_BICG_isfinite_c(rho)) THEN
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+     IF(ABS(pi_old(new_seed)) < almost0) THEN
+        CALL komega_BICG_set_failure(status, 3)
+        RETURN
+     END IF
+     alpha_new = alpha * pi_old(new_seed) / pi(new_seed)
+     rho_new = rho / pi_old(new_seed)**2
+     IF(.NOT. komega_BICG_isfinite_c(alpha_new) .OR. &
+     &  .NOT. komega_BICG_isfinite_c(rho_new)) THEN
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+     !
+     ! For restarting
+     !
+     IF(itermax > 0) THEN
+        DO jter = 1, iter
+           IF(.NOT. komega_BICG_isfinite_c(pi_save(new_seed, jter - 2)) .OR. &
+           &  .NOT. komega_BICG_isfinite_c(pi_save(new_seed, jter - 1)) .OR. &
+           &  .NOT. komega_BICG_isfinite_c(pi_save(new_seed, jter))) THEN
+              CALL komega_BICG_set_failure(status, 5)
+              RETURN
+           END IF
+           IF(ABS(pi_save(new_seed, jter - 1)) < almost0 .OR. &
+           &  ABS(pi_save(new_seed, jter)) < almost0) THEN
+              CALL komega_BICG_set_failure(status, 3)
+              RETURN
+           END IF
+        END DO
+     END IF
+     !
+     iz_seed = new_seed
      z_seed = z(iz_seed)
      !
-     alpha = alpha * pi_old(iz_seed) / pi(iz_seed)
-     rho = rho / pi_old(iz_seed)**2
+     alpha = alpha_new
+     rho = rho_new
      !
      scale = 1d0 / pi(iz_seed)
      CALL zscal(ndim, scale, v2, 1)
@@ -360,7 +520,7 @@ END SUBROUTINE komega_BICG_restart
 SUBROUTINE komega_BICG_update(v12, v2, v14, v4, x, r_l, status) BIND(C)
   !
   USE ISO_C_BINDING
-  USE komega_parameter, ONLY : iter, itermax, ndim, nl, nz, &
+  USE komega_parameter, ONLY : iter, itermax, ndim, nl, nz, iz_seed, &
   &                            threshold, almost0, lz_conv, resnorm
   USE komega_vals_c, ONLY : alpha, alpha_old, alpha_save, &
   &                         beta, beta_save, rho, z_seed, pi
@@ -374,29 +534,70 @@ SUBROUTINE komega_BICG_update(v12, v2, v14, v4, x, r_l, status) BIND(C)
   INTEGER(C_INT),INTENT(INOUT) :: status(3)
   !
   INTEGER :: iz
-  COMPLEX(8) :: rho_old, alpha_denom
+  REAL(8) :: res_shift
+  COMPLEX(8) :: rho_old, alpha_denom, resdot
   !
   iter = iter + 1
   status(1:3) = 0
+  status(3) = iz_seed
   !
   rho_old = rho
   rho = zdotcMPI(ndim,v4,v2)
+  IF(.NOT. komega_BICG_isfinite_c(rho)) THEN
+     CALL komega_BICG_set_failure(status, 5)
+     RETURN
+  END IF
   IF(iter == 1) THEN
      beta = CMPLX(0d0, 0d0, KIND(0d0))
   ELSE
+     IF(.NOT. komega_BICG_isfinite_c(rho_old)) THEN
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+     IF(ABS(rho_old) < almost0) THEN
+        CALL komega_BICG_set_failure(status, 4)
+        RETURN
+     END IF
      beta = rho / rho_old
+     IF(.NOT. komega_BICG_isfinite_c(beta)) THEN
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
   END IF
   v12(1:ndim) = z_seed * v2(1:ndim) - v12(1:ndim)
   v14(1:ndim) = CONJG(z_seed) * v4(1:ndim) - v14(1:ndim)
   alpha_old = alpha
+  IF(.NOT. komega_BICG_isfinite_c(alpha)) THEN
+     CALL komega_BICG_set_failure(status, 5)
+     RETURN
+  END IF
+  IF(ABS(alpha) < almost0) THEN
+     CALL komega_BICG_set_failure(status, 2)
+     RETURN
+  END IF
   alpha_denom = zdotcMPI(ndim,v4,v12) - beta * rho / alpha
   !
+  IF(.NOT. komega_BICG_isfinite_c(alpha_denom)) THEN
+     CALL komega_BICG_set_failure(status, 5)
+     RETURN
+  END IF
   IF(ABS(alpha_denom) < almost0) THEN
-     status(2) = 2
+     CALL komega_BICG_set_failure(status, 2)
+     RETURN
   ELSE IF(ABS(rho) < almost0) THEN
-     status(2) = 4
+     CALL komega_BICG_set_failure(status, 4)
+     RETURN
   END IF
   alpha = rho / alpha_denom
+  IF(.NOT. komega_BICG_isfinite_c(alpha)) THEN
+     CALL komega_BICG_set_failure(status, 5)
+     RETURN
+  END IF
+  !
+  CALL komega_BICG_check_projection(r_l, status)
+  IF(status(2) /= 0) RETURN
+  CALL komega_BICG_check_shiftedeqn(status)
+  IF(status(2) /= 0) RETURN
   !
   ! For restarting
   !
@@ -426,13 +627,39 @@ SUBROUTINE komega_BICG_update(v12, v2, v14, v4, x, r_l, status) BIND(C)
   ! Seed Switching
   !
   CALL komega_BICG_seed_switch(v2,v4,status)
+  IF(status(2) /= 0) RETURN
   !
   ! Convergence check
   !
-  resnorm = SQRT(DBLE(zdotcMPI(ndim,v2,v2)))
+  resdot = zdotcMPI(ndim,v2,v2)
+  IF(.NOT. komega_BICG_isfinite_c(resdot) .OR. DBLE(resdot) < 0d0) THEN
+     CALL komega_BICG_set_failure(status, 5)
+     RETURN
+  END IF
+  resnorm = SQRT(DBLE(resdot))
+  IF(.NOT. komega_BICG_isfinite_r(resnorm)) THEN
+     CALL komega_BICG_set_failure(status, 5)
+     RETURN
+  END IF
   !
   DO iz = 1, nz
-     IF(ABS(resnorm/pi(iz)) < threshold) lz_conv(iz) = .TRUE.
+     IF(.NOT. komega_BICG_isfinite_c(pi(iz))) THEN
+        status(3) = iz
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+     IF(ABS(pi(iz)) < almost0) THEN
+        status(3) = iz
+        CALL komega_BICG_set_failure(status, 3)
+        RETURN
+     END IF
+     res_shift = ABS(resnorm/pi(iz))
+     IF(.NOT. komega_BICG_isfinite_r(res_shift)) THEN
+        status(3) = iz
+        CALL komega_BICG_set_failure(status, 5)
+        RETURN
+     END IF
+     IF(res_shift < threshold) lz_conv(iz) = .TRUE.
   END DO
   !
   IF(resnorm < threshold) THEN

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -348,6 +348,20 @@ add_test(NAME unittest_setmemory_zero_size_common
 set_tests_properties(unittest_setmemory_zero_size_common
     PROPERTIES LABELS "unit;setmemory")
 
+# Unit test: komega BiCG non-finite guard
+add_executable(unittest_komega_bicg_nonfinite
+    ${CMAKE_SOURCE_DIR}/test/unittest_komega_bicg_nonfinite.c)
+target_include_directories(unittest_komega_bicg_nonfinite
+    PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(unittest_komega_bicg_nonfinite komega)
+if(MPI_FOUND)
+    target_link_libraries(unittest_komega_bicg_nonfinite ${MPI_C_LIBRARIES})
+endif(MPI_FOUND)
+add_test(NAME unittest_komega_bicg_nonfinite
+    COMMAND unittest_komega_bicg_nonfinite)
+set_tests_properties(unittest_komega_bicg_nonfinite
+    PROPERTIES LABELS "unit;spectrum")
+
 # MPI consistency for the off-diagonal spectrum (4-site Hubbard needs np=4)
 add_hphi_mpi_test(spectrum_hubbard_offdiag_single_mpi exact:4)
 set_tests_properties(spectrum_hubbard_offdiag_single_mpi

--- a/test/unittest_komega_bicg_nonfinite.c
+++ b/test/unittest_komega_bicg_nonfinite.c
@@ -1,0 +1,53 @@
+/* Unit test for BiCG non-finite input detection.
+ * The pre-fix path propagated NaN through rho/alpha/resnorm and reported it
+ * only indirectly after contaminating the update state. */
+#include "komega/komega.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+
+#ifdef MPI
+#include <mpi.h>
+#endif
+
+int main(int argc, char **argv) {
+  int ndim = 1;
+  int nl = 1;
+  int nz = 1;
+  int itermax = 2;
+  int comm = 0;
+  int status[3] = {0, 0, 0};
+  double threshold = 1.0e-12;
+  double complex x[1] = {0.0};
+  double complex z[1] = {1.0 + 0.1 * I};
+  double complex v12[1] = {0.0};
+  double complex v2[1] = {NAN + 0.0 * I};
+  double complex v14[1] = {0.0};
+  double complex v4[1] = {1.0};
+  double complex r_l[1] = {1.0};
+
+#ifdef MPI
+  MPI_Init(&argc, &argv);
+  comm = (int)MPI_Comm_c2f(MPI_COMM_WORLD);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+
+  komega_bicg_init(&ndim, &nl, &nz, x, z, &itermax, &threshold, &comm);
+  komega_bicg_update(v12, v2, v14, v4, x, r_l, status);
+  komega_bicg_finalize();
+
+#ifdef MPI
+  MPI_Finalize();
+#endif
+
+  if (status[0] < 0 && status[1] == 5) {
+    printf("UNIT TEST PASSED\n");
+    return 0;
+  }
+
+  printf("UNIT TEST FAILED: status=(%d,%d,%d)\n", status[0], status[1], status[2]);
+  return 1;
+}


### PR DESCRIPTION
## Summary

This PR adds diagnostics and fail-fast handling for shifted BiCG non-finite failures in spectrum calculations.

- Add iteration-1 per-rank diagnostics in `CalcSpectrumByBiCG`
  - local `v2` norm / non-finite count
  - local `H v2` norm / non-finite count
  - first few non-finite samples
- Add `status=5` handling in `komega_bicg` for NaN/Inf detection
- Stop immediately on breakdown/non-finite failures before writing contaminated restart/output files
- Keep the existing `status=1` non-convergence restart-save behavior
- Add a komega unit test that injects NaN and verifies `status=5`

## Motivation

Recent CI failures showed BiCG can enter a bad state at iteration 1 and then continue until `Lanczos_max`, producing misleading residual output. This PR does not assume the CI flake root cause; instead it makes the next failure diagnosable and prevents non-finite values from propagating through the solver state.

The iteration-1 diagnostics should distinguish:

- corrupted input residual vector
- corruption during `H v`
- solver scalar/reduction failure after finite input vectors
- finite but wrong-value divergence

## Notes

For failure status `2/3/4/5`, this PR skips restart/output writing because komega may return before saving the current iteration coefficients. For `status=1` non-convergence, the previous restart-save behavior is preserved.

## Tests

- `git diff --check`
- `unittest_komega_bicg_nonfinite`
- `spectrum_bicg_nonconvergence_reject`
- `spectrum_hubbard_offdiag_single_mpi` with `MPIRUN='mpirun --oversubscribe -np 4'`
- `spectrum_hubbard_offdiag_single`
- `spectrum_hubbard_offdiag_pair_density`
- `spectrum_hubbard_offdiag_single_mpi --repeat until-fail:20`
- `ENABLE_MPI=OFF` build of `unittest_komega_bicg_nonfinite`
- Manual NaN-injection check in an MPI=4 spectrum run confirmed per-rank diagnostics and immediate `status=5` failure.
