### PR TITLE
Fix stale ModPara imaginary values

### DIFF
--- a/src/readdef.c
+++ b/src/readdef.c
@@ -682,11 +682,21 @@ int ReadDefFileNInt(
         //! Read header (1 line).
             fgetsMPI(ctmp, sizeof(ctmp) / sizeof(char), fp);   //8
             double dtmp, dtmp2;
+            int nread;
             X->read_hacker = 1;
         //! Read lines.
             while (fgetsMPI(ctmp2, 256, fp) != NULL) {
               if (*ctmp2 == '\n') continue;
-              sscanf(ctmp2, "%s %lf %lf\n", ctmp, &dtmp, &dtmp2);
+              dtmp = 0.0;
+              dtmp2 = 0.0;
+              nread = sscanf(ctmp2, "%199s %lf %lf", ctmp, &dtmp, &dtmp2);
+              if (nread < 2) {
+                fprintf(stdoutMPI,
+                        "Error in %s\n ModPara line must contain a keyword and numeric value: %s",
+                        defname, ctmp2);
+                fclose(fp);
+                return (-1);
+              }
               if (CheckWords(ctmp, "Nsite") == 0) {
                 X->Nsite = (int) dtmp;
               }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,9 @@ set_tests_properties(unittest_symmetry_basis
 add_hphi_test(lanczos_hubbard_square)
 add_hphi_test(lanczos_hubbard_square_calchs2)
 add_hphi_test(lanczos_hubbard_square_ncond_calchs2)
+add_hphi_test(modpara_parse_validation)
+set_tests_properties(modpara_parse_validation
+    PROPERTIES LABELS "validation;input")
 add_hphi_test(lanczos_hubbard_chain_polarized_calchs2)
 add_hphi_test(calchs2_unsupported_reject)
 add_hphi_test(threebody_calcmodel_validation)

--- a/test/modpara_parse_validation.sh
+++ b/test/modpara_parse_validation.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+testname="modpara_parse_validation"
+hphi="../../src/HPhi"
+
+rm -rf "${testname}"
+mkdir -p "${testname}"
+cd "${testname}"
+
+cat > stan.in <<EOF
+model = "Hubbard"
+method = "Lanczos"
+lattice = "chain"
+L = 4
+t = 1.0
+U = 4.0
+nelec = 4
+2Sz = 0
+EOF
+
+"${hphi}" -sdry stan.in > generate.log 2>&1 || {
+  cat generate.log
+  exit 1
+}
+
+awk '
+  $1 == "Lanczos_max" {
+    print "Lanczos_max"
+    next
+  }
+  { print }
+' modpara.def > modpara.def.tmp
+mv modpara.def.tmp modpara.def
+
+set +e
+"${hphi}" -e namelist.def > malformed.log 2>&1
+rc=$?
+set -e
+
+if [ "${rc}" -eq 0 ]; then
+  echo "Expected a ModPara line without a numeric value to be rejected."
+  cat malformed.log
+  exit 1
+fi
+
+if ! grep -q "ModPara line must contain a keyword and numeric value" malformed.log; then
+  echo "Malformed ModPara was not rejected by the expected parser guard."
+  cat malformed.log
+  exit 1
+fi
+
+echo "ModPara parser rejects a line without a numeric value."

--- a/test/spectrum_hubbard_offdiag_single.sh
+++ b/test/spectrum_hubbard_offdiag_single.sh
@@ -64,7 +64,8 @@ initial_iv     -1
 exct           1
 LanczosEps     14
 LanczosTarget  2
-LargeValue     8.0
+# The ignored third field must not leak into later one-value Omega lines.
+LargeValue     8.0  3.25
 NumAve         5
 ExpecInterval  20
 NOmega         5

--- a/test/spectrum_hubbard_offdiag_single_mpi.sh
+++ b/test/spectrum_hubbard_offdiag_single_mpi.sh
@@ -112,7 +112,8 @@ initial_iv     -1
 exct           1
 LanczosEps     14
 LanczosTarget  2
-LargeValue     8.0
+# The ignored third field must not leak into later one-value Omega lines.
+LargeValue     8.0  3.25
 NumAve         5
 ExpecInterval  20
 NOmega         5


### PR DESCRIPTION
## Summary

- reset the parsed ModPara numeric fields for every input line so an omitted optional third value defaults to zero
- validate the `sscanf` result and reject ModPara entries that do not contain a numeric value
- add parser and spectrum regressions for stale optional imaginary values in serial and MPI runs

## Root cause

The ModPara parser reused `dtmp2` without initializing it for each line and did not check how many fields `sscanf` parsed. One-value `OmegaOrg`, `OmegaMin`, and `OmegaMax` entries could therefore receive an indeterminate or stale imaginary component. In the failing MPI spectrum test this corrupted the BiCG frequency on one rank and caused an alpha breakdown.

The spectrum regressions now place an explicit third value on an earlier parameter line, making the stale-value behavior deterministic while retaining the normal one-value Omega syntax.

## User impact

One-value ModPara spectrum entries now produce deterministic real values with a zero imaginary component. Malformed entries that omit their required numeric value fail immediately with a parser error instead of reusing a previous value.

## Validation

- validation-labeled tests: 25/25 passed
- related serial spectrum regressions: 8/8 passed
- `spectrum_hubbard_offdiag_single_mpi`: passed with 4 MPI ranks in both batched and `HPHI_MPI_NOBATCH=1` modes
- deterministic A/B regression:
  - base implementation accumulated L1 difference: `3.2042205427`
  - fixed implementation accumulated L1 difference: `0.0000004354`
- `git diff --check` passed
