### PR TITLE
Optimize symmetry matvec with local-row plan

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(HPhi PRIVATE
   readdef.c sz.c vec12.c xsetmem.c ErrorMessage.c LogMessage.c
   ProgressMessage.c wrapperMPI.c splash.c time.c eigenIO.c struct.c
   nbody_interall.c anomalous_pair.c green_output.c symmetry_basis.c symmetry_basis_io.c
+  symmetry_matvec_plan.c
 )
 
 # Multiply operations
@@ -95,6 +96,9 @@ target_sources(HPhi PRIVATE
   ${STDFACE_DIR}/src/Wannier90.c
 )
 target_link_libraries(HPhi komega ${LAPACK_LIBRARIES} m)
+if(TARGET OpenMP::OpenMP_C)
+  target_link_libraries(HPhi OpenMP::OpenMP_C)
+endif()
 if(MPI_FOUND)
   target_link_libraries(HPhi ${MPI_C_LIBRARIES})
 endif(MPI_FOUND)

--- a/src/HPhiMain.c
+++ b/src/HPhiMain.c
@@ -34,6 +34,7 @@
 #include "CalcTime.h"
 #include "symmetry_basis.h"
 #include "symmetry_basis_io.h"
+#include "symmetry_matvec_plan.h"
 
 /*!
   @mainpage
@@ -767,15 +768,26 @@ int main(int argc, char* argv[]){
     StopTimer(2000);
 
     if (X.Bind.Def.iFlgSymmetryBasis == TRUE) {
+      StartTimer(1100);
       if (BuildSymmetryBasis(&(X.Bind)) != 0) {
+        StopTimer(1100);
         exitMPI(-1);
       }
       if (ActivateSymmetryBasisDimension(&(X.Bind)) != 0) {
+        StopTimer(1100);
         exitMPI(-1);
       }
       if (ValidateSymmetrySectorOptions(&(X.Bind)) != 0) {
+        StopTimer(1100);
         exitMPI(-1);
       }
+      StopTimer(1100);
+      StartTimer(1101);
+      if (BuildSymmetryMatvecPlan(&(X.Bind)) != 0) {
+        StopTimer(1101);
+        exitMPI(-1);
+      }
+      StopTimer(1101);
     }
       
     switch (X.Bind.Def.iCalcType) {
@@ -843,6 +855,8 @@ int main(int argc, char* argv[]){
   
   StopTimer(0);
   OutputTimer(&(X.Bind));
+  FreeSymmetryBasis(X.Bind.Sym);
+  X.Bind.Sym = NULL;
   FinalizeMPI();
   return 0;
 }

--- a/src/include/symmetry_basis.h
+++ b/src/include/symmetry_basis.h
@@ -5,6 +5,7 @@
 
 struct BindStruct;
 struct DefineList;
+struct SymmetryMatvecPlan;
 
 struct SymmetryBasisVector {
   unsigned long int rep_state;
@@ -44,6 +45,8 @@ struct SymmetryBasisRuntime {
   int *mpi_recvcounts;
   int *mpi_displs;
   double complex *mpi_full_v1;
+  int matvec_mode;
+  struct SymmetryMatvecPlan *matvec_plan;
 };
 
 int ValidateSymmetryGroupInput(const struct DefineList *def);

--- a/src/include/symmetry_matvec_plan.h
+++ b/src/include/symmetry_matvec_plan.h
@@ -1,0 +1,42 @@
+#ifndef HPHI_SYMMETRY_MATVEC_PLAN_H
+#define HPHI_SYMMETRY_MATVEC_PLAN_H
+
+#include "Common.h"
+
+struct BindStruct;
+
+#define SYMMETRY_MATVEC_MODE_PLAN 0
+#define SYMMETRY_MATVEC_MODE_LEGACY 1
+
+struct SymmetryMatvecPlan {
+  int ready;
+  unsigned long int dim;
+  unsigned long int local_offset;
+  unsigned long int local_dim;
+  size_t nnz;
+  size_t *row_ptr;
+  unsigned long int *col_index;
+  double complex *values;
+};
+
+/**
+ * Receive one matrix entry H(out_index, beta) from SymmetryEnumerateColumn().
+ * coefficient includes the canonical phase and norm[out_index]/norm[beta],
+ * but does not include an input-vector amplitude.
+ */
+typedef int (*SymmetryEntryCallback)(unsigned long int out_index,
+                                     double complex coefficient,
+                                     void *context);
+
+int SymmetryEnumerateColumn(const struct BindStruct *X,
+                            unsigned long int beta,
+                            SymmetryEntryCallback callback,
+                            void *context);
+int BuildSymmetryMatvecPlan(struct BindStruct *X);
+int ApplySymmetryMatvecPlan(const struct BindStruct *X,
+                            double complex *tmp_v0,
+                            const double complex *full_v1,
+                            double complex *local_prdct);
+void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan);
+
+#endif /* HPHI_SYMMETRY_MATVEC_PLAN_H */

--- a/src/include/wrapperMPI.h
+++ b/src/include/wrapperMPI.h
@@ -34,6 +34,7 @@ double complex SumMPI_dc(double complex norm);
 double SumMPI_d(double norm);
 unsigned long int SumMPI_li(unsigned long int idim);
 int SumMPI_i(int idim);
+int BcastMPI_i(int root, int idim);
 unsigned long int BcastMPI_li(int root, unsigned long int idim);
 double NormMPI_dc(unsigned long int idim, double complex *_v1);
 double complex VecProdMPI(long unsigned int ndim, double complex *v1, double complex *v2);

--- a/src/mltplySpinSym.c
+++ b/src/mltplySpinSym.c
@@ -2,107 +2,56 @@
 #ifdef MPI
 #include <mpi.h>
 #endif
-#include <limits.h>
+#include "CalcTime.h"
 #include "DefCommon.h"
-#include "bitcalc.h"
 #include "global.h"
-#include "symmetry_basis.h"
 #include "struct.h"
-#include "wrapperMPI.h"
+#include "symmetry_basis.h"
+#include "symmetry_matvec_plan.h"
 
-static int apply_exchange_halfspin(unsigned long int state,
-                                   int site0,
-                                   int site1,
-                                   unsigned long int *out_state)
-{
-  unsigned long int b0 = (state >> (unsigned int)site0) & 1UL;
-  unsigned long int b1 = (state >> (unsigned int)site1) & 1UL;
-  if (b0 == b1) return FALSE;
-  *out_state = state ^ (1UL << (unsigned int)site0) ^ (1UL << (unsigned int)site1);
-  return TRUE;
-}
+struct LegacyApplyContext {
+  const struct BindStruct *X;
+  double complex *tmp_v0;
+  const double complex *full_v1;
+  double complex input_amp;
+  double complex prdct;
+};
 
-static unsigned long int mask_between_sites(unsigned int site0, unsigned int site1)
+static int apply_legacy_entry(unsigned long int out_index,
+                              double complex coefficient,
+                              void *context)
 {
-  unsigned int lo = site0 < site1 ? site0 : site1;
-  unsigned int hi = site0 < site1 ? site1 : site0;
-  if (hi <= lo + 1U) return 0UL;
-  return (1UL << hi) - (1UL << (lo + 1U));
-}
-
-static int apply_spinless_hopping_hermite(unsigned long int state,
-                                          unsigned int site1,
-                                          unsigned int site2,
-                                          double complex trans,
-                                          unsigned long int *out_state,
-                                          double complex *hval)
-{
-  unsigned long int mask1 = 1UL << site1;
-  unsigned long int mask2 = 1UL << site2;
-  unsigned long int occupied1 = state & mask1;
-  unsigned long int occupied2 = state & mask2;
-  int sgn = 1;
-  if (site1 == site2) return FALSE;
-  if ((occupied1 == 0UL && occupied2 == 0UL) ||
-      (occupied1 != 0UL && occupied2 != 0UL)) {
-    return FALSE;
-  }
-  SgnBit(state & mask_between_sites(site1, site2), &sgn);
-  *out_state = state ^ mask1 ^ mask2;
-  if (occupied1 != 0UL && occupied2 == 0UL) {
-    *hval = (double)sgn * conj(trans);
-  } else {
-    *hval = (double)sgn * trans;
-  }
-  return TRUE;
-}
-
-static int apply_hubbard_hopping_hermite(unsigned long int state,
-                                         unsigned int site1,
-                                         unsigned int spin1,
-                                         unsigned int site2,
-                                         unsigned int spin2,
-                                         double complex trans,
-                                         unsigned long int *out_state,
-                                         double complex *hval)
-{
-  const unsigned int max_bits = (unsigned int)(sizeof(unsigned long int) * CHAR_BIT);
-  unsigned int orbital1;
-  unsigned int orbital2;
-  if (spin1 > 1U || spin2 > 1U) return FALSE;
-  if (site1 > (max_bits - spin1) / 2U ||
-      site2 > (max_bits - spin2) / 2U) {
-    return FALSE;
-  }
-  orbital1 = 2U * site1 + spin1;
-  orbital2 = 2U * site2 + spin2;
-  if (orbital1 >= max_bits || orbital2 >= max_bits) return FALSE;
-  return apply_spinless_hopping_hermite(state, orbital1, orbital2, trans,
-                                        out_state, hval);
-}
-
-static int add_canonicalized_transition(struct BindStruct *X,
-                                        double complex *tmp_v0,
-                                        const double complex *full_v1,
-                                        double complex *prdct,
-                                        unsigned long int beta,
-                                        unsigned long int to_state,
-                                        double complex hval,
-                                        double complex input_amp)
-{
-  unsigned long int alpha;
-  unsigned long int local_alpha;
-  double norm_factor;
+  unsigned long int local_index;
   double complex contribution;
-  struct SymmetryCanonicalResult result;
-  if (SymmetryCanonicalizeState(X, to_state, &result) != 0) return -1;
-  if (result.found != TRUE) return 0;
-  alpha = result.basis_index;
-  if (SymmetryBasisGlobalToLocal(X->Sym, alpha, &local_alpha) != TRUE) return 0;
-  norm_factor = X->Sym->basis[alpha].norm / X->Sym->basis[beta].norm;
-  contribution = hval * result.phase * norm_factor * input_amp;
-  tmp_v0[local_alpha] += contribution;
-  *prdct += conj(full_v1[alpha]) * contribution;
+  struct LegacyApplyContext *apply = (struct LegacyApplyContext *)context;
+  if (SymmetryBasisGlobalToLocal(apply->X->Sym, out_index, &local_index) != TRUE) {
+    return 0;
+  }
+  contribution = coefficient * apply->input_amp;
+  apply->tmp_v0[local_index] += contribution;
+  apply->prdct += conj(apply->full_v1[out_index]) * contribution;
+  return 0;
+}
+
+static int apply_legacy_scan(struct BindStruct *X,
+                             double complex *tmp_v0,
+                             const double complex *full_v1,
+                             double complex *prdct)
+{
+  unsigned long int beta;
+  struct LegacyApplyContext context;
+  context.X = X;
+  context.tmp_v0 = tmp_v0;
+  context.full_v1 = full_v1;
+  context.prdct = 0.0;
+  for (beta = 1UL; beta <= X->Sym->dim; beta++) {
+    context.input_amp = full_v1[beta];
+    if (cabs(context.input_amp) == 0.0) continue;
+    if (SymmetryEnumerateColumn(X, beta, apply_legacy_entry, &context) != 0) {
+      return -1;
+    }
+  }
+  *prdct = context.prdct;
   return 0;
 }
 
@@ -136,73 +85,33 @@ int mltplySpinSym(struct BindStruct *X,
                   double complex *tmp_v0,
                   double complex *tmp_v1)
 {
-  unsigned long int beta;
   double complex prdct = 0.0;
-  const double complex *full_v1 = get_full_input_vector(X, tmp_v1);
+  const double complex *full_v1;
+
+  StartTimer(1501);
+  full_v1 = get_full_input_vector(X, tmp_v1);
+  StopTimer(1501);
   if (full_v1 == NULL) return -1;
 
-  for (beta = 1; beta <= X->Sym->dim; beta++) {
-    unsigned int p;
-    double complex vin = full_v1[beta];
-    if (cabs(vin) == 0.0) continue;
-
-    {
-      unsigned long int local_beta;
-      if (SymmetryBasisGlobalToLocal(X->Sym, beta, &local_beta) == TRUE) {
-        tmp_v0[local_beta] += X->Sym->sym_diagonal[beta] * vin;
-        prdct += X->Sym->sym_diagonal[beta] * conj(vin) * vin;
-      }
+  if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_LEGACY) {
+    StartTimer(1502);
+    if (apply_legacy_scan(X, tmp_v0, full_v1, &prdct) != 0) {
+      StopTimer(1502);
+      return -1;
     }
-
-    if (X->Def.iCalcModel == Spin) {
-      for (p = 0; p < X->Def.NExchangeCoupling; p++) {
-        unsigned long int out_state;
-        if (apply_exchange_halfspin(X->Sym->basis[beta].rep_state,
-                                    X->Def.ExchangeCoupling[p][0],
-                                    X->Def.ExchangeCoupling[p][1],
-                                    &out_state) == TRUE) {
-          if (add_canonicalized_transition(X, tmp_v0, full_v1, &prdct, beta, out_state,
-                                           X->Def.ParaExchangeCoupling[p], vin) != 0) {
-            return -1;
-          }
-        }
-      }
-    } else if (X->Def.iCalcModel == SpinlessFermion) {
-      for (p = 0; p < X->Def.EDNTransfer; p += 2U) {
-        unsigned long int out_state;
-        double complex hval;
-        double complex trans = -X->Def.EDParaGeneralTransfer[p];
-        unsigned int site1 = (unsigned int)X->Def.EDGeneralTransfer[p][0];
-        unsigned int site2 = (unsigned int)X->Def.EDGeneralTransfer[p][2];
-        if (apply_spinless_hopping_hermite(X->Sym->basis[beta].rep_state,
-                                           site1, site2, trans,
-                                           &out_state, &hval) == TRUE) {
-          if (add_canonicalized_transition(X, tmp_v0, full_v1, &prdct, beta, out_state,
-                                           hval, vin) != 0) {
-            return -1;
-          }
-        }
-      }
-    } else if (X->Def.iCalcModel == Hubbard) {
-      for (p = 0; p < X->Def.EDNTransfer; p += 2U) {
-        unsigned long int out_state;
-        double complex hval;
-        double complex trans = -X->Def.EDParaGeneralTransfer[p];
-        unsigned int site1 = (unsigned int)X->Def.EDGeneralTransfer[p][0];
-        unsigned int spin1 = (unsigned int)X->Def.EDGeneralTransfer[p][1];
-        unsigned int site2 = (unsigned int)X->Def.EDGeneralTransfer[p][2];
-        unsigned int spin2 = (unsigned int)X->Def.EDGeneralTransfer[p][3];
-        if (apply_hubbard_hopping_hermite(X->Sym->basis[beta].rep_state,
-                                          site1, spin1, site2, spin2, trans,
-                                          &out_state, &hval) == TRUE) {
-          if (add_canonicalized_transition(X, tmp_v0, full_v1, &prdct, beta, out_state,
-                                           hval, vin) != 0) {
-            return -1;
-          }
-        }
-      }
+    StopTimer(1502);
+  } else if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN) {
+    StartTimer(1503);
+    if (ApplySymmetryMatvecPlan(X, tmp_v0, full_v1, &prdct) != 0) {
+      StopTimer(1503);
+      return -1;
     }
+    StopTimer(1503);
+  } else {
+    fprintf(stdoutMPI, "Error: invalid symmetry matvec mode.\n");
+    return -1;
   }
+
   X->Large.prdct += prdct;
   return 0;
 }

--- a/src/symmetry_basis.c
+++ b/src/symmetry_basis.c
@@ -4,6 +4,7 @@
 #include "DefCommon.h"
 #include "global.h"
 #include "symmetry_basis.h"
+#include "symmetry_matvec_plan.h"
 #include "struct.h"
 #include "wrapperMPI.h"
 
@@ -536,6 +537,8 @@ int ActivateSymmetryBasisDimension(struct BindStruct *X)
   if (X->Sym != NULL && X->Sym->enabled == TRUE) {
     int rank = 0;
     if (nproc < 1 || myrank < 0 || myrank >= nproc) return -1;
+    FreeSymmetryMatvecPlan(X->Sym->matvec_plan);
+    X->Sym->matvec_plan = NULL;
     symmetry_block_range(X->Sym->dim, myrank, nproc,
                          &X->Sym->local_offset, &X->Sym->local_dim);
 #ifdef MPI
@@ -606,6 +609,7 @@ int ValidateSymmetrySectorOptions(const struct BindStruct *X)
 void FreeSymmetryBasis(struct SymmetryBasisRuntime *sym)
 {
   if (sym == NULL) return;
+  FreeSymmetryMatvecPlan(sym->matvec_plan);
   free(sym->basis);
   free(sym->sym_diagonal);
   free(sym->rep_hash_keys);

--- a/src/symmetry_matvec_plan.c
+++ b/src/symmetry_matvec_plan.c
@@ -1,0 +1,371 @@
+#include <limits.h>
+#include <stdint.h>
+#include "DefCommon.h"
+#include "bitcalc.h"
+#include "global.h"
+#include "struct.h"
+#include "symmetry_basis.h"
+#include "symmetry_matvec_plan.h"
+#include "wrapperMPI.h"
+
+static int apply_exchange_halfspin(unsigned long int state,
+                                   int site0,
+                                   int site1,
+                                   unsigned long int *out_state)
+{
+  unsigned long int b0 = (state >> (unsigned int)site0) & 1UL;
+  unsigned long int b1 = (state >> (unsigned int)site1) & 1UL;
+  if (b0 == b1) return FALSE;
+  *out_state = state ^ (1UL << (unsigned int)site0) ^ (1UL << (unsigned int)site1);
+  return TRUE;
+}
+
+static unsigned long int mask_between_sites(unsigned int site0, unsigned int site1)
+{
+  unsigned int lo = site0 < site1 ? site0 : site1;
+  unsigned int hi = site0 < site1 ? site1 : site0;
+  if (hi <= lo + 1U) return 0UL;
+  return (1UL << hi) - (1UL << (lo + 1U));
+}
+
+static int apply_spinless_hopping_hermite(unsigned long int state,
+                                          unsigned int site1,
+                                          unsigned int site2,
+                                          double complex trans,
+                                          unsigned long int *out_state,
+                                          double complex *hval)
+{
+  unsigned long int mask1 = 1UL << site1;
+  unsigned long int mask2 = 1UL << site2;
+  unsigned long int occupied1 = state & mask1;
+  unsigned long int occupied2 = state & mask2;
+  int sgn = 1;
+  if (site1 == site2) return FALSE;
+  if ((occupied1 == 0UL && occupied2 == 0UL) ||
+      (occupied1 != 0UL && occupied2 != 0UL)) {
+    return FALSE;
+  }
+  SgnBit(state & mask_between_sites(site1, site2), &sgn);
+  *out_state = state ^ mask1 ^ mask2;
+  if (occupied1 != 0UL && occupied2 == 0UL) {
+    *hval = (double)sgn * conj(trans);
+  } else {
+    *hval = (double)sgn * trans;
+  }
+  return TRUE;
+}
+
+static int apply_hubbard_hopping_hermite(unsigned long int state,
+                                         unsigned int site1,
+                                         unsigned int spin1,
+                                         unsigned int site2,
+                                         unsigned int spin2,
+                                         double complex trans,
+                                         unsigned long int *out_state,
+                                         double complex *hval)
+{
+  const unsigned int max_bits = (unsigned int)(sizeof(unsigned long int) * CHAR_BIT);
+  unsigned int orbital1;
+  unsigned int orbital2;
+  if (spin1 > 1U || spin2 > 1U) return FALSE;
+  if (site1 > (max_bits - spin1) / 2U ||
+      site2 > (max_bits - spin2) / 2U) {
+    return FALSE;
+  }
+  orbital1 = 2U * site1 + spin1;
+  orbital2 = 2U * site2 + spin2;
+  if (orbital1 >= max_bits || orbital2 >= max_bits) return FALSE;
+  return apply_spinless_hopping_hermite(state, orbital1, orbital2, trans,
+                                        out_state, hval);
+}
+
+static int emit_canonicalized_transition(const struct BindStruct *X,
+                                         unsigned long int beta,
+                                         unsigned long int to_state,
+                                         double complex hval,
+                                         SymmetryEntryCallback callback,
+                                         void *context)
+{
+  double norm_factor;
+  double complex coefficient;
+  struct SymmetryCanonicalResult result;
+  if (SymmetryCanonicalizeState(X, to_state, &result) != 0) return -1;
+  if (result.found != TRUE) return 0;
+  if (X->Sym->basis[beta].norm == 0.0) return -1;
+  norm_factor = X->Sym->basis[result.basis_index].norm /
+                X->Sym->basis[beta].norm;
+  coefficient = hval * result.phase * norm_factor;
+  return callback(result.basis_index, coefficient, context);
+}
+
+int SymmetryEnumerateColumn(const struct BindStruct *X,
+                            unsigned long int beta,
+                            SymmetryEntryCallback callback,
+                            void *context)
+{
+  unsigned int p;
+  if (X == NULL || X->Sym == NULL || callback == NULL || beta == 0UL ||
+      beta > X->Sym->dim || X->Sym->sym_diagonal == NULL) {
+    return -1;
+  }
+
+  if (callback(beta, X->Sym->sym_diagonal[beta], context) != 0) return -1;
+
+  if (X->Def.iCalcModel == Spin) {
+    for (p = 0; p < X->Def.NExchangeCoupling; p++) {
+      unsigned long int out_state;
+      if (apply_exchange_halfspin(X->Sym->basis[beta].rep_state,
+                                  X->Def.ExchangeCoupling[p][0],
+                                  X->Def.ExchangeCoupling[p][1],
+                                  &out_state) == TRUE &&
+          emit_canonicalized_transition(X, beta, out_state,
+                                        X->Def.ParaExchangeCoupling[p],
+                                        callback, context) != 0) {
+        return -1;
+      }
+    }
+    return 0;
+  }
+
+  if (X->Def.iCalcModel == SpinlessFermion) {
+    for (p = 0; p < X->Def.EDNTransfer; p += 2U) {
+      unsigned long int out_state;
+      double complex hval;
+      double complex trans = -X->Def.EDParaGeneralTransfer[p];
+      unsigned int site1 = (unsigned int)X->Def.EDGeneralTransfer[p][0];
+      unsigned int site2 = (unsigned int)X->Def.EDGeneralTransfer[p][2];
+      if (apply_spinless_hopping_hermite(X->Sym->basis[beta].rep_state,
+                                         site1, site2, trans,
+                                         &out_state, &hval) == TRUE &&
+          emit_canonicalized_transition(X, beta, out_state, hval,
+                                        callback, context) != 0) {
+        return -1;
+      }
+    }
+    return 0;
+  }
+
+  if (X->Def.iCalcModel == Hubbard) {
+    for (p = 0; p < X->Def.EDNTransfer; p += 2U) {
+      unsigned long int out_state;
+      double complex hval;
+      double complex trans = -X->Def.EDParaGeneralTransfer[p];
+      unsigned int site1 = (unsigned int)X->Def.EDGeneralTransfer[p][0];
+      unsigned int spin1 = (unsigned int)X->Def.EDGeneralTransfer[p][1];
+      unsigned int site2 = (unsigned int)X->Def.EDGeneralTransfer[p][2];
+      unsigned int spin2 = (unsigned int)X->Def.EDGeneralTransfer[p][3];
+      if (apply_hubbard_hopping_hermite(X->Sym->basis[beta].rep_state,
+                                        site1, spin1, site2, spin2, trans,
+                                        &out_state, &hval) == TRUE &&
+          emit_canonicalized_transition(X, beta, out_state, hval,
+                                        callback, context) != 0) {
+        return -1;
+      }
+    }
+    return 0;
+  }
+
+  return -1;
+}
+
+struct CountEntriesContext {
+  size_t count;
+};
+
+static int count_entry(unsigned long int out_index,
+                       double complex coefficient,
+                       void *context)
+{
+  struct CountEntriesContext *count = (struct CountEntriesContext *)context;
+  (void)out_index;
+  (void)coefficient;
+  if (count->count == SIZE_MAX) return -1;
+  count->count++;
+  return 0;
+}
+
+struct FillEntriesContext {
+  struct SymmetryMatvecPlan *plan;
+  size_t next;
+  size_t end;
+};
+
+static int fill_transposed_entry(unsigned long int out_index,
+                                 double complex coefficient,
+                                 void *context)
+{
+  struct FillEntriesContext *fill = (struct FillEntriesContext *)context;
+  if (fill->next >= fill->end || out_index == 0UL ||
+      out_index > fill->plan->dim) {
+    return -1;
+  }
+  fill->plan->col_index[fill->next] = out_index;
+  fill->plan->values[fill->next] = conj(coefficient);
+  fill->next++;
+  return 0;
+}
+
+static int parse_matvec_mode(void)
+{
+  const char *value = getenv("HPHI_SYMMETRY_MATVEC");
+  if (value == NULL || strcmp(value, "plan") == 0) {
+    return SYMMETRY_MATVEC_MODE_PLAN;
+  }
+  if (strcmp(value, "legacy") == 0) {
+    return SYMMETRY_MATVEC_MODE_LEGACY;
+  }
+  fprintf(stdoutMPI,
+          "Error: HPHI_SYMMETRY_MATVEC must be 'plan' or 'legacy', got '%s'.\n",
+          value);
+  return -1;
+}
+
+static int select_matvec_mode(void)
+{
+  int mode = SYMMETRY_MATVEC_MODE_PLAN;
+  if (myrank == 0) mode = parse_matvec_mode();
+  return BcastMPI_i(0, mode);
+}
+
+void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan)
+{
+  if (plan == NULL) return;
+  free(plan->row_ptr);
+  free(plan->col_index);
+  free(plan->values);
+  free(plan);
+}
+
+int BuildSymmetryMatvecPlan(struct BindStruct *X)
+{
+  unsigned long int local_row;
+  size_t row_ptr_bytes;
+  size_t col_bytes;
+  size_t value_bytes;
+  size_t plan_bytes;
+  size_t min_row_nnz = SIZE_MAX;
+  size_t max_row_nnz = 0U;
+  struct SymmetryMatvecPlan *plan;
+  int mode;
+
+  if (X == NULL || X->Sym == NULL || X->Sym->enabled != TRUE) return -1;
+  FreeSymmetryMatvecPlan(X->Sym->matvec_plan);
+  X->Sym->matvec_plan = NULL;
+
+  mode = select_matvec_mode();
+  if (mode < 0) return -1;
+  X->Sym->matvec_mode = mode;
+  if (mode == SYMMETRY_MATVEC_MODE_LEGACY) {
+    fprintf(stdoutMPI,
+            "Symmetry matvec: mode=legacy (replicated beta scan).\n");
+    return 0;
+  }
+
+  plan = (struct SymmetryMatvecPlan *)calloc(1, sizeof(*plan));
+  if (plan == NULL) return -1;
+  plan->dim = X->Sym->dim;
+  plan->local_offset = X->Sym->local_offset;
+  plan->local_dim = X->Sym->local_dim;
+
+  if (plan->local_dim > (unsigned long int)(SIZE_MAX - 1U) ||
+      (size_t)plan->local_dim + 1U > SIZE_MAX / sizeof(*plan->row_ptr)) {
+    goto fail;
+  }
+  row_ptr_bytes = ((size_t)plan->local_dim + 1U) * sizeof(*plan->row_ptr);
+  plan->row_ptr = (size_t *)calloc((size_t)plan->local_dim + 1U,
+                                  sizeof(*plan->row_ptr));
+  if (plan->row_ptr == NULL) goto fail;
+
+  for (local_row = 0UL; local_row < plan->local_dim; local_row++) {
+    unsigned long int alpha = plan->local_offset + local_row + 1UL;
+    struct CountEntriesContext count = {0U};
+    if (SymmetryEnumerateColumn(X, alpha, count_entry, &count) != 0) goto fail;
+    if (plan->row_ptr[local_row] > SIZE_MAX - count.count) goto fail;
+    plan->row_ptr[local_row + 1UL] = plan->row_ptr[local_row] + count.count;
+    if (count.count < min_row_nnz) min_row_nnz = count.count;
+    if (count.count > max_row_nnz) max_row_nnz = count.count;
+  }
+  plan->nnz = plan->row_ptr[plan->local_dim];
+
+  if (plan->nnz > SIZE_MAX / sizeof(*plan->col_index) ||
+      plan->nnz > SIZE_MAX / sizeof(*plan->values)) {
+    goto fail;
+  }
+  col_bytes = plan->nnz * sizeof(*plan->col_index);
+  value_bytes = plan->nnz * sizeof(*plan->values);
+  if (plan->nnz > 0U) {
+    plan->col_index = (unsigned long int *)malloc(col_bytes);
+    plan->values = (double complex *)malloc(value_bytes);
+    if (plan->col_index == NULL || plan->values == NULL) goto fail;
+  }
+
+  for (local_row = 0UL; local_row < plan->local_dim; local_row++) {
+    unsigned long int alpha = plan->local_offset + local_row + 1UL;
+    struct FillEntriesContext fill;
+    fill.plan = plan;
+    fill.next = plan->row_ptr[local_row];
+    fill.end = plan->row_ptr[local_row + 1UL];
+    if (SymmetryEnumerateColumn(X, alpha, fill_transposed_entry, &fill) != 0 ||
+        fill.next != fill.end) {
+      goto fail;
+    }
+  }
+
+  if (row_ptr_bytes > SIZE_MAX - col_bytes ||
+      row_ptr_bytes + col_bytes > SIZE_MAX - value_bytes) {
+    goto fail;
+  }
+  plan_bytes = row_ptr_bytes + col_bytes + value_bytes;
+  if (plan->local_dim == 0UL) min_row_nnz = 0U;
+  plan->ready = TRUE;
+  X->Sym->matvec_plan = plan;
+  fprintf(stdoutMPI,
+          "Symmetry matvec: mode=plan local_rows=%lu local_nnz=%zu "
+          "row_nnz_min=%zu row_nnz_max=%zu row_nnz_mean=%.3f bytes=%zu.\n",
+          plan->local_dim, plan->nnz, min_row_nnz, max_row_nnz,
+          plan->local_dim > 0UL ? (double)plan->nnz / (double)plan->local_dim : 0.0,
+          plan_bytes);
+  return 0;
+
+fail:
+  FreeSymmetryMatvecPlan(plan);
+  fprintf(stdoutMPI, "Error: failed to build symmetry matvec plan.\n");
+  return -1;
+}
+
+int ApplySymmetryMatvecPlan(const struct BindStruct *X,
+                            double complex *tmp_v0,
+                            const double complex *full_v1,
+                            double complex *local_prdct)
+{
+  unsigned long int local_row;
+  double complex prdct = 0.0;
+  const struct SymmetryMatvecPlan *plan;
+  if (X == NULL || X->Sym == NULL || tmp_v0 == NULL || full_v1 == NULL ||
+      local_prdct == NULL) {
+    return -1;
+  }
+  plan = X->Sym->matvec_plan;
+  if (plan == NULL || plan->ready != TRUE || plan->dim != X->Sym->dim ||
+      plan->local_offset != X->Sym->local_offset ||
+      plan->local_dim != X->Sym->local_dim) {
+    fprintf(stdoutMPI, "Error: symmetry matvec plan does not match the active sector.\n");
+    return -1;
+  }
+
+  /* unsigned long canonical loops require OpenMP 3.0 or later. */
+#pragma omp parallel for default(none) schedule(static) reduction(+:prdct) \
+  shared(plan, tmp_v0, full_v1)
+  for (local_row = 0UL; local_row < plan->local_dim; local_row++) {
+    size_t p;
+    double complex sum = 0.0;
+    unsigned long int global_alpha = plan->local_offset + local_row + 1UL;
+    for (p = plan->row_ptr[local_row]; p < plan->row_ptr[local_row + 1UL]; p++) {
+      sum += plan->values[p] * full_v1[plan->col_index[p]];
+    }
+    tmp_v0[local_row + 1UL] += sum;
+    prdct += conj(full_v1[global_alpha]) * sum;
+  }
+  *local_prdct = prdct;
+  return 0;
+}

--- a/src/time.c
+++ b/src/time.c
@@ -103,6 +103,8 @@ void OutputTimer(struct BindStruct *X) {
   //fp = childfopenMPI(fileName, "w");
   StampTime(fp, "All", 0);
   StampTime(fp, "  sz", 1000);
+  StampTime(fp, "  symmetry basis build/activate", 1100);
+  StampTime(fp, "  symmetry matvec plan build", 1101);
   StampTime(fp, "  diagonalcalc", 2000);
   if(X->Def.iFlgCalcSpec == CALCSPEC_NOT){
     if(X->Def.iCalcType==TPQCalc || X->Def.iCalcType==cTPQ) {
@@ -173,6 +175,9 @@ void OutputTimer(struct BindStruct *X) {
   fprintf(fp,"================================================\n");
   
   StampTime(fp,"All mltply",1);
+  StampTime(fp,"  symmetry input Allgatherv",1501);
+  StampTime(fp,"  symmetry legacy beta scan",1502);
+  StampTime(fp,"  symmetry local-row plan apply",1503);
   StampTime(fp,"  diagonal", 100);
 
   switch(X->Def.iCalcModel){

--- a/src/wrapperMPI.c
+++ b/src/wrapperMPI.c
@@ -300,6 +300,24 @@ int SumMPI_i(
   return(idim);
 }/*int SumMPI_i*/
 /**
+@brief MPI wrapper function to broadcast an integer across processes.
+@return Broadcasted value across processes.
+@author Mitsuaki Kawamura (The University of Tokyo)
+*/
+int BcastMPI_i(
+  int root,//!<[in] The source process of the broadcast
+  int idim//!<[in] Value to be broadcasted
+) {
+  int idim0;
+  idim0 = idim;
+#ifdef MPI
+  if (MPI_Bcast(&idim0, 1, MPI_INT, root, MPI_COMM_WORLD) != MPI_SUCCESS) {
+    exitMPI(-1);
+  }
+#endif
+  return(idim0);
+}/*int BcastMPI_i*/
+/**
 @brief MPI wrapper function to broadcast unsigned long
 integer across processes.
 @return Broadcasted value across processes.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,12 +49,16 @@ endmacro()
 add_executable(unittest_symmetry_basis
     ${CMAKE_SOURCE_DIR}/test/unittest_symmetry_basis.c
     ${CMAKE_SOURCE_DIR}/src/symmetry_basis.c
+    ${CMAKE_SOURCE_DIR}/src/symmetry_matvec_plan.c
     ${CMAKE_SOURCE_DIR}/src/bitcalc.c
     ${CMAKE_SOURCE_DIR}/src/ErrorMessage.c)
 target_include_directories(unittest_symmetry_basis
     PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
 target_compile_definitions(unittest_symmetry_basis PRIVATE DSFMT_MEXP=19937)
 target_link_libraries(unittest_symmetry_basis m)
+if(TARGET OpenMP::OpenMP_C)
+    target_link_libraries(unittest_symmetry_basis OpenMP::OpenMP_C)
+endif()
 add_test(NAME unittest_symmetry_basis
     COMMAND unittest_symmetry_basis)
 set_tests_properties(unittest_symmetry_basis

--- a/test/symmetry_spin_chain_lanczos.sh
+++ b/test/symmetry_spin_chain_lanczos.sh
@@ -171,6 +171,7 @@ diff=`awk -v a="${sym_energy}" -v b="${ref_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; p
 test "${diff}" = "0.000000"
 
 grep -q "Symmetry basis: raw_dim=20 sector_dim=4 group_order=6" symmetry.log
+grep -q "Symmetry matvec: mode=plan" symmetry.log
 
 cat > namelist_heisenberg_ref.def <<EOF
 CalcMod calcmod.def
@@ -195,22 +196,39 @@ Ising ising.def
 TransSym qptransidx.def
 EOF
 
-run_hphi symmetry_heisenberg.log ../../src/HPhi -e namelist_heisenberg.def
+run_hphi symmetry_heisenberg.log env HPHI_SYMMETRY_MATVEC=plan ../../src/HPhi -e namelist_heisenberg.def
 sym_heisenberg_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
 test -n "${ref_heisenberg_energy}"
 test -n "${sym_heisenberg_energy}"
 heisenberg_diff=`awk -v a="${sym_heisenberg_energy}" -v b="${ref_heisenberg_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
 test "${heisenberg_diff}" = "0.000000"
 grep -q "Symmetry basis: raw_dim=20 sector_dim=4 group_order=6" symmetry_heisenberg.log
+grep -q "Symmetry matvec: mode=plan" symmetry_heisenberg.log
 
 rm -rf output
 write_kpi_over_3_transsym_l6
-run_hphi symmetry_complex.log ../../src/HPhi -e namelist.def
+run_hphi symmetry_complex.log env HPHI_SYMMETRY_MATVEC=plan ../../src/HPhi -e namelist.def
 complex_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
 test -n "${complex_energy}"
 complex_diff=`awk -v a="${complex_energy}" 'BEGIN{d=a+1.0; if(d<0)d=-d; printf "%8.6f", d}'`
 test "${complex_diff}" = "0.000000"
 grep -q "Symmetry basis: raw_dim=20 sector_dim=3 group_order=6" symmetry_complex.log
+grep -q "Symmetry matvec: mode=plan" symmetry_complex.log
+
+rm -rf output
+run_hphi symmetry_complex_legacy.log env HPHI_SYMMETRY_MATVEC=legacy ../../src/HPhi -e namelist.def
+legacy_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+test -n "${legacy_energy}"
+legacy_diff=`awk -v a="${legacy_energy}" -v b="${complex_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.16e", d}'`
+awk -v d="${legacy_diff}" 'BEGIN{exit !(d <= 1.0e-12)}'
+grep -q "Symmetry matvec: mode=legacy" symmetry_complex_legacy.log
+
+rm -rf output
+if env HPHI_SYMMETRY_MATVEC=invalid ../../src/HPhi -e namelist.def > symmetry_invalid_mode.log 2>&1; then
+    cat symmetry_invalid_mode.log
+    exit 1
+fi
+grep -q "HPHI_SYMMETRY_MATVEC must be 'plan' or 'legacy'" symmetry_invalid_mode.log
 
 run_mpi_symmetry_case() {
     label="$1"
@@ -219,12 +237,16 @@ run_mpi_symmetry_case() {
     expected_dim="$4"
     log_file="symmetry_${label}_mpi.log"
     rm -rf output
-    ${MPIRUN} ../../src/HPhi -e "${namelist}" > "${log_file}" 2>&1
+    if ! HPHI_SYMMETRY_MATVEC=plan ${MPIRUN} ../../src/HPhi -e "${namelist}" > "${log_file}" 2>&1; then
+        cat "${log_file}"
+        exit 1
+    fi
     mpi_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
     test -n "${mpi_energy}"
     mpi_diff=`awk -v a="${mpi_energy}" -v b="${expected_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
     test "${mpi_diff}" = "0.000000"
     grep -q "Symmetry basis: raw_dim=20 sector_dim=${expected_dim} group_order=6" "${log_file}"
+    grep -q "Symmetry matvec: mode=plan" "${log_file}"
     if grep -q "MPI site separation summary" "${log_file}"; then
         echo "TransSym MPI path unexpectedly used site decomposition."
         exit 1
@@ -238,6 +260,32 @@ if [ -n "${MPIRUN}" ]; then
         run_mpi_symmetry_case heisenberg namelist_heisenberg.def "${sym_heisenberg_energy}" 4
         write_kpi_over_3_transsym_l6
         run_mpi_symmetry_case complex namelist.def "${complex_energy}" 3
+
+        cat > symmetry_rank_env.sh <<'EOF'
+#!/bin/sh
+rank=${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-0}}}
+if [ "${rank}" -eq 0 ]; then
+    export HPHI_SYMMETRY_MATVEC=plan
+else
+    export HPHI_SYMMETRY_MATVEC=invalid
+fi
+exec "$@"
+EOF
+        chmod +x symmetry_rank_env.sh
+        rm -rf output
+        if ! ${MPIRUN} ./symmetry_rank_env.sh ../../src/HPhi -e namelist.def > symmetry_rank_env_mpi.log 2>&1; then
+            cat symmetry_rank_env_mpi.log
+            exit 1
+        fi
+        rank_env_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+        test -n "${rank_env_energy}"
+        rank_env_diff=`awk -v a="${rank_env_energy}" -v b="${complex_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
+        test "${rank_env_diff}" = "0.000000"
+        grep -q "Symmetry matvec: mode=plan" symmetry_rank_env_mpi.log
+        if grep -q "HPHI_SYMMETRY_MATVEC must be" symmetry_rank_env_mpi.log; then
+            cat symmetry_rank_env_mpi.log
+            exit 1
+        fi
     fi
 fi
 

--- a/test/unittest_symmetry_basis.c
+++ b/test/unittest_symmetry_basis.c
@@ -4,6 +4,7 @@
 #include <math.h>
 #include "DefCommon.h"
 #include "symmetry_basis.h"
+#include "symmetry_matvec_plan.h"
 #include "struct.h"
 
 FILE *stdoutMPI = NULL;
@@ -17,6 +18,12 @@ int g_tj_odd_split_guard_enabled = 0;
 long unsigned int g_tj_odd_split_up_mask = 0;
 long unsigned int g_tj_odd_split_down_mask = 0;
 static unsigned long int test_raw_dim = 0;
+
+int BcastMPI_i(int root, int value)
+{
+  (void)root;
+  return value;
+}
 
 static int perm_storage[6][6];
 static int anti_storage[6][6];
@@ -623,6 +630,262 @@ static void assert_complex_close(double complex got,
   }
 }
 
+struct LegacyVectorContext {
+  double complex *output;
+  double complex input_amp;
+  unsigned long int dim;
+};
+
+static int accumulate_legacy_vector_entry(unsigned long int out_index,
+                                          double complex coefficient,
+                                          void *context)
+{
+  struct LegacyVectorContext *legacy = (struct LegacyVectorContext *)context;
+  if (out_index == 0UL || out_index > legacy->dim) return -1;
+  legacy->output[out_index] += coefficient * legacy->input_amp;
+  return 0;
+}
+
+static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
+                                                     int require_duplicate,
+                                                     const char *label)
+{
+  unsigned long int alpha, beta;
+  size_t p;
+  size_t matrix_size;
+  int duplicate_found = 0;
+  double difference_norm2 = 0.0;
+  double legacy_norm2 = 0.0;
+  double complex expected_prdct = 0.0;
+  double complex plan_prdct = 0.0;
+  double complex *dense;
+  double complex *input;
+  double complex *legacy_output;
+  double complex *output;
+  unsigned int *multiplicity;
+  struct SymmetryMatvecPlan *plan;
+
+  if (ActivateSymmetryBasisDimension(X) != 0 || BuildSymmetryMatvecPlan(X) != 0) {
+    fprintf(stderr, "%s: plan setup failed\n", label);
+    exit(1);
+  }
+  plan = X->Sym->matvec_plan;
+  assert_int_eq(plan != NULL && plan->ready == TRUE, 1, label);
+  assert_ulong_eq(plan->dim, X->Sym->dim, label);
+  assert_ulong_eq(plan->local_offset, 0UL, label);
+  assert_ulong_eq(plan->local_dim, X->Sym->dim, label);
+
+  if (plan->dim > SIZE_MAX / plan->dim) {
+    fprintf(stderr, "%s: dense matrix size overflow\n", label);
+    exit(1);
+  }
+  matrix_size = (size_t)plan->dim * (size_t)plan->dim;
+  dense = (double complex *)calloc(matrix_size, sizeof(*dense));
+  multiplicity = (unsigned int *)calloc(matrix_size, sizeof(*multiplicity));
+  input = (double complex *)calloc((size_t)plan->dim + 1U, sizeof(*input));
+  legacy_output = (double complex *)calloc((size_t)plan->dim + 1U,
+                                           sizeof(*legacy_output));
+  output = (double complex *)calloc((size_t)plan->dim + 1U, sizeof(*output));
+  if (dense == NULL || multiplicity == NULL || input == NULL ||
+      legacy_output == NULL || output == NULL) {
+    fprintf(stderr, "%s: dense test allocation failed\n", label);
+    exit(1);
+  }
+
+  for (alpha = 1UL; alpha <= plan->dim; alpha++) {
+    unsigned long int local_row = alpha - 1UL;
+    for (p = plan->row_ptr[local_row]; p < plan->row_ptr[local_row + 1UL]; p++) {
+      size_t index = (size_t)(alpha - 1UL) * (size_t)plan->dim +
+                     (size_t)(plan->col_index[p] - 1UL);
+      dense[index] += plan->values[p];
+      multiplicity[index]++;
+      if (multiplicity[index] > 1U) duplicate_found = 1;
+    }
+  }
+  if (require_duplicate != 0) assert_int_eq(duplicate_found, 1, label);
+
+  for (alpha = 1UL; alpha <= plan->dim; alpha++) {
+    for (beta = 1UL; beta <= plan->dim; beta++) {
+      double complex plan_value = dense[(size_t)(alpha - 1UL) * (size_t)plan->dim +
+                                        (size_t)(beta - 1UL)];
+      double complex expected = canonicalized_matrix_element(X, alpha, beta);
+      double complex transpose = dense[(size_t)(beta - 1UL) * (size_t)plan->dim +
+                                       (size_t)(alpha - 1UL)];
+      assert_complex_close(plan_value, expected, 1.0e-12, label);
+      assert_complex_close(plan_value, conj(transpose), 1.0e-12, label);
+    }
+  }
+
+  for (beta = 1UL; beta <= plan->dim; beta++) {
+    input[beta] = 0.125 * (double)beta + I * 0.0625 * (double)(beta + 1UL);
+  }
+  {
+    struct LegacyVectorContext legacy;
+    legacy.output = legacy_output;
+    legacy.dim = plan->dim;
+    for (beta = 1UL; beta <= plan->dim; beta++) {
+      legacy.input_amp = input[beta];
+      if (SymmetryEnumerateColumn(X, beta, accumulate_legacy_vector_entry,
+                                  &legacy) != 0) {
+        fprintf(stderr, "%s: legacy vector scan failed\n", label);
+        exit(1);
+      }
+    }
+  }
+  if (ApplySymmetryMatvecPlan(X, output, input, &plan_prdct) != 0) {
+    fprintf(stderr, "%s: plan apply failed\n", label);
+    exit(1);
+  }
+  for (alpha = 1UL; alpha <= plan->dim; alpha++) {
+    double complex expected = 0.0;
+    for (beta = 1UL; beta <= plan->dim; beta++) {
+      expected += dense[(size_t)(alpha - 1UL) * (size_t)plan->dim +
+                        (size_t)(beta - 1UL)] * input[beta];
+    }
+    assert_complex_close(output[alpha], expected, 1.0e-12, label);
+    assert_complex_close(output[alpha], legacy_output[alpha], 1.0e-12, label);
+    difference_norm2 += pow(cabs(output[alpha] - legacy_output[alpha]), 2.0);
+    legacy_norm2 += pow(cabs(legacy_output[alpha]), 2.0);
+    expected_prdct += conj(input[alpha]) * expected;
+  }
+  if (sqrt(difference_norm2) / fmax(sqrt(legacy_norm2), 1.0e-300) > 1.0e-12) {
+    fprintf(stderr, "%s: plan/legacy relative L2 error exceeds 1e-12\n", label);
+    exit(1);
+  }
+  assert_complex_close(plan_prdct, expected_prdct, 1.0e-12, label);
+
+  X->Sym->local_offset++;
+  assert_int_eq(ApplySymmetryMatvecPlan(X, output, input, &plan_prdct), -1,
+                "plan snapshot guard");
+  X->Sym->local_offset--;
+
+  free(dense);
+  free(multiplicity);
+  free(input);
+  free(legacy_output);
+  free(output);
+}
+
+static void assert_spin_plan(unsigned int nsite,
+                             unsigned int nup,
+                             unsigned int momentum_index,
+                             double diagonal_coupling,
+                             const char *label)
+{
+  struct BindStruct X;
+  setup_bind(&X, nsite, nup, momentum_index);
+  if (diagonal_coupling != 0.0) set_ising_ring_diagonal(nsite, diagonal_coupling);
+  if (BuildSymmetryBasis(&X) != 0) {
+    fprintf(stderr, "%s: BuildSymmetryBasis failed\n", label);
+    exit(1);
+  }
+  assert_plan_matches_canonicalized_matrix(&X, 1, label);
+  FreeSymmetryBasis(X.Sym);
+  free(list_1);
+  free(list_Diagonal);
+  list_1 = NULL;
+  list_Diagonal = NULL;
+}
+
+static void assert_spin_diagonal_only_plan(const char *label)
+{
+  struct BindStruct X;
+  setup_bind(&X, 6, 3, 1);
+  X.Def.NExchangeCoupling = 0U;
+  set_ising_ring_diagonal(6, 0.37);
+  if (BuildSymmetryBasis(&X) != 0) {
+    fprintf(stderr, "%s: BuildSymmetryBasis failed\n", label);
+    exit(1);
+  }
+  assert_plan_matches_canonicalized_matrix(&X, 0, label);
+  FreeSymmetryBasis(X.Sym);
+  free(list_1);
+  free(list_Diagonal);
+  list_1 = NULL;
+  list_Diagonal = NULL;
+}
+
+static void assert_spinless_plan(unsigned int nsite,
+                                 unsigned int ne,
+                                 unsigned int momentum_index,
+                                 double density_coupling,
+                                 const char *label)
+{
+  struct BindStruct X;
+  setup_spinless_bind(&X, nsite, ne, momentum_index);
+  setup_spinless_transfer_ring(&X.Def, nsite);
+  if (density_coupling != 0.0) {
+    setup_spinless_coulomb_ring(&X.Def, nsite, density_coupling);
+    set_spinless_coulomb_ring_diagonal(nsite, density_coupling);
+  }
+  if (BuildSymmetryBasis(&X) != 0) {
+    fprintf(stderr, "%s: BuildSymmetryBasis failed\n", label);
+    exit(1);
+  }
+  assert_plan_matches_canonicalized_matrix(&X, 0, label);
+  FreeSymmetryBasis(X.Sym);
+  free(list_1);
+  free(list_Diagonal);
+  list_1 = NULL;
+  list_Diagonal = NULL;
+}
+
+static void assert_hubbard_plan(unsigned int nsite,
+                                unsigned int nup,
+                                unsigned int ndown,
+                                unsigned int momentum_index,
+                                double coulomb_intra,
+                                const char *label)
+{
+  struct BindStruct X;
+  setup_hubbard_bind(&X, nsite, nup, ndown, momentum_index);
+  setup_hubbard_transfer_ring(&X.Def, nsite);
+  if (coulomb_intra != 0.0) {
+    setup_hubbard_coulomb_intra(&X.Def, nsite, coulomb_intra);
+  }
+  if (BuildSymmetryBasis(&X) != 0) {
+    fprintf(stderr, "%s: BuildSymmetryBasis failed\n", label);
+    exit(1);
+  }
+  assert_plan_matches_canonicalized_matrix(&X, 0, label);
+  FreeSymmetryBasis(X.Sym);
+  free(list_1);
+  free(list_Diagonal);
+  list_1 = NULL;
+  list_Diagonal = NULL;
+}
+
+static void assert_zero_row_plan(const char *label)
+{
+  struct BindStruct X;
+  double complex input[2] = {0.0, 1.0};
+  double complex output[1] = {0.0};
+  double complex prdct = 1.0;
+  setup_bind(&X, 4, 2, 1);
+  if (BuildSymmetryBasis(&X) != 0) {
+    fprintf(stderr, "%s: BuildSymmetryBasis failed\n", label);
+    exit(1);
+  }
+  nproc = 2;
+  myrank = 1;
+  if (ActivateSymmetryBasisDimension(&X) != 0 || BuildSymmetryMatvecPlan(&X) != 0) {
+    fprintf(stderr, "%s: zero-row plan setup failed\n", label);
+    exit(1);
+  }
+  assert_ulong_eq(X.Sym->local_dim, 0UL, label);
+  assert_int_eq(X.Sym->matvec_plan != NULL, 1, label);
+  assert_ulong_eq((unsigned long int)X.Sym->matvec_plan->nnz, 0UL, label);
+  assert_int_eq(ApplySymmetryMatvecPlan(&X, output, input, &prdct), 0, label);
+  assert_complex_close(prdct, 0.0, 1.0e-12, label);
+  nproc = 1;
+  myrank = 0;
+  FreeSymmetryBasis(X.Sym);
+  free(list_1);
+  free(list_Diagonal);
+  list_1 = NULL;
+  list_Diagonal = NULL;
+}
+
 static void assert_symmetry_dim(unsigned int nsite,
                                 unsigned int nup,
                                 unsigned int momentum_index,
@@ -1088,6 +1351,21 @@ int main(void)
                                           "C6 k=pi/3 Ising diagonal is orbit-invariant");
   assert_canonicalized_matrix_matches_raw(6, 3, 1, 1.0,
                                           "C6 k=pi/3 Ising canonicalized matrix matches raw reference");
+  assert_spin_plan(6, 3, 0, 1.0,
+                   "C6 k=0 Spin local-row plan matches canonicalized matrix");
+  assert_spin_plan(6, 3, 1, 1.0,
+                   "C6 k=pi/3 Spin local-row plan matches canonicalized matrix");
+  assert_spin_diagonal_only_plan(
+      "C6 k=pi/3 diagonal-only local-row plan matches canonicalized matrix");
+  assert_spinless_plan(6, 3, 0, 0.25,
+                       "SpinlessFermion C6 k=0 local-row plan matches canonicalized matrix");
+  assert_spinless_plan(6, 3, 1, 0.25,
+                       "SpinlessFermion C6 k=pi/3 local-row plan matches canonicalized matrix");
+  assert_hubbard_plan(4, 2, 2, 0, 0.5,
+                      "Hubbard C4 k=0 local-row plan matches canonicalized matrix");
+  assert_hubbard_plan(4, 2, 2, 1, 0.5,
+                      "Hubbard C4 k=pi/2 local-row plan matches canonicalized matrix");
+  assert_zero_row_plan("local-row plan supports zero-row rank");
   assert_representative_hash_matches_basis(6, 3, 1,
                                            "C6 k=pi/3 representative hash matches basis");
   assert_hash_probe_lookup_handles_collision("representative hash probing handles collisions");


### PR DESCRIPTION
## Summary
- Build a reusable local-row sparse plan for translation-symmetry matvecs.
- Replace the replicated basis-column scan with an OpenMP-parallel apply over rows owned by each MPI rank.
- Keep a developer-only `HPHI_SYMMETRY_MATVEC=plan|legacy` switch for rollback and A/B diagnostics, synchronized across MPI ranks.
- Add lifecycle handling, timers, unit coverage, and serial/MPI integration regressions.

## Motivation
The momentum-basis path previously made every MPI rank rescan all symmetry-sector basis columns on every matvec, even though each rank owns only local output rows. This scan dominated runtime and did not strong-scale.

## User impact
There are no input/output format or public option changes. The local-row plan is the default, while the legacy path remains available through the developer environment switch.

## Validation
- Push CI passed all 7 matrix jobs on commit `f9ca24d9`.
- Symmetry suite: 9/9 serial and 9/9 with 16 MPI ranks.
- Selected symmetry tests: 6/6 with 1, 2, and 4 OpenMP threads; 6/6 with AddressSanitizer.
- Independent spectrum checks agree to `3.2e-15`; the lowest ten levels of the `L=16` antiferromagnetic Heisenberg chain agree to `9.3e-14`.
- For the `L=24` antiferromagnetic Heisenberg chain, same-layout plan/legacy comparisons passed 48/48 cases. Median matvec speedups were `924x` at 1 node and `457x` at 8 nodes, with maximum energy difference `3.6e-15` and maximum RSS ratio `0.898`.
- `git diff --check` passes.
