### PR TITLE
Document MomentumIndex usage and SpinlessFermion support

### DIFF
--- a/doc/en/source/filespecification/standardmode_en/Parameters_for_conserved_quantities_en.rst
+++ b/doc/en/source/filespecification/standardmode_en/Parameters_for_conserved_quantities_en.rst
@@ -40,12 +40,39 @@ Parameters for conserved quantities
    * ``model = "Spin"`` with ``2S = 1``, fixed ``2Sz``, and
      exchange-only spin couplings with ``Jz = 0`` and no field, general,
      or pair terms.
+   * ``model = "SpinlessFermion"`` with fixed ``ncond`` and hopping-only
+     terms. Density interactions (``V``/``CoulombInter``), general
+     interactions, and pair terms are not supported with
+     ``MomentumIndex`` in Standard mode.
    * ``model = "Fermion Hubbard"`` (or ``"Hubbard"``) with fixed
      ``nelec`` and ``2Sz``, nearest-neighbor hopping ``t``/``t0``, and
      onsite ``U``. Chemical-potential or field terms
      (``mu``, ``h``, ``Gamma``, ``Gamma_y``), longer-range hopping
      (``t'``, ``t''``), offsite Coulomb terms (``V``/``CoulombInter``),
      and general or pair terms are not supported with ``MomentumIndex``.
+
+   To obtain the lowest energy at every momentum point, run one Standard-mode
+   calculation for each :math:`m=0,\ldots,L-1`, changing only
+   ``MomentumIndex``. For example, a six-site spin chain in the :math:`m=1`
+   sector can be specified as follows:
+
+   .. code-block:: text
+
+      L = 6
+      model = Spin
+      method = Lanczos
+      lattice = chain
+      Jx = 1.0
+      Jy = 1.0
+      Jz = 0.0
+      2Sz = 0
+      MomentumIndex = 1
+
+   If this input is saved as ``stan.in``, run ``HPhi -s stan.in``. The
+   corresponding momentum is :math:`k=2\pi m/L`, and the lowest energy is
+   written to ``output/zvo_energy.dat``. Run each value of ``MomentumIndex``
+   in a separate working directory, or save the output before the next run,
+   so that the results are not overwritten.
 
 .. raw:: latex
 

--- a/doc/ja/source/filespecification/standardmode_ja/Parameters_for_conserved_quantities_ja.rst
+++ b/doc/ja/source/filespecification/standardmode_ja/Parameters_for_conserved_quantities_ja.rst
@@ -36,12 +36,39 @@
    * ``model = "Spin"`` では ``2S = 1``、固定 ``2Sz``、かつ
      ``Jz = 0`` で磁場・一般相互作用・pair 項を含まない
      exchange-only のスピン相互作用に対応します。
+   * ``model = "SpinlessFermion"`` では固定 ``ncond`` と hopping-only
+     の項に対応します。密度相互作用 (``V``/``CoulombInter``)、
+     一般相互作用、pair 項はスタンダードモードの ``MomentumIndex``
+     と併用できません。
    * ``model = "Fermion Hubbard"`` または ``"Hubbard"`` では、固定
      ``nelec`` と ``2Sz``、最近接ホッピング ``t``/``t0``、オンサイト
      ``U`` に対応します。化学ポテンシャルや磁場項
      (``mu``, ``h``, ``Gamma``, ``Gamma_y``)、遠距離ホッピング
      (``t'``, ``t''``)、非局所 Coulomb 項 (``V``/``CoulombInter``)、
      一般相互作用、pair 項は ``MomentumIndex`` と併用できません。
+
+   各運動量点の最低エネルギーを求めるには、``MomentumIndex`` だけを
+   変更し、:math:`m=0,\ldots,L-1` ごとにスタンダードモードの計算を
+   個別に実行します。例えば6サイトのスピン鎖の :math:`m=1`
+   セクターは次のように指定できます。
+
+   .. code-block:: text
+
+      L = 6
+      model = Spin
+      method = Lanczos
+      lattice = chain
+      Jx = 1.0
+      Jy = 1.0
+      Jz = 0.0
+      2Sz = 0
+      MomentumIndex = 1
+
+   この入力を ``stan.in`` に保存した場合は ``HPhi -s stan.in`` を
+   実行します。対応する運動量は :math:`k=2\pi m/L` で、最低エネルギーは
+   ``output/zvo_energy.dat`` に出力されます。結果が上書きされないよう、
+   ``MomentumIndex`` ごとに異なる作業ディレクトリで実行するか、次の計算前に
+   出力を保存してください。
 
 .. raw:: latex
 


### PR DESCRIPTION
## Summary

- document `MomentumIndex` support and restrictions for `SpinlessFermion` in the English and Japanese manuals
- explain how to run one Standard-mode calculation per momentum sector
- add a minimal spin-chain input and identify the momentum and energy output

## Why

The existing `MomentumIndex` section documented the Spin and Hubbard cases, but omitted the already-supported `SpinlessFermion` case and did not show the practical steps for obtaining the lowest energy at every momentum point.

## User impact

Users can now find the supported models and restrictions, copy a minimal input, map `MomentumIndex = m` to `k = 2*pi*m/L`, and avoid overwriting results from successive momentum-sector runs.

## Validation

- English Sphinx HTML build: passed
- Japanese Sphinx HTML build: passed
- changed manual pages: no new Sphinx warnings
- Standard-mode momentum generation tests for Spin, SpinlessFermion, and Hubbard: 3/3 passed
- `git diff --check`: passed

This is a documentation-only change. Existing regression tests already cover Standard-mode generation, expert-mode equivalence, unsupported inputs, and serial/MPI symmetry calculations, so no additional sample or CI test is included.

Related to #201.
