### PR TITLE
Fix Hubbard doublon in momentum basis

### DIFF
--- a/src/expec_energy_flct.c
+++ b/src/expec_energy_flct.c
@@ -40,6 +40,7 @@
 #include "expec_energy_flct.h"
 #include "wrapperMPI.h"
 #include "CalcTime.h"
+#include "symmetry_basis.h"
 
 /**
  * @brief Calculate energy expectation value and variance
@@ -125,7 +126,7 @@ int expec_energy_flct(struct BindStruct *X){
   case tJGC:
   case Kondo:
   case KondoGC:
-      expec_energy_flct_Hubbard(X);
+      if (expec_energy_flct_Hubbard(X) != 0) return -1;
   break;
   
   case SpinGC:
@@ -369,7 +370,16 @@ int expec_energy_flct_Hubbard(struct BindStruct *X){
     double tmp_v02;
     long unsigned int i_max,tmp_list_1;
     unsigned int l_ibit1,u_ibit1,i_32;
+    int use_symmetry_basis;
     i_max=X->Check.idim_max;
+
+    use_symmetry_basis = X->Def.iFlgSymmetryBasis == TRUE;
+    if (use_symmetry_basis == TRUE &&
+        (X->Sym == NULL || X->Sym->enabled != TRUE || X->Sym->basis == NULL ||
+         X->Sym->local_offset > X->Sym->dim ||
+         i_max > X->Sym->dim - X->Sym->local_offset)) {
+        return -1;
+    }
 
     i_32   = (unsigned int)(pow(2,32)-1);
 
@@ -396,14 +406,19 @@ int expec_energy_flct_Hubbard(struct BindStruct *X){
     }
 //[e]
 #pragma omp parallel for reduction(+:tmp_D,tmp_D2,tmp_N,tmp_N2,tmp_Sz,tmp_Sz2) default(none) shared(v0,list_1) \
-  firstprivate(i_max, X,myrank,is1_up_a,is1_down_a,is1_up_b,is1_down_b,i_32) \
+  firstprivate(i_max, X,myrank,is1_up_a,is1_down_a,is1_up_b,is1_down_b,i_32,use_symmetry_basis) \
   private(j, tmp_v02,D,N,Sz,isite1,tmp_list_1,bit_up,bit_down,bit_D,u_ibit1,l_ibit1,ibit_up,ibit_down,ibit_D)
     for(j = 1; j <= i_max; j++) {
         tmp_v02 = conj(v0[j]) * v0[j];
         bit_up = 0;
         bit_down = 0;
         bit_D = 0;
-        tmp_list_1 = list_1[j];
+        if (use_symmetry_basis == TRUE) {
+            unsigned long int global_index = X->Sym->local_offset + j;
+            tmp_list_1 = X->Sym->basis[global_index].rep_state;
+        } else {
+            tmp_list_1 = list_1[j];
+        }
 // isite1 > X->Def.Nsite
         ibit_up = (unsigned long int) myrank & is1_up_a;
         u_ibit1 = ibit_up >> 32;

--- a/test/symmetry_hubbard_lanczos.sh
+++ b/test/symmetry_hubbard_lanczos.sh
@@ -214,6 +214,19 @@ assert_energy_matches_reference() {
     fi
 }
 
+assert_doublon_matches_reference() {
+    expected="$1"
+    log="$2"
+    doublon=`awk '$1 == "Doublon" {print $2; exit}' output/zvo_energy.dat`
+    test -n "${doublon}"
+    if ! awk -v a="${doublon}" -v b="${expected}" \
+        'BEGIN{d=a-b; if(d<0)d=-d; exit(d <= 1.0e-6 ? 0 : 1)}'; then
+        cat "${log}"
+        echo "Doublon mismatch: got ${doublon}, reference ${expected}"
+        exit 1
+    fi
+}
+
 expect_failure() {
     pattern="$1"
     log="$2"
@@ -248,6 +261,7 @@ run_mpi_symmetry_case() {
     label="$1"
     expected_energy="$2"
     expected_dim="$3"
+    expected_doublon="${4:-}"
     log_file="hubbard_${label}_mpi.log"
     rm -rf output
     if ! ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
@@ -255,6 +269,9 @@ run_mpi_symmetry_case() {
         exit 1
     fi
     assert_energy_matches_reference "${expected_energy}" "${log_file}"
+    if [ -n "${expected_doublon}" ]; then
+        assert_doublon_matches_reference "${expected_doublon}" "${log_file}"
+    fi
     assert_symmetry_log "${expected_dim}" "${log_file}"
 }
 
@@ -262,10 +279,11 @@ run_mpi_if_available() {
     label="$1"
     expected_energy="$2"
     expected_dim="$3"
+    expected_doublon="${4:-}"
     if [ -n "${MPIRUN}" ]; then
         MPI_NP=`printf "%s\n" "${MPIRUN}" | awk '{for(i=1;i<=NF;i++){if($i=="-np"||$i=="-n"){print $(i+1); exit}}}'`
         if printf "%s\n" "${MPI_NP}" | grep -Eq "^[0-9]+$" && [ "${MPI_NP}" -gt 1 ]; then
-            run_mpi_symmetry_case "$label" "$expected_energy" "$expected_dim"
+            run_mpi_symmetry_case "$label" "$expected_energy" "$expected_dim" "$expected_doublon"
         fi
     fi
 }
@@ -279,20 +297,23 @@ write_ref_namelist
 
 ../../src/HPhi -e namelist.def > hubbard_ref.log 2>&1
 ref_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+ref_doublon=`awk '$1 == "Doublon" {print $2; exit}' output/zvo_energy.dat`
 test -n "${ref_energy}"
+test -n "${ref_doublon}"
 rm -rf output
 
 write_k0_transsym
 write_sym_namelist yes
 ../../src/HPhi -e namelist.def > hubbard_k0.log 2>&1
 assert_energy_matches_reference "${ref_energy}" hubbard_k0.log
+assert_doublon_matches_reference "${ref_doublon}" hubbard_k0.log
 grep -q "Symmetry basis: raw_dim=16 sector_dim=4 group_order=4" hubbard_k0.log
 if grep -q "MPI site separation summary" hubbard_k0.log; then
     cat hubbard_k0.log
     echo "TransSym Hubbard serial path unexpectedly used site decomposition."
     exit 1
 fi
-run_mpi_if_available k0 "${ref_energy}" 4
+run_mpi_if_available k0 "${ref_energy}" 4 "${ref_doublon}"
 
 rm -rf output
 write_kpi2_transsym
@@ -314,8 +335,9 @@ write_sym_namelist yes
 perl -0pi -e 's/CalcType 0/CalcType 3/' calcmod.def
 ../../src/HPhi -e namelist.def > hubbard_k0_cg.log 2>&1
 assert_energy_matches_reference "${ref_energy}" hubbard_k0_cg.log
+assert_doublon_matches_reference "${ref_doublon}" hubbard_k0_cg.log
 assert_symmetry_log 4 hubbard_k0_cg.log
-run_mpi_if_available k0_cg "${ref_energy}" 4
+run_mpi_if_available k0_cg "${ref_energy}" 4 "${ref_doublon}"
 write_calcmod
 
 rm -rf output


### PR DESCRIPTION
## Summary

- evaluate Hubbard observables from the translation-symmetry basis representative state instead of the unrelated raw `list_1[j]` entry
- convert each rank-local vector index to the global symmetry-basis index with `local_offset + j`
- reject an inconsistent symmetry-basis runtime instead of silently falling back to the raw basis
- compare the reported doublon against the conventional basis in the existing Hubbard symmetry regression, including MPI runs

## Why

After the momentum-sector basis is activated, `v0[j]` indexes a symmetry-sector vector, while `list_1[j]` still indexes the original restricted Hilbert-space basis. The Hubbard energy-fluctuation routine paired sector-vector weights with unrelated raw states, so the energy remained correct through the symmetry-aware matvec but the reported doublon was wrong.

For the periodic four-site Hubbard test, the conventional basis gives `0.2138232813467352`. Before this fix, `MomentumIndex = 0` reported `0.4862379162016107`; after the fix it reports `0.2138233065891299`, a difference of `2.52e-8` from the conventional-basis result.

## User impact

Hubbard `MomentumIndex` calculations now report the correct doublon in `zvo_energy.dat`. There are no input or output format changes.

## Validation

- Release build without MPI: passed
- `symmetry_hubbard_lanczos` without MPI: 1/1 passed
- Release build with Open MPI 5.0.9: passed
- symmetry suite with 2 MPI ranks: 9/9 passed
- `symmetry_hubbard_lanczos` with 16 MPI ranks: 1/1 passed
- shell syntax check and `git diff --check`: passed

Related to #201.
