### PR TITLE
Fix Komega build with Intel MPI

### DIFF
--- a/src/komega/komega_math.F90
+++ b/src/komega/komega_math.F90
@@ -78,7 +78,7 @@ CONTAINS
 FUNCTION ddotMPI(n,dx,dy) RESULT(prod)
   !
 #if defined(MPI)
-  USE mpi, ONLY : MPI_Allreduce, MPI_DOUBLE_PRECISION, MPI_SUM
+  USE mpi
   USE komega_parameter, ONLY : comm, lmpi
 #endif
   !
@@ -110,7 +110,7 @@ END FUNCTION ddotMPI
 FUNCTION zdotcMPI(n,zx,zy,local_prod_out) RESULT(prod)
   !
 #if defined(MPI)
-  USE mpi, ONLY : MPI_Allreduce, MPI_DOUBLE_COMPLEX, MPI_SUM
+  USE mpi
   USE komega_parameter, ONLY : comm, lmpi
 #endif
   !
@@ -148,7 +148,7 @@ END FUNCTION zdotcMPI
 FUNCTION zdotuMPI(n,zx,zy) RESULT(prod)
   !
 #if defined(MPI)
-  USE mpi, ONLY : MPI_Allreduce, MPI_DOUBLE_COMPLEX, MPI_SUM
+  USE mpi
   USE komega_parameter, ONLY : comm, lmpi
 #endif
   !
@@ -184,7 +184,7 @@ END FUNCTION zdotuMPI
 FUNCTION dabsmax(array, n) RESULT(maxarray)
   !
 #if defined(MPI)
-  USE mpi, ONLY : MPI_Allreduce, MPI_DOUBLE_PRECISION, MPI_MAX
+  USE mpi
   USE komega_parameter, ONLY : comm, lmpi
 #endif
   !


### PR DESCRIPTION
## Summary

- replace restrictive MPI ONLY imports with plain USE mpi in the four Komega scalar-reduction routines
- keep the separate send/receive buffers introduced by 5bee7b45
- preserve removal of the GNU -fallow-argument-mismatch workaround

## Root cause

Commit 5bee7b45 imported MPI_Allreduce through an ONLY list. GNU Fortran with Open MPI accepts that form, but Intel Fortran with Intel MPI rejects the generic interface with error #6580. Plain USE mpi provides an explicit interface under both MPI implementations.

## Validation

- Intel Fortran Classic 2021.8 with Intel MPI 2021.8: the actual Komega sources compile with mpiifort
- GNU Fortran 16.1 with Open MPI 5.0.9: Debug full build passes
- unittest_komega_bicg_nonfinite passes
- spectrum_hubbard_square passes
- spectrum_hubbard_offdiag_single passes
- spectrum_bicg_nonconvergence_reject passes
- spectrum_hubbard_offdiag_single_mpi passes with four MPI ranks

Fixes #291