### PR TITLE
perf: use halo exchange for MomentumIndex vectors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ target_sources(HPhi PRIVATE
   readdef.c sz.c vec12.c xsetmem.c ErrorMessage.c LogMessage.c
   ProgressMessage.c wrapperMPI.c splash.c time.c eigenIO.c struct.c
   nbody_interall.c anomalous_pair.c green_output.c symmetry_basis.c symmetry_basis_io.c
-  symmetry_matvec_plan.c
+  symmetry_matvec_plan.c symmetry_vector_halo.c
 )
 
 # Multiply operations

--- a/src/include/symmetry_basis.h
+++ b/src/include/symmetry_basis.h
@@ -59,6 +59,7 @@ struct SymmetryBasisRuntime {
   int *mpi_displs;
   double complex *mpi_full_v1;
   int matvec_mode;
+  int vector_exchange_mode;
   struct SymmetryMatvecPlan *matvec_plan;
 };
 

--- a/src/include/symmetry_matvec_plan.h
+++ b/src/include/symmetry_matvec_plan.h
@@ -9,8 +9,12 @@ struct BindStruct;
 #define SYMMETRY_MATVEC_MODE_PLAN 0
 #define SYMMETRY_MATVEC_MODE_LEGACY 1
 
+#define SYMMETRY_VECTOR_EXCHANGE_ALLGATHER 0
+#define SYMMETRY_VECTOR_EXCHANGE_HALO 1
+
 struct SymmetryMatvecPlan {
   int ready;
+  int columns_remapped;
   unsigned long int dim;
   unsigned long int local_offset;
   unsigned long int local_dim;
@@ -48,6 +52,11 @@ int ApplySymmetryMatvecPlan(const struct BindStruct *X,
                             double complex *tmp_v0,
                             const double complex *full_v1,
                             double complex *local_prdct);
+int ApplySymmetryMatvecPlanHalo(const struct BindStruct *X,
+                                double complex *tmp_v0,
+                                const double complex *local_v1,
+                                double complex *local_prdct);
+int RemapSymmetryMatvecPlanColumns(struct SymmetryMatvecPlan *plan);
 void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan);
 
 #endif /* HPHI_SYMMETRY_MATVEC_PLAN_H */

--- a/src/include/symmetry_matvec_plan.h
+++ b/src/include/symmetry_matvec_plan.h
@@ -18,6 +18,23 @@ struct SymmetryMatvecPlan {
   size_t *row_ptr;
   unsigned long int *col_index;
   double complex *values;
+  size_t local_column_nnz;
+  size_t remote_column_nnz;
+  size_t ghost_count;
+  size_t send_value_count;
+  size_t incoming_peer_count;
+  size_t outgoing_peer_count;
+  size_t max_recv_from_peer;
+  size_t max_send_to_peer;
+  size_t topology_scratch_bytes;
+  size_t halo_schedule_bytes_estimate;
+  size_t halo_runtime_buffer_bytes_estimate;
+  size_t allgather_nonlocal_values_per_call;
+  size_t allgather_payload_bytes_per_call;
+  unsigned int column_slot_width;
+  unsigned long long matvec_calls;
+  unsigned long long input_allgather_calls;
+  unsigned long long prdct_allreduce_calls;
 };
 
 /**

--- a/src/include/symmetry_matvec_plan.h
+++ b/src/include/symmetry_matvec_plan.h
@@ -2,6 +2,7 @@
 #define HPHI_SYMMETRY_MATVEC_PLAN_H
 
 #include "Common.h"
+#include "symmetry_vector_halo.h"
 
 struct BindStruct;
 
@@ -20,21 +21,13 @@ struct SymmetryMatvecPlan {
   double complex *values;
   size_t local_column_nnz;
   size_t remote_column_nnz;
-  size_t ghost_count;
-  size_t send_value_count;
-  size_t incoming_peer_count;
-  size_t outgoing_peer_count;
-  size_t max_recv_from_peer;
-  size_t max_send_to_peer;
-  size_t topology_scratch_bytes;
-  size_t halo_schedule_bytes_estimate;
-  size_t halo_runtime_buffer_bytes_estimate;
   size_t allgather_nonlocal_values_per_call;
   size_t allgather_payload_bytes_per_call;
   unsigned int column_slot_width;
   unsigned long long matvec_calls;
   unsigned long long input_allgather_calls;
   unsigned long long prdct_allreduce_calls;
+  struct SymmetryVectorHaloPlan halo;
 };
 
 /**

--- a/src/include/symmetry_matvec_plan.h
+++ b/src/include/symmetry_matvec_plan.h
@@ -1,6 +1,7 @@
 #ifndef HPHI_SYMMETRY_MATVEC_PLAN_H
 #define HPHI_SYMMETRY_MATVEC_PLAN_H
 
+#include <stdint.h>
 #include "Common.h"
 #include "symmetry_vector_halo.h"
 
@@ -12,6 +13,11 @@ struct BindStruct;
 #define SYMMETRY_VECTOR_EXCHANGE_ALLGATHER 0
 #define SYMMETRY_VECTOR_EXCHANGE_HALO 1
 
+enum SymmetryColumnWidth {
+  SYMMETRY_COLUMN_U32 = 32,
+  SYMMETRY_COLUMN_U64 = 64
+};
+
 struct SymmetryMatvecPlan {
   int ready;
   int columns_remapped;
@@ -21,13 +27,19 @@ struct SymmetryMatvecPlan {
   size_t nnz;
   size_t row_nnz_max;
   size_t *row_ptr;
+  /* Global 1-origin columns before halo remap and in allgather mode. */
   unsigned long int *col_index;
+  /* Exactly one adaptive 0-origin slot array owns halo-mode columns. */
+  uint32_t *column_slot32;
+  uint64_t *column_slot64;
   double complex *values;
+  size_t column_storage_bytes;
+  size_t matrix_storage_bytes;
   size_t local_column_nnz;
   size_t remote_column_nnz;
   size_t allgather_nonlocal_values_per_call;
   size_t allgather_payload_bytes_per_call;
-  unsigned int column_slot_width;
+  enum SymmetryColumnWidth column_slot_width;
   unsigned long long matvec_calls;
   unsigned long long input_allgather_calls;
   unsigned long long prdct_allreduce_calls;

--- a/src/include/symmetry_vector_halo.h
+++ b/src/include/symmetry_vector_halo.h
@@ -30,6 +30,7 @@ struct SymmetryVectorHaloPlan {
   size_t schedule_bytes;
   size_t runtime_buffer_bytes;
   unsigned long long schedule_checksum;
+  unsigned long long exchange_calls;
   unsigned long long reference_exchange_calls;
 };
 
@@ -50,6 +51,8 @@ int ExchangeSymmetryVectorHaloReference(
     struct SymmetryVectorHaloPlan *halo,
     const double complex *local_vector,
     const double complex *full_vector);
+int ExchangeSymmetryVectorHalo(struct SymmetryVectorHaloPlan *halo,
+                               const double complex *local_vector);
 void FreeSymmetryVectorHaloPlan(struct SymmetryVectorHaloPlan *halo);
 
 #endif /* HPHI_SYMMETRY_VECTOR_HALO_H */

--- a/src/include/symmetry_vector_halo.h
+++ b/src/include/symmetry_vector_halo.h
@@ -1,0 +1,55 @@
+#ifndef HPHI_SYMMETRY_VECTOR_HALO_H
+#define HPHI_SYMMETRY_VECTOR_HALO_H
+
+#include "Common.h"
+
+struct SymmetryVectorHaloPlan {
+  int request_layout_ready;
+  int ready;
+  int reference_enabled;
+  int nrank;
+  int rank;
+  unsigned long int dim;
+  unsigned long int local_offset;
+  unsigned long int local_dim;
+  size_t ghost_count;
+  size_t send_value_count;
+  size_t incoming_peer_count;
+  size_t outgoing_peer_count;
+  size_t max_recv_from_peer;
+  size_t max_send_to_peer;
+  int *send_counts;
+  int *send_displs;
+  int *recv_counts;
+  int *recv_displs;
+  unsigned long int *ghost_global_index;
+  unsigned long int *send_local_index;
+  double complex *send_values;
+  double complex *ghost_values;
+  size_t topology_scratch_bytes;
+  size_t schedule_bytes;
+  size_t runtime_buffer_bytes;
+  unsigned long long schedule_checksum;
+  unsigned long long reference_exchange_calls;
+};
+
+int SymmetryVectorOwnerOfGlobalIndex(unsigned long int dim,
+                                     int nrank,
+                                     unsigned long int global_index);
+int BuildSymmetryVectorHaloPlan(struct SymmetryVectorHaloPlan *halo,
+                                unsigned long int dim,
+                                unsigned long int local_offset,
+                                unsigned long int local_dim,
+                                const unsigned long int *global_columns,
+                                size_t column_count,
+                                int nrank,
+                                int rank,
+                                size_t *local_column_count,
+                                size_t *remote_column_count);
+int ExchangeSymmetryVectorHaloReference(
+    struct SymmetryVectorHaloPlan *halo,
+    const double complex *local_vector,
+    const double complex *full_vector);
+void FreeSymmetryVectorHaloPlan(struct SymmetryVectorHaloPlan *halo);
+
+#endif /* HPHI_SYMMETRY_VECTOR_HALO_H */

--- a/src/mltply.c
+++ b/src/mltply.c
@@ -26,6 +26,7 @@
 #include "mltplyCommon.h"
 #include "diagonalcalc.h"
 #include "symmetry_basis.h"
+#include "symmetry_matvec_plan.h"
 
 /**
  * @file   mltply.c
@@ -132,7 +133,12 @@ int mltply(struct BindStruct *X, double complex *tmp_v0,double complex *tmp_v1) 
       StopTimer(1);
       return -1;
     }
+    StartTimer(1513);
     X->Large.prdct = SumMPI_dc(X->Large.prdct);
+    StopTimer(1513);
+    if (X->Sym->matvec_plan != NULL) {
+      X->Sym->matvec_plan->prdct_allreduce_calls++;
+    }
     StopTimer(1);
     return 0;
   }

--- a/src/mltplySpinSym.c
+++ b/src/mltplySpinSym.c
@@ -73,6 +73,9 @@ static const double complex *get_full_input_vector(struct BindStruct *X,
                           X->Sym->mpi_displs, MPI_DOUBLE_COMPLEX,
                           MPI_COMM_WORLD);
     if (ierr != MPI_SUCCESS) return NULL;
+    if (X->Sym->matvec_plan != NULL) {
+      X->Sym->matvec_plan->input_allgather_calls++;
+    }
     return X->Sym->mpi_full_v1;
   }
 #else
@@ -112,6 +115,9 @@ int mltplySpinSym(struct BindStruct *X,
     return -1;
   }
 
+  if (X->Sym->matvec_plan != NULL) {
+    X->Sym->matvec_plan->matvec_calls++;
+  }
   X->Large.prdct += prdct;
   return 0;
 }

--- a/src/mltplySpinSym.c
+++ b/src/mltplySpinSym.c
@@ -96,6 +96,18 @@ int mltplySpinSym(struct BindStruct *X,
   StopTimer(1501);
   if (full_v1 == NULL) return -1;
 
+  if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN &&
+      X->Sym->matvec_plan != NULL &&
+      X->Sym->matvec_plan->halo.reference_enabled == TRUE) {
+    if (ExchangeSymmetryVectorHaloReference(
+            &X->Sym->matvec_plan->halo, tmp_v1, full_v1) != 0) {
+      fprintf(stdoutMPI,
+              "Error: symmetry halo reference exchange did not match "
+              "the gathered input vector.\n");
+      return -1;
+    }
+  }
+
   if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_LEGACY) {
     StartTimer(1502);
     if (apply_legacy_scan(X, tmp_v0, full_v1, &prdct) != 0) {

--- a/src/mltplySpinSym.c
+++ b/src/mltplySpinSym.c
@@ -89,23 +89,44 @@ int mltplySpinSym(struct BindStruct *X,
                   double complex *tmp_v1)
 {
   double complex prdct = 0.0;
-  const double complex *full_v1;
+  const double complex *full_v1 = NULL;
 
-  StartTimer(1501);
-  full_v1 = get_full_input_vector(X, tmp_v1);
-  StopTimer(1501);
-  if (full_v1 == NULL) return -1;
+  if (X->Sym->vector_exchange_mode ==
+      SYMMETRY_VECTOR_EXCHANGE_ALLGATHER) {
+    StartTimer(1501);
+    full_v1 = get_full_input_vector(X, tmp_v1);
+    StopTimer(1501);
+    if (full_v1 == NULL) return -1;
 
-  if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN &&
-      X->Sym->matvec_plan != NULL &&
-      X->Sym->matvec_plan->halo.reference_enabled == TRUE) {
-    if (ExchangeSymmetryVectorHaloReference(
-            &X->Sym->matvec_plan->halo, tmp_v1, full_v1) != 0) {
+    if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN &&
+        X->Sym->matvec_plan != NULL &&
+        X->Sym->matvec_plan->halo.reference_enabled == TRUE) {
+      if (ExchangeSymmetryVectorHaloReference(
+              &X->Sym->matvec_plan->halo, tmp_v1, full_v1) != 0) {
+        fprintf(stdoutMPI,
+                "Error: symmetry halo reference exchange did not match "
+                "the gathered input vector.\n");
+        return -1;
+      }
+    }
+  } else if (X->Sym->vector_exchange_mode ==
+             SYMMETRY_VECTOR_EXCHANGE_HALO) {
+    if (X->Sym->matvec_mode != SYMMETRY_MATVEC_MODE_PLAN ||
+        X->Sym->matvec_plan == NULL || X->Sym->mpi_full_v1 != NULL ||
+        X->Sym->mpi_recvcounts != NULL || X->Sym->mpi_displs != NULL) {
       fprintf(stdoutMPI,
-              "Error: symmetry halo reference exchange did not match "
-              "the gathered input vector.\n");
+              "Error: invalid symmetry production halo state.\n");
       return -1;
     }
+    if (ExchangeSymmetryVectorHalo(
+            &X->Sym->matvec_plan->halo, tmp_v1) != 0) {
+      fprintf(stdoutMPI,
+              "Error: symmetry production halo exchange failed.\n");
+      return -1;
+    }
+  } else {
+    fprintf(stdoutMPI, "Error: invalid symmetry vector exchange mode.\n");
+    return -1;
   }
 
   if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_LEGACY) {
@@ -116,8 +137,17 @@ int mltplySpinSym(struct BindStruct *X,
     }
     StopTimer(1502);
   } else if (X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN) {
+    int apply_status;
     StartTimer(1503);
-    if (ApplySymmetryMatvecPlan(X, tmp_v0, full_v1, &prdct) != 0) {
+    if (X->Sym->vector_exchange_mode ==
+        SYMMETRY_VECTOR_EXCHANGE_HALO) {
+      apply_status =
+          ApplySymmetryMatvecPlanHalo(X, tmp_v0, tmp_v1, &prdct);
+    } else {
+      apply_status =
+          ApplySymmetryMatvecPlan(X, tmp_v0, full_v1, &prdct);
+    }
+    if (apply_status != 0) {
       StopTimer(1503);
       return -1;
     }

--- a/src/symmetry_basis.c
+++ b/src/symmetry_basis.c
@@ -1073,7 +1073,6 @@ int SymmetryCanonicalizeSpinState(const struct BindStruct *X,
 int ActivateSymmetryBasisDimension(struct BindStruct *X)
 {
   if (X->Sym != NULL && X->Sym->enabled == TRUE) {
-    int rank = 0;
     if (nproc < 1 || myrank < 0 || myrank >= nproc) return -1;
     FreeSymmetryMatvecPlan(X->Sym->matvec_plan);
     X->Sym->matvec_plan = NULL;
@@ -1086,32 +1085,8 @@ int ActivateSymmetryBasisDimension(struct BindStruct *X)
     X->Sym->mpi_recvcounts = NULL;
     X->Sym->mpi_displs = NULL;
     X->Sym->mpi_full_v1 = NULL;
-    if (nproc > 1) {
-      if (X->Sym->dim > (unsigned long int)INT_MAX) {
-        fprintf(stdoutMPI,
-                "Error: TransSym MPI sector dimension %lu exceeds MPI int count limit.\n",
-                X->Sym->dim);
-        return -1;
-      }
-      X->Sym->mpi_recvcounts = (int *)calloc((size_t)nproc, sizeof(int));
-      X->Sym->mpi_displs = (int *)calloc((size_t)nproc, sizeof(int));
-      X->Sym->mpi_full_v1 = (double complex *)calloc(X->Sym->dim + 1UL,
-                                                     sizeof(double complex));
-      if (X->Sym->mpi_recvcounts == NULL || X->Sym->mpi_displs == NULL ||
-          X->Sym->mpi_full_v1 == NULL) {
-        return -1;
-      }
-      for (rank = 0; rank < nproc; rank++) {
-        unsigned long int offset;
-        unsigned long int count;
-        symmetry_block_range(X->Sym->dim, rank, nproc, &offset, &count);
-        X->Sym->mpi_recvcounts[rank] = (int)count;
-        X->Sym->mpi_displs[rank] = (int)offset;
-      }
-    }
-#else
-    (void)rank;
 #endif
+    X->Sym->vector_exchange_mode = SYMMETRY_VECTOR_EXCHANGE_ALLGATHER;
     X->Check.idim_max = X->Sym->local_dim;
     X->Check.idim_maxMPI = X->Sym->dim;
   }

--- a/src/symmetry_basis.c
+++ b/src/symmetry_basis.c
@@ -1086,7 +1086,7 @@ int ActivateSymmetryBasisDimension(struct BindStruct *X)
     X->Sym->mpi_displs = NULL;
     X->Sym->mpi_full_v1 = NULL;
 #endif
-    X->Sym->vector_exchange_mode = SYMMETRY_VECTOR_EXCHANGE_ALLGATHER;
+    X->Sym->vector_exchange_mode = SYMMETRY_VECTOR_EXCHANGE_HALO;
     X->Check.idim_max = X->Sym->local_dim;
     X->Check.idim_maxMPI = X->Sym->dim;
   }

--- a/src/symmetry_matvec_plan.c
+++ b/src/symmetry_matvec_plan.c
@@ -1,5 +1,8 @@
 #include <limits.h>
 #include <stdint.h>
+#ifdef MPI
+#include <mpi.h>
+#endif
 #include "DefCommon.h"
 #include "bitcalc.h"
 #include "global.h"
@@ -228,6 +231,270 @@ static int select_matvec_mode(void)
   return BcastMPI_i(0, mode);
 }
 
+static int checked_size_add(size_t lhs, size_t rhs, size_t *result)
+{
+  if (result == NULL || lhs > SIZE_MAX - rhs) return -1;
+  *result = lhs + rhs;
+  return 0;
+}
+
+static int checked_size_mul(size_t lhs, size_t rhs, size_t *result)
+{
+  if (result == NULL || (lhs != 0U && rhs > SIZE_MAX / lhs)) return -1;
+  *result = lhs * rhs;
+  return 0;
+}
+
+static int owner_of_global_index(unsigned long int dim,
+                                 int nrank,
+                                 unsigned long int global_index)
+{
+  unsigned long int base;
+  unsigned long int remainder;
+  unsigned long int zero_index;
+  unsigned long int large_block_end;
+  if (nrank < 1 || global_index == 0UL || global_index > dim) return -1;
+  base = dim / (unsigned long int)nrank;
+  remainder = dim % (unsigned long int)nrank;
+  zero_index = global_index - 1UL;
+  large_block_end = (base + 1UL) * remainder;
+  if (zero_index < large_block_end) {
+    return (int)(zero_index / (base + 1UL));
+  }
+  if (base == 0UL) return -1;
+  return (int)(remainder + (zero_index - large_block_end) / base);
+}
+
+static int mpi_collectives_active(void)
+{
+#ifdef MPI
+  int initialized = 0;
+  int finalized = 0;
+  if (MPI_Initialized(&initialized) != MPI_SUCCESS || initialized == 0) {
+    return FALSE;
+  }
+  if (MPI_Finalized(&finalized) != MPI_SUCCESS || finalized != 0) {
+    return FALSE;
+  }
+  return TRUE;
+#else
+  return FALSE;
+#endif
+}
+
+static int agree_plan_error(int mpi_active, int local_error)
+{
+#ifdef MPI
+  int global_error = local_error;
+  if (mpi_active != FALSE &&
+      MPI_Allreduce(&local_error, &global_error, 1, MPI_INT, MPI_MAX,
+                    MPI_COMM_WORLD) != MPI_SUCCESS) {
+    return -1;
+  }
+  return global_error;
+#else
+  (void)mpi_active;
+  return local_error;
+#endif
+}
+
+static int BuildSymmetryMatvecTopology(struct SymmetryMatvecPlan *plan)
+{
+  unsigned char *remote_bits = NULL;
+  unsigned long long *recv_counts = NULL;
+  unsigned long long *send_counts = NULL;
+  unsigned long int first_local;
+  unsigned long int last_local;
+  size_t bitset_bytes = 0U;
+  size_t peer_bytes = 0U;
+  size_t schedule_count_bytes = 0U;
+  size_t p;
+  size_t byte_index;
+  int mpi_active;
+  int local_error = 0;
+  int rank;
+
+  if (plan == NULL || nproc < 1 || myrank < 0 || myrank >= nproc ||
+      plan->local_offset > plan->dim ||
+      plan->local_dim > plan->dim - plan->local_offset) {
+    return -1;
+  }
+  StartTimer(1130);
+  first_local = plan->local_offset + 1UL;
+  last_local = plan->local_offset + plan->local_dim;
+  if (plan->dim - plan->local_dim > (unsigned long int)SIZE_MAX) {
+    local_error = 1;
+  } else {
+    plan->allgather_nonlocal_values_per_call =
+        (size_t)(plan->dim - plan->local_dim);
+    if (checked_size_mul(plan->allgather_nonlocal_values_per_call,
+                         sizeof(double complex),
+                         &plan->allgather_payload_bytes_per_call) != 0) {
+      local_error = 1;
+    }
+  }
+
+  for (p = 0U; p < plan->nnz; p++) {
+    unsigned long int column = plan->col_index[p];
+    if (column == 0UL || column > plan->dim) {
+      local_error = 1;
+      break;
+    }
+    if (plan->local_dim > 0UL &&
+        column >= first_local && column <= last_local) {
+      plan->local_column_nnz++;
+    } else {
+      plan->remote_column_nnz++;
+    }
+  }
+  mpi_active = mpi_collectives_active();
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+  if (mpi_active != FALSE) {
+#ifdef MPI
+    int comm_size = 0;
+    if (MPI_Comm_size(MPI_COMM_WORLD, &comm_size) != MPI_SUCCESS ||
+        comm_size != nproc) {
+      local_error = 1;
+    }
+#endif
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+
+  if (plan->remote_column_nnz > 0U) {
+    if (plan->dim / 8UL > (unsigned long int)SIZE_MAX) {
+      local_error = 1;
+    } else {
+      bitset_bytes = (size_t)(plan->dim / 8UL);
+    }
+    if (local_error == 0 && plan->dim % 8UL != 0UL) {
+      if (bitset_bytes == SIZE_MAX) {
+        local_error = 1;
+      } else {
+        bitset_bytes++;
+      }
+    }
+    if (local_error == 0) {
+      remote_bits = (unsigned char *)calloc(bitset_bytes, sizeof(*remote_bits));
+      if (remote_bits == NULL) local_error = 1;
+    }
+  }
+  if (nproc > 1) {
+    if ((size_t)nproc > SIZE_MAX / sizeof(*recv_counts)) {
+      local_error = 1;
+    } else {
+      recv_counts = (unsigned long long *)calloc((size_t)nproc,
+                                                 sizeof(*recv_counts));
+      send_counts = (unsigned long long *)calloc((size_t)nproc,
+                                                 sizeof(*send_counts));
+      if (recv_counts == NULL || send_counts == NULL) local_error = 1;
+      if (checked_size_mul(2U * sizeof(*recv_counts), (size_t)nproc,
+                           &peer_bytes) != 0) {
+        local_error = 1;
+      }
+    }
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+
+  for (p = 0U; p < plan->nnz; p++) {
+    unsigned long int column = plan->col_index[p];
+    if (plan->local_dim == 0UL ||
+        column < first_local || column > last_local) {
+      unsigned long int zero_index = column - 1UL;
+      remote_bits[(size_t)(zero_index / 8UL)] |=
+          (unsigned char)(1U << (unsigned int)(zero_index % 8UL));
+    }
+  }
+  for (byte_index = 0U; byte_index < bitset_bytes; byte_index++) {
+    unsigned char bits = remote_bits[byte_index];
+    unsigned int bit;
+    for (bit = 0U; bits != 0U && bit < 8U; bit++) {
+      if ((bits & (unsigned char)(1U << bit)) != 0U) {
+        unsigned long int global_index =
+            (unsigned long int)(byte_index * 8U + (size_t)bit + 1U);
+        int owner = owner_of_global_index(plan->dim, nproc, global_index);
+        if (owner < 0 || owner == myrank) {
+          local_error = 1;
+          break;
+        }
+        plan->ghost_count++;
+        recv_counts[owner]++;
+      }
+    }
+    if (local_error != 0) break;
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+
+  for (rank = 0; rank < nproc; rank++) {
+    if (recv_counts != NULL && recv_counts[rank] > 0ULL) {
+      plan->incoming_peer_count++;
+      if (recv_counts[rank] > (unsigned long long)SIZE_MAX) {
+        local_error = 1;
+      } else if ((size_t)recv_counts[rank] > plan->max_recv_from_peer) {
+        plan->max_recv_from_peer = (size_t)recv_counts[rank];
+      }
+    }
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+
+#ifdef MPI
+  if (mpi_active != FALSE && nproc > 1) {
+    local_error =
+        MPI_Alltoall(recv_counts, 1, MPI_UNSIGNED_LONG_LONG,
+                     send_counts, 1, MPI_UNSIGNED_LONG_LONG,
+                     MPI_COMM_WORLD) == MPI_SUCCESS ? 0 : 1;
+  }
+#endif
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+  if (mpi_active != FALSE && nproc > 1) {
+    for (rank = 0; rank < nproc; rank++) {
+      if (send_counts[rank] > 0ULL) {
+        if (send_counts[rank] > (unsigned long long)SIZE_MAX ||
+            plan->send_value_count >
+                SIZE_MAX - (size_t)send_counts[rank]) {
+          local_error = 1;
+          break;
+        }
+        plan->outgoing_peer_count++;
+        plan->send_value_count += (size_t)send_counts[rank];
+        if ((size_t)send_counts[rank] > plan->max_send_to_peer) {
+          plan->max_send_to_peer = (size_t)send_counts[rank];
+        }
+      }
+    }
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+
+  if (checked_size_mul(4U * sizeof(unsigned long long), (size_t)nproc,
+                       &schedule_count_bytes) != 0 ||
+      checked_size_add(bitset_bytes, peer_bytes,
+                       &plan->topology_scratch_bytes) != 0 ||
+      checked_size_add(plan->ghost_count, plan->send_value_count, &p) != 0 ||
+      checked_size_mul(p, sizeof(unsigned long int),
+                       &plan->halo_schedule_bytes_estimate) != 0 ||
+      checked_size_add(plan->halo_schedule_bytes_estimate,
+                       schedule_count_bytes,
+                       &plan->halo_schedule_bytes_estimate) != 0 ||
+      checked_size_mul(p, sizeof(double complex),
+                       &plan->halo_runtime_buffer_bytes_estimate) != 0 ||
+      checked_size_add((size_t)plan->local_dim, plan->ghost_count, &p) != 0) {
+    local_error = 1;
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+  plan->column_slot_width = p <= (size_t)UINT32_MAX ? 32U : 64U;
+  free(remote_bits);
+  free(recv_counts);
+  free(send_counts);
+  StopTimer(1130);
+  return 0;
+
+fail:
+  free(remote_bits);
+  free(recv_counts);
+  free(send_counts);
+  StopTimer(1130);
+  return -1;
+}
+
 void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan)
 {
   if (plan == NULL) return;
@@ -240,16 +507,18 @@ void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan)
 int BuildSymmetryMatvecPlan(struct BindStruct *X)
 {
   unsigned long int local_row;
-  size_t row_ptr_bytes;
-  size_t col_bytes;
-  size_t value_bytes;
-  size_t plan_bytes;
+  size_t row_ptr_bytes = 0U;
+  size_t col_bytes = 0U;
+  size_t value_bytes = 0U;
+  size_t plan_bytes = 0U;
   size_t min_row_nnz = SIZE_MAX;
   size_t max_row_nnz = 0U;
   size_t *row_counts = NULL;
-  struct SymmetryMatvecPlan *plan;
+  struct SymmetryMatvecPlan *plan = NULL;
   int count_error = 0;
   int fill_error = 0;
+  int local_error = 0;
+  int mpi_active;
   int mode;
 
   if (X == NULL || X->Sym == NULL || X->Sym->enabled != TRUE) return -1;
@@ -265,26 +534,36 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
     return 0;
   }
 
+  mpi_active = mpi_collectives_active();
   plan = (struct SymmetryMatvecPlan *)calloc(1, sizeof(*plan));
-  if (plan == NULL) return -1;
+  local_error = plan == NULL ? 1 : 0;
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
   plan->dim = X->Sym->dim;
   plan->local_offset = X->Sym->local_offset;
   plan->local_dim = X->Sym->local_dim;
 
-  if (plan->local_dim > (unsigned long int)(SIZE_MAX - 1U) ||
+  if (plan->local_offset > plan->dim ||
+      plan->local_dim > plan->dim - plan->local_offset ||
+      plan->local_dim > (unsigned long int)(SIZE_MAX - 1U) ||
       (size_t)plan->local_dim + 1U > SIZE_MAX / sizeof(*plan->row_ptr)) {
-    goto fail;
+    local_error = 1;
+  } else {
+    row_ptr_bytes = ((size_t)plan->local_dim + 1U) * sizeof(*plan->row_ptr);
+    plan->row_ptr = (size_t *)calloc((size_t)plan->local_dim + 1U,
+                                    sizeof(*plan->row_ptr));
+    if (plan->row_ptr == NULL) local_error = 1;
   }
-  row_ptr_bytes = ((size_t)plan->local_dim + 1U) * sizeof(*plan->row_ptr);
-  plan->row_ptr = (size_t *)calloc((size_t)plan->local_dim + 1U,
-                                  sizeof(*plan->row_ptr));
-  if (plan->row_ptr == NULL) goto fail;
-  if (plan->local_dim > 0UL) {
-    if ((size_t)plan->local_dim > SIZE_MAX / sizeof(*row_counts)) goto fail;
+  if (local_error == 0 && plan->local_dim > 0UL) {
+    if ((size_t)plan->local_dim > SIZE_MAX / sizeof(*row_counts)) {
+      local_error = 1;
+    }
+  }
+  if (local_error == 0 && plan->local_dim > 0UL) {
     row_counts = (size_t *)malloc((size_t)plan->local_dim *
                                  sizeof(*row_counts));
-    if (row_counts == NULL) goto fail;
+    if (row_counts == NULL) local_error = 1;
   }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
 
   StartTimer(1120);
 #pragma omp parallel for default(none) schedule(static) reduction(|:count_error) \
@@ -299,21 +578,20 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
       row_counts[local_row] = count.count;
     }
   }
-  if (count_error != 0) {
-    StopTimer(1120);
-    goto fail;
-  }
-  for (local_row = 0UL; local_row < plan->local_dim; local_row++) {
-    size_t row_count = row_counts[local_row];
-    if (plan->row_ptr[local_row] > SIZE_MAX - row_count) {
-      StopTimer(1120);
-      goto fail;
+  if (count_error == 0) {
+    for (local_row = 0UL; local_row < plan->local_dim; local_row++) {
+      size_t row_count = row_counts[local_row];
+      if (plan->row_ptr[local_row] > SIZE_MAX - row_count) {
+        count_error = 1;
+        break;
+      }
+      plan->row_ptr[local_row + 1UL] = plan->row_ptr[local_row] + row_count;
+      if (row_count < min_row_nnz) min_row_nnz = row_count;
+      if (row_count > max_row_nnz) max_row_nnz = row_count;
     }
-    plan->row_ptr[local_row + 1UL] = plan->row_ptr[local_row] + row_count;
-    if (row_count < min_row_nnz) min_row_nnz = row_count;
-    if (row_count > max_row_nnz) max_row_nnz = row_count;
   }
   StopTimer(1120);
+  if (agree_plan_error(mpi_active, count_error) != 0) goto fail;
   free(row_counts);
   row_counts = NULL;
   plan->nnz = plan->row_ptr[plan->local_dim];
@@ -322,20 +600,20 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
   StartTimer(1121);
   if (plan->nnz > SIZE_MAX / sizeof(*plan->col_index) ||
       plan->nnz > SIZE_MAX / sizeof(*plan->values)) {
-    StopTimer(1121);
-    goto fail;
+    local_error = 1;
+  } else {
+    col_bytes = plan->nnz * sizeof(*plan->col_index);
+    value_bytes = plan->nnz * sizeof(*plan->values);
   }
-  col_bytes = plan->nnz * sizeof(*plan->col_index);
-  value_bytes = plan->nnz * sizeof(*plan->values);
-  if (plan->nnz > 0U) {
+  if (local_error == 0 && plan->nnz > 0U) {
     plan->col_index = (unsigned long int *)malloc(col_bytes);
     plan->values = (double complex *)malloc(value_bytes);
     if (plan->col_index == NULL || plan->values == NULL) {
-      StopTimer(1121);
-      goto fail;
+      local_error = 1;
     }
   }
   StopTimer(1121);
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
 
   StartTimer(1122);
 #pragma omp parallel for default(none) schedule(static) reduction(|:fill_error) \
@@ -351,26 +629,31 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
       fill_error = 1;
     }
   }
-  if (fill_error != 0) {
-    StopTimer(1122);
-    goto fail;
-  }
   StopTimer(1122);
+  if (agree_plan_error(mpi_active, fill_error) != 0) goto fail;
+
+  if (BuildSymmetryMatvecTopology(plan) != 0) goto fail;
 
   if (row_ptr_bytes > SIZE_MAX - col_bytes ||
       row_ptr_bytes + col_bytes > SIZE_MAX - value_bytes) {
-    goto fail;
+    local_error = 1;
+  } else {
+    plan_bytes = row_ptr_bytes + col_bytes + value_bytes;
   }
-  plan_bytes = row_ptr_bytes + col_bytes + value_bytes;
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
   if (plan->local_dim == 0UL) min_row_nnz = 0U;
   plan->ready = TRUE;
   X->Sym->matvec_plan = plan;
   fprintf(stdoutMPI,
           "Symmetry matvec: mode=plan local_rows=%lu local_nnz=%zu "
-          "row_nnz_min=%zu row_nnz_max=%zu row_nnz_mean=%.3f bytes=%zu.\n",
+          "row_nnz_min=%zu row_nnz_max=%zu row_nnz_mean=%.3f bytes=%zu "
+          "local_column_nnz=%zu remote_column_nnz=%zu ghost_count=%zu "
+          "incoming_peers=%zu outgoing_peers=%zu.\n",
           plan->local_dim, plan->nnz, min_row_nnz, max_row_nnz,
           plan->local_dim > 0UL ? (double)plan->nnz / (double)plan->local_dim : 0.0,
-          plan_bytes);
+          plan_bytes, plan->local_column_nnz, plan->remote_column_nnz,
+          plan->ghost_count, plan->incoming_peer_count,
+          plan->outgoing_peer_count);
   return 0;
 
 fail:

--- a/src/symmetry_matvec_plan.c
+++ b/src/symmetry_matvec_plan.c
@@ -10,6 +10,7 @@
 #include "CalcTime.h"
 #include "symmetry_basis.h"
 #include "symmetry_matvec_plan.h"
+#include "symmetry_vector_halo.h"
 #include "wrapperMPI.h"
 
 static int apply_exchange_halfspin(unsigned long int state,
@@ -231,38 +232,28 @@ static int select_matvec_mode(void)
   return BcastMPI_i(0, mode);
 }
 
-static int checked_size_add(size_t lhs, size_t rhs, size_t *result)
+static int parse_halo_reference_mode(void)
 {
-  if (result == NULL || lhs > SIZE_MAX - rhs) return -1;
-  *result = lhs + rhs;
-  return 0;
-}
-
-static int checked_size_mul(size_t lhs, size_t rhs, size_t *result)
-{
-  if (result == NULL || (lhs != 0U && rhs > SIZE_MAX / lhs)) return -1;
-  *result = lhs * rhs;
-  return 0;
-}
-
-static int owner_of_global_index(unsigned long int dim,
-                                 int nrank,
-                                 unsigned long int global_index)
-{
-  unsigned long int base;
-  unsigned long int remainder;
-  unsigned long int zero_index;
-  unsigned long int large_block_end;
-  if (nrank < 1 || global_index == 0UL || global_index > dim) return -1;
-  base = dim / (unsigned long int)nrank;
-  remainder = dim % (unsigned long int)nrank;
-  zero_index = global_index - 1UL;
-  large_block_end = (base + 1UL) * remainder;
-  if (zero_index < large_block_end) {
-    return (int)(zero_index / (base + 1UL));
+  const char *value = getenv("HPHI_SYMMETRY_HALO_REFERENCE");
+  if (value == NULL || strcmp(value, "0") == 0 ||
+      strcmp(value, "off") == 0) {
+    return FALSE;
   }
-  if (base == 0UL) return -1;
-  return (int)(remainder + (zero_index - large_block_end) / base);
+  if (strcmp(value, "1") == 0 || strcmp(value, "on") == 0) {
+    return TRUE;
+  }
+  fprintf(stdoutMPI,
+          "Error: HPHI_SYMMETRY_HALO_REFERENCE must be "
+          "'0'/'off' or '1'/'on', got '%s'.\n",
+          value);
+  return -1;
+}
+
+static int select_halo_reference_mode(void)
+{
+  int enabled = FALSE;
+  if (myrank == 0) enabled = parse_halo_reference_mode();
+  return BcastMPI_i(0, enabled);
 }
 
 static int mpi_collectives_active(void)
@@ -298,206 +289,10 @@ static int agree_plan_error(int mpi_active, int local_error)
 #endif
 }
 
-static int BuildSymmetryMatvecTopology(struct SymmetryMatvecPlan *plan)
-{
-  unsigned char *remote_bits = NULL;
-  unsigned long long *recv_counts = NULL;
-  unsigned long long *send_counts = NULL;
-  unsigned long int first_local;
-  unsigned long int last_local;
-  size_t bitset_bytes = 0U;
-  size_t peer_bytes = 0U;
-  size_t schedule_count_bytes = 0U;
-  size_t p;
-  size_t byte_index;
-  int mpi_active;
-  int local_error = 0;
-  int rank;
-
-  if (plan == NULL || nproc < 1 || myrank < 0 || myrank >= nproc ||
-      plan->local_offset > plan->dim ||
-      plan->local_dim > plan->dim - plan->local_offset) {
-    return -1;
-  }
-  StartTimer(1130);
-  first_local = plan->local_offset + 1UL;
-  last_local = plan->local_offset + plan->local_dim;
-  if (plan->dim - plan->local_dim > (unsigned long int)SIZE_MAX) {
-    local_error = 1;
-  } else {
-    plan->allgather_nonlocal_values_per_call =
-        (size_t)(plan->dim - plan->local_dim);
-    if (checked_size_mul(plan->allgather_nonlocal_values_per_call,
-                         sizeof(double complex),
-                         &plan->allgather_payload_bytes_per_call) != 0) {
-      local_error = 1;
-    }
-  }
-
-  for (p = 0U; p < plan->nnz; p++) {
-    unsigned long int column = plan->col_index[p];
-    if (column == 0UL || column > plan->dim) {
-      local_error = 1;
-      break;
-    }
-    if (plan->local_dim > 0UL &&
-        column >= first_local && column <= last_local) {
-      plan->local_column_nnz++;
-    } else {
-      plan->remote_column_nnz++;
-    }
-  }
-  mpi_active = mpi_collectives_active();
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-  if (mpi_active != FALSE) {
-#ifdef MPI
-    int comm_size = 0;
-    if (MPI_Comm_size(MPI_COMM_WORLD, &comm_size) != MPI_SUCCESS ||
-        comm_size != nproc) {
-      local_error = 1;
-    }
-#endif
-  }
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-
-  if (plan->remote_column_nnz > 0U) {
-    if (plan->dim / 8UL > (unsigned long int)SIZE_MAX) {
-      local_error = 1;
-    } else {
-      bitset_bytes = (size_t)(plan->dim / 8UL);
-    }
-    if (local_error == 0 && plan->dim % 8UL != 0UL) {
-      if (bitset_bytes == SIZE_MAX) {
-        local_error = 1;
-      } else {
-        bitset_bytes++;
-      }
-    }
-    if (local_error == 0) {
-      remote_bits = (unsigned char *)calloc(bitset_bytes, sizeof(*remote_bits));
-      if (remote_bits == NULL) local_error = 1;
-    }
-  }
-  if (nproc > 1) {
-    if ((size_t)nproc > SIZE_MAX / sizeof(*recv_counts)) {
-      local_error = 1;
-    } else {
-      recv_counts = (unsigned long long *)calloc((size_t)nproc,
-                                                 sizeof(*recv_counts));
-      send_counts = (unsigned long long *)calloc((size_t)nproc,
-                                                 sizeof(*send_counts));
-      if (recv_counts == NULL || send_counts == NULL) local_error = 1;
-      if (checked_size_mul(2U * sizeof(*recv_counts), (size_t)nproc,
-                           &peer_bytes) != 0) {
-        local_error = 1;
-      }
-    }
-  }
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-
-  for (p = 0U; p < plan->nnz; p++) {
-    unsigned long int column = plan->col_index[p];
-    if (plan->local_dim == 0UL ||
-        column < first_local || column > last_local) {
-      unsigned long int zero_index = column - 1UL;
-      remote_bits[(size_t)(zero_index / 8UL)] |=
-          (unsigned char)(1U << (unsigned int)(zero_index % 8UL));
-    }
-  }
-  for (byte_index = 0U; byte_index < bitset_bytes; byte_index++) {
-    unsigned char bits = remote_bits[byte_index];
-    unsigned int bit;
-    for (bit = 0U; bits != 0U && bit < 8U; bit++) {
-      if ((bits & (unsigned char)(1U << bit)) != 0U) {
-        unsigned long int global_index =
-            (unsigned long int)(byte_index * 8U + (size_t)bit + 1U);
-        int owner = owner_of_global_index(plan->dim, nproc, global_index);
-        if (owner < 0 || owner == myrank) {
-          local_error = 1;
-          break;
-        }
-        plan->ghost_count++;
-        recv_counts[owner]++;
-      }
-    }
-    if (local_error != 0) break;
-  }
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-
-  for (rank = 0; rank < nproc; rank++) {
-    if (recv_counts != NULL && recv_counts[rank] > 0ULL) {
-      plan->incoming_peer_count++;
-      if (recv_counts[rank] > (unsigned long long)SIZE_MAX) {
-        local_error = 1;
-      } else if ((size_t)recv_counts[rank] > plan->max_recv_from_peer) {
-        plan->max_recv_from_peer = (size_t)recv_counts[rank];
-      }
-    }
-  }
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-
-#ifdef MPI
-  if (mpi_active != FALSE && nproc > 1) {
-    local_error =
-        MPI_Alltoall(recv_counts, 1, MPI_UNSIGNED_LONG_LONG,
-                     send_counts, 1, MPI_UNSIGNED_LONG_LONG,
-                     MPI_COMM_WORLD) == MPI_SUCCESS ? 0 : 1;
-  }
-#endif
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-  if (mpi_active != FALSE && nproc > 1) {
-    for (rank = 0; rank < nproc; rank++) {
-      if (send_counts[rank] > 0ULL) {
-        if (send_counts[rank] > (unsigned long long)SIZE_MAX ||
-            plan->send_value_count >
-                SIZE_MAX - (size_t)send_counts[rank]) {
-          local_error = 1;
-          break;
-        }
-        plan->outgoing_peer_count++;
-        plan->send_value_count += (size_t)send_counts[rank];
-        if ((size_t)send_counts[rank] > plan->max_send_to_peer) {
-          plan->max_send_to_peer = (size_t)send_counts[rank];
-        }
-      }
-    }
-  }
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-
-  if (checked_size_mul(4U * sizeof(unsigned long long), (size_t)nproc,
-                       &schedule_count_bytes) != 0 ||
-      checked_size_add(bitset_bytes, peer_bytes,
-                       &plan->topology_scratch_bytes) != 0 ||
-      checked_size_add(plan->ghost_count, plan->send_value_count, &p) != 0 ||
-      checked_size_mul(p, sizeof(unsigned long int),
-                       &plan->halo_schedule_bytes_estimate) != 0 ||
-      checked_size_add(plan->halo_schedule_bytes_estimate,
-                       schedule_count_bytes,
-                       &plan->halo_schedule_bytes_estimate) != 0 ||
-      checked_size_mul(p, sizeof(double complex),
-                       &plan->halo_runtime_buffer_bytes_estimate) != 0 ||
-      checked_size_add((size_t)plan->local_dim, plan->ghost_count, &p) != 0) {
-    local_error = 1;
-  }
-  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
-  plan->column_slot_width = p <= (size_t)UINT32_MAX ? 32U : 64U;
-  free(remote_bits);
-  free(recv_counts);
-  free(send_counts);
-  StopTimer(1130);
-  return 0;
-
-fail:
-  free(remote_bits);
-  free(recv_counts);
-  free(send_counts);
-  StopTimer(1130);
-  return -1;
-}
-
 void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan)
 {
   if (plan == NULL) return;
+  FreeSymmetryVectorHaloPlan(&plan->halo);
   free(plan->row_ptr);
   free(plan->col_index);
   free(plan->values);
@@ -520,6 +315,7 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
   int local_error = 0;
   int mpi_active;
   int mode;
+  int halo_reference_mode;
 
   if (X == NULL || X->Sym == NULL || X->Sym->enabled != TRUE) return -1;
   FreeSymmetryMatvecPlan(X->Sym->matvec_plan);
@@ -533,6 +329,8 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
             "Symmetry matvec: mode=legacy (replicated beta scan).\n");
     return 0;
   }
+  halo_reference_mode = select_halo_reference_mode();
+  if (halo_reference_mode < 0) return -1;
 
   mpi_active = mpi_collectives_active();
   plan = (struct SymmetryMatvecPlan *)calloc(1, sizeof(*plan));
@@ -632,7 +430,33 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
   StopTimer(1122);
   if (agree_plan_error(mpi_active, fill_error) != 0) goto fail;
 
-  if (BuildSymmetryMatvecTopology(plan) != 0) goto fail;
+  if (plan->dim - plan->local_dim > (unsigned long int)SIZE_MAX ||
+      (size_t)(plan->dim - plan->local_dim) >
+          SIZE_MAX / sizeof(double complex)) {
+    local_error = 1;
+  } else {
+    plan->allgather_nonlocal_values_per_call =
+        (size_t)(plan->dim - plan->local_dim);
+    plan->allgather_payload_bytes_per_call =
+        plan->allgather_nonlocal_values_per_call * sizeof(double complex);
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+  if (BuildSymmetryVectorHaloPlan(
+          &plan->halo, plan->dim, plan->local_offset, plan->local_dim,
+          plan->col_index, plan->nnz, nproc, myrank,
+          &plan->local_column_nnz, &plan->remote_column_nnz) != 0) {
+    goto fail;
+  }
+  plan->halo.reference_enabled = halo_reference_mode;
+  if ((size_t)plan->local_dim >
+      SIZE_MAX - plan->halo.ghost_count) {
+    local_error = 1;
+  } else {
+    size_t slot_count = (size_t)plan->local_dim + plan->halo.ghost_count;
+    plan->column_slot_width =
+        slot_count <= (size_t)UINT32_MAX ? 32U : 64U;
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
 
   if (row_ptr_bytes > SIZE_MAX - col_bytes ||
       row_ptr_bytes + col_bytes > SIZE_MAX - value_bytes) {
@@ -648,12 +472,15 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
           "Symmetry matvec: mode=plan local_rows=%lu local_nnz=%zu "
           "row_nnz_min=%zu row_nnz_max=%zu row_nnz_mean=%.3f bytes=%zu "
           "local_column_nnz=%zu remote_column_nnz=%zu ghost_count=%zu "
-          "incoming_peers=%zu outgoing_peers=%zu.\n",
+          "incoming_peers=%zu outgoing_peers=%zu halo_schedule=%s "
+          "halo_reference=%s.\n",
           plan->local_dim, plan->nnz, min_row_nnz, max_row_nnz,
           plan->local_dim > 0UL ? (double)plan->nnz / (double)plan->local_dim : 0.0,
           plan_bytes, plan->local_column_nnz, plan->remote_column_nnz,
-          plan->ghost_count, plan->incoming_peer_count,
-          plan->outgoing_peer_count);
+          plan->halo.ghost_count, plan->halo.incoming_peer_count,
+          plan->halo.outgoing_peer_count,
+          plan->halo.ready == TRUE ? "ready" : "request-layout-only",
+          plan->halo.reference_enabled == TRUE ? "on" : "off");
   return 0;
 
 fail:

--- a/src/symmetry_matvec_plan.c
+++ b/src/symmetry_matvec_plan.c
@@ -403,18 +403,50 @@ int RemapSymmetryMatvecPlanColumns(struct SymmetryMatvecPlan *plan)
 {
   size_t column;
   size_t slot_count;
+  uint32_t *column_slot32 = NULL;
+  uint64_t *column_slot64 = NULL;
+  enum SymmetryColumnWidth column_width;
   int remap_error = 0;
   if (plan == NULL || plan->columns_remapped == TRUE ||
       plan->local_offset > plan->dim ||
       plan->local_dim > plan->dim - plan->local_offset ||
       (plan->nnz > 0U && plan->col_index == NULL) ||
+      plan->column_slot32 != NULL || plan->column_slot64 != NULL ||
       (size_t)plan->local_dim > SIZE_MAX - plan->halo.ghost_count) {
     return -1;
   }
   slot_count = (size_t)plan->local_dim + plan->halo.ghost_count;
+  column_width =
+      slot_count <= (size_t)UINT32_MAX ? SYMMETRY_COLUMN_U32
+                                       : SYMMETRY_COLUMN_U64;
   StartTimer(1132);
+  if (plan->nnz > 0U) {
+    if (column_width == SYMMETRY_COLUMN_U32) {
+      if (plan->nnz > SIZE_MAX / sizeof(*column_slot32)) {
+        remap_error = 1;
+      } else {
+        column_slot32 =
+            (uint32_t *)malloc(plan->nnz * sizeof(*column_slot32));
+        if (column_slot32 == NULL) remap_error = 1;
+      }
+    } else {
+      if (plan->nnz > SIZE_MAX / sizeof(*column_slot64)) {
+        remap_error = 1;
+      } else {
+        column_slot64 =
+            (uint64_t *)malloc(plan->nnz * sizeof(*column_slot64));
+        if (column_slot64 == NULL) remap_error = 1;
+      }
+    }
+  }
+  if (remap_error != 0) {
+    StopTimer(1132);
+    free(column_slot32);
+    free(column_slot64);
+    return -1;
+  }
 #pragma omp parallel for default(none) schedule(static) reduction(|:remap_error) \
-  shared(plan, slot_count)
+  shared(plan, slot_count, column_width, column_slot32, column_slot64)
   for (column = 0U; column < plan->nnz; column++) {
     unsigned long int global_index = plan->col_index[column];
     size_t slot = 0U;
@@ -435,14 +467,31 @@ int RemapSymmetryMatvecPlanColumns(struct SymmetryMatvecPlan *plan)
       }
       slot = (size_t)plan->local_dim + ghost_position;
     }
-    if (slot >= slot_count || slot > (size_t)ULONG_MAX) {
+    if (slot >= slot_count) {
       remap_error = 1;
       continue;
     }
-    plan->col_index[column] = (unsigned long int)slot;
+    if (column_width == SYMMETRY_COLUMN_U32) {
+      if (slot > (size_t)UINT32_MAX) {
+        remap_error = 1;
+        continue;
+      }
+      column_slot32[column] = (uint32_t)slot;
+    } else {
+      column_slot64[column] = (uint64_t)slot;
+    }
   }
   StopTimer(1132);
-  if (remap_error != 0) return -1;
+  if (remap_error != 0) {
+    free(column_slot32);
+    free(column_slot64);
+    return -1;
+  }
+  free(plan->col_index);
+  plan->col_index = NULL;
+  plan->column_slot32 = column_slot32;
+  plan->column_slot64 = column_slot64;
+  plan->column_slot_width = column_width;
   plan->columns_remapped = TRUE;
   return 0;
 }
@@ -453,6 +502,8 @@ void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan)
   FreeSymmetryVectorHaloPlan(&plan->halo);
   free(plan->row_ptr);
   free(plan->col_index);
+  free(plan->column_slot32);
+  free(plan->column_slot64);
   free(plan->values);
   free(plan);
 }
@@ -462,6 +513,7 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
   unsigned long int local_row;
   size_t row_ptr_bytes = 0U;
   size_t col_bytes = 0U;
+  size_t ghost_index_bytes = 0U;
   size_t value_bytes = 0U;
   size_t plan_bytes = 0U;
   size_t min_row_nnz = SIZE_MAX;
@@ -637,7 +689,8 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
   } else {
     size_t slot_count = (size_t)plan->local_dim + plan->halo.ghost_count;
     plan->column_slot_width =
-        slot_count <= (size_t)UINT32_MAX ? 32U : 64U;
+        slot_count <= (size_t)UINT32_MAX ? SYMMETRY_COLUMN_U32
+                                         : SYMMETRY_COLUMN_U64;
   }
   if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
   if (vector_exchange_mode == SYMMETRY_VECTOR_EXCHANGE_HALO) {
@@ -646,6 +699,23 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
       local_error = 1;
     }
     if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+    if (plan->column_slot_width == SYMMETRY_COLUMN_U32) {
+      col_bytes = plan->nnz * sizeof(*plan->column_slot32);
+    } else {
+      col_bytes = plan->nnz * sizeof(*plan->column_slot64);
+    }
+    if (plan->halo.ghost_count >
+        SIZE_MAX / sizeof(*plan->halo.ghost_global_index)) {
+      local_error = 1;
+    } else {
+      ghost_index_bytes =
+          plan->halo.ghost_count * sizeof(*plan->halo.ghost_global_index);
+      if (ghost_index_bytes > plan->halo.schedule_bytes) local_error = 1;
+    }
+    if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+    free(plan->halo.ghost_global_index);
+    plan->halo.ghost_global_index = NULL;
+    plan->halo.schedule_bytes -= ghost_index_bytes;
   }
 
   if (row_ptr_bytes > SIZE_MAX - col_bytes ||
@@ -655,6 +725,8 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
     plan_bytes = row_ptr_bytes + col_bytes + value_bytes;
   }
   if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+  plan->column_storage_bytes = col_bytes;
+  plan->matrix_storage_bytes = plan_bytes;
   if (plan->local_dim == 0UL) min_row_nnz = 0U;
   plan->ready = TRUE;
   X->Sym->matvec_plan = plan;
@@ -664,7 +736,7 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
           "row_nnz_min=%zu row_nnz_max=%zu row_nnz_mean=%.3f bytes=%zu "
           "local_column_nnz=%zu remote_column_nnz=%zu ghost_count=%zu "
           "incoming_peers=%zu outgoing_peers=%zu halo_schedule=%s "
-          "columns=%s halo_reference=%s.\n",
+          "columns=%s column_slot_width=%u halo_reference=%s.\n",
           vector_exchange_mode == SYMMETRY_VECTOR_EXCHANGE_HALO
               ? "halo"
               : "allgather",
@@ -675,6 +747,7 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
           plan->halo.outgoing_peer_count,
           plan->halo.ready == TRUE ? "ready" : "request-layout-only",
           plan->columns_remapped == TRUE ? "local/ghost-slots" : "global",
+          (unsigned int)plan->column_slot_width,
           plan->halo.reference_enabled == TRUE ? "on" : "off");
   return 0;
 
@@ -701,7 +774,8 @@ int ApplySymmetryMatvecPlan(const struct BindStruct *X,
   if (plan == NULL || plan->ready != TRUE || plan->dim != X->Sym->dim ||
       plan->local_offset != X->Sym->local_offset ||
       plan->local_dim != X->Sym->local_dim ||
-      plan->columns_remapped == TRUE) {
+      plan->columns_remapped == TRUE ||
+      (plan->nnz > 0U && plan->col_index == NULL)) {
     fprintf(stdoutMPI, "Error: symmetry matvec plan does not match the active sector.\n");
     return -1;
   }
@@ -723,34 +797,16 @@ int ApplySymmetryMatvecPlan(const struct BindStruct *X,
   return 0;
 }
 
-int ApplySymmetryMatvecPlanHalo(const struct BindStruct *X,
-                                double complex *tmp_v0,
-                                const double complex *local_v1,
-                                double complex *local_prdct)
+static int apply_symmetry_matvec_plan_halo_u32(
+    const struct SymmetryMatvecPlan *plan,
+    double complex *tmp_v0,
+    const double complex *local_v1,
+    size_t slot_count,
+    double complex *local_prdct)
 {
   unsigned long int local_row;
   double complex prdct = 0.0;
-  const struct SymmetryMatvecPlan *plan;
-  size_t slot_count;
   int apply_error = 0;
-  if (X == NULL || X->Sym == NULL || tmp_v0 == NULL || local_v1 == NULL ||
-      local_prdct == NULL) {
-    return -1;
-  }
-  plan = X->Sym->matvec_plan;
-  if (plan == NULL || plan->ready != TRUE ||
-      plan->columns_remapped != TRUE || plan->halo.ready != TRUE ||
-      plan->dim != X->Sym->dim ||
-      plan->local_offset != X->Sym->local_offset ||
-      plan->local_dim != X->Sym->local_dim ||
-      (size_t)plan->local_dim > SIZE_MAX - plan->halo.ghost_count) {
-    fprintf(stdoutMPI,
-            "Error: symmetry halo matvec plan does not match "
-            "the active sector.\n");
-    return -1;
-  }
-  slot_count = (size_t)plan->local_dim + plan->halo.ghost_count;
-
 #pragma omp parallel for default(none) schedule(static) \
   reduction(+:prdct) reduction(|:apply_error) \
   shared(plan, tmp_v0, local_v1, slot_count)
@@ -759,7 +815,7 @@ int ApplySymmetryMatvecPlanHalo(const struct BindStruct *X,
     double complex sum = 0.0;
     for (p = plan->row_ptr[local_row];
          p < plan->row_ptr[local_row + 1UL]; p++) {
-      size_t slot = (size_t)plan->col_index[p];
+      size_t slot = (size_t)plan->column_slot32[p];
       double complex input_value;
       if (slot >= slot_count) {
         apply_error = 1;
@@ -777,4 +833,85 @@ int ApplySymmetryMatvecPlanHalo(const struct BindStruct *X,
   if (apply_error != 0) return -1;
   *local_prdct = prdct;
   return 0;
+}
+
+static int apply_symmetry_matvec_plan_halo_u64(
+    const struct SymmetryMatvecPlan *plan,
+    double complex *tmp_v0,
+    const double complex *local_v1,
+    size_t slot_count,
+    double complex *local_prdct)
+{
+  unsigned long int local_row;
+  double complex prdct = 0.0;
+  int apply_error = 0;
+#pragma omp parallel for default(none) schedule(static) \
+  reduction(+:prdct) reduction(|:apply_error) \
+  shared(plan, tmp_v0, local_v1, slot_count)
+  for (local_row = 0UL; local_row < plan->local_dim; local_row++) {
+    size_t p;
+    double complex sum = 0.0;
+    for (p = plan->row_ptr[local_row];
+         p < plan->row_ptr[local_row + 1UL]; p++) {
+      uint64_t raw_slot = plan->column_slot64[p];
+      size_t slot;
+      double complex input_value;
+      if (raw_slot >= (uint64_t)slot_count) {
+        apply_error = 1;
+        continue;
+      }
+      slot = (size_t)raw_slot;
+      input_value =
+          slot < (size_t)plan->local_dim
+              ? local_v1[slot + 1U]
+              : plan->halo.ghost_values[slot - (size_t)plan->local_dim];
+      sum += plan->values[p] * input_value;
+    }
+    tmp_v0[local_row + 1UL] += sum;
+    prdct += conj(local_v1[local_row + 1UL]) * sum;
+  }
+  if (apply_error != 0) return -1;
+  *local_prdct = prdct;
+  return 0;
+}
+
+int ApplySymmetryMatvecPlanHalo(const struct BindStruct *X,
+                                double complex *tmp_v0,
+                                const double complex *local_v1,
+                                double complex *local_prdct)
+{
+  const struct SymmetryMatvecPlan *plan;
+  size_t slot_count;
+  if (X == NULL || X->Sym == NULL || tmp_v0 == NULL || local_v1 == NULL ||
+      local_prdct == NULL) {
+    return -1;
+  }
+  plan = X->Sym->matvec_plan;
+  if (plan == NULL || plan->ready != TRUE ||
+      plan->columns_remapped != TRUE || plan->halo.ready != TRUE ||
+      plan->dim != X->Sym->dim ||
+      plan->local_offset != X->Sym->local_offset ||
+      plan->local_dim != X->Sym->local_dim ||
+      plan->col_index != NULL ||
+      (plan->column_slot_width != SYMMETRY_COLUMN_U32 &&
+       plan->column_slot_width != SYMMETRY_COLUMN_U64) ||
+      (plan->column_slot_width == SYMMETRY_COLUMN_U32 &&
+       (plan->column_slot64 != NULL ||
+        (plan->nnz > 0U && plan->column_slot32 == NULL))) ||
+      (plan->column_slot_width == SYMMETRY_COLUMN_U64 &&
+       (plan->column_slot32 != NULL ||
+        (plan->nnz > 0U && plan->column_slot64 == NULL))) ||
+      (size_t)plan->local_dim > SIZE_MAX - plan->halo.ghost_count) {
+    fprintf(stdoutMPI,
+            "Error: symmetry halo matvec plan does not match "
+            "the active sector.\n");
+    return -1;
+  }
+  slot_count = (size_t)plan->local_dim + plan->halo.ghost_count;
+  if (plan->column_slot_width == SYMMETRY_COLUMN_U32) {
+    return apply_symmetry_matvec_plan_halo_u32(
+        plan, tmp_v0, local_v1, slot_count, local_prdct);
+  }
+  return apply_symmetry_matvec_plan_halo_u64(
+      plan, tmp_v0, local_v1, slot_count, local_prdct);
 }

--- a/src/symmetry_matvec_plan.c
+++ b/src/symmetry_matvec_plan.c
@@ -232,6 +232,29 @@ static int select_matvec_mode(void)
   return BcastMPI_i(0, mode);
 }
 
+static int parse_vector_exchange_mode(void)
+{
+  const char *value = getenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
+  if (value == NULL || strcmp(value, "allgather") == 0) {
+    return SYMMETRY_VECTOR_EXCHANGE_ALLGATHER;
+  }
+  if (strcmp(value, "halo") == 0) {
+    return SYMMETRY_VECTOR_EXCHANGE_HALO;
+  }
+  fprintf(stdoutMPI,
+          "Error: HPHI_SYMMETRY_VECTOR_EXCHANGE must be "
+          "'allgather' or 'halo', got '%s'.\n",
+          value);
+  return -1;
+}
+
+static int select_vector_exchange_mode(void)
+{
+  int mode = SYMMETRY_VECTOR_EXCHANGE_ALLGATHER;
+  if (myrank == 0) mode = parse_vector_exchange_mode();
+  return BcastMPI_i(0, mode);
+}
+
 static int parse_halo_reference_mode(void)
 {
   const char *value = getenv("HPHI_SYMMETRY_HALO_REFERENCE");
@@ -289,6 +312,141 @@ static int agree_plan_error(int mpi_active, int local_error)
 #endif
 }
 
+static int configure_full_input_vector(struct BindStruct *X,
+                                       int required,
+                                       int mpi_active)
+{
+#ifdef MPI
+  int local_error = 0;
+  int rank;
+  free(X->Sym->mpi_recvcounts);
+  free(X->Sym->mpi_displs);
+  free(X->Sym->mpi_full_v1);
+  X->Sym->mpi_recvcounts = NULL;
+  X->Sym->mpi_displs = NULL;
+  X->Sym->mpi_full_v1 = NULL;
+  if (required == FALSE || nproc <= 1) return 0;
+  if (X->Sym->dim > (unsigned long int)INT_MAX ||
+      X->Sym->dim > (unsigned long int)(SIZE_MAX / sizeof(double complex) -
+                                        1U)) {
+    local_error = 1;
+  } else {
+    X->Sym->mpi_recvcounts =
+        (int *)calloc((size_t)nproc, sizeof(*X->Sym->mpi_recvcounts));
+    X->Sym->mpi_displs =
+        (int *)calloc((size_t)nproc, sizeof(*X->Sym->mpi_displs));
+    X->Sym->mpi_full_v1 =
+        (double complex *)calloc((size_t)X->Sym->dim + 1U,
+                                 sizeof(*X->Sym->mpi_full_v1));
+    if (X->Sym->mpi_recvcounts == NULL || X->Sym->mpi_displs == NULL ||
+        X->Sym->mpi_full_v1 == NULL) {
+      local_error = 1;
+    }
+  }
+  if (agree_plan_error(mpi_active, local_error) != 0) {
+    free(X->Sym->mpi_recvcounts);
+    free(X->Sym->mpi_displs);
+    free(X->Sym->mpi_full_v1);
+    X->Sym->mpi_recvcounts = NULL;
+    X->Sym->mpi_displs = NULL;
+    X->Sym->mpi_full_v1 = NULL;
+    fprintf(stdoutMPI,
+            "Error: failed to allocate the symmetry full input vector.\n");
+    return -1;
+  }
+  for (rank = 0; rank < nproc; rank++) {
+    unsigned long int offset;
+    unsigned long int count;
+    unsigned long int base =
+        X->Sym->dim / (unsigned long int)nproc;
+    unsigned long int remainder =
+        X->Sym->dim % (unsigned long int)nproc;
+    unsigned long int unsigned_rank = (unsigned long int)rank;
+    count = base + (unsigned_rank < remainder ? 1UL : 0UL);
+    offset = base * unsigned_rank +
+             (unsigned_rank < remainder ? unsigned_rank : remainder);
+    X->Sym->mpi_recvcounts[rank] = (int)count;
+    X->Sym->mpi_displs[rank] = (int)offset;
+  }
+#else
+  (void)X;
+  (void)required;
+  (void)mpi_active;
+#endif
+  return 0;
+}
+
+static int find_ghost_position(const struct SymmetryVectorHaloPlan *halo,
+                               unsigned long int global_index,
+                               size_t *position)
+{
+  size_t left = 0U;
+  size_t right = halo->ghost_count;
+  while (left < right) {
+    size_t middle = left + (right - left) / 2U;
+    unsigned long int candidate = halo->ghost_global_index[middle];
+    if (candidate < global_index) {
+      left = middle + 1U;
+    } else {
+      right = middle;
+    }
+  }
+  if (left >= halo->ghost_count ||
+      halo->ghost_global_index[left] != global_index) {
+    return -1;
+  }
+  *position = left;
+  return 0;
+}
+
+int RemapSymmetryMatvecPlanColumns(struct SymmetryMatvecPlan *plan)
+{
+  size_t column;
+  size_t slot_count;
+  int remap_error = 0;
+  if (plan == NULL || plan->columns_remapped == TRUE ||
+      plan->local_offset > plan->dim ||
+      plan->local_dim > plan->dim - plan->local_offset ||
+      (plan->nnz > 0U && plan->col_index == NULL) ||
+      (size_t)plan->local_dim > SIZE_MAX - plan->halo.ghost_count) {
+    return -1;
+  }
+  slot_count = (size_t)plan->local_dim + plan->halo.ghost_count;
+  StartTimer(1132);
+#pragma omp parallel for default(none) schedule(static) reduction(|:remap_error) \
+  shared(plan, slot_count)
+  for (column = 0U; column < plan->nnz; column++) {
+    unsigned long int global_index = plan->col_index[column];
+    size_t slot = 0U;
+    if (global_index == 0UL || global_index > plan->dim) {
+      remap_error = 1;
+      continue;
+    }
+    if (global_index > plan->local_offset &&
+        global_index <= plan->local_offset + plan->local_dim) {
+      slot = (size_t)(global_index - plan->local_offset - 1UL);
+    } else {
+      size_t ghost_position = 0U;
+      if (find_ghost_position(&plan->halo, global_index,
+                              &ghost_position) != 0 ||
+          (size_t)plan->local_dim > SIZE_MAX - ghost_position) {
+        remap_error = 1;
+        continue;
+      }
+      slot = (size_t)plan->local_dim + ghost_position;
+    }
+    if (slot >= slot_count || slot > (size_t)ULONG_MAX) {
+      remap_error = 1;
+      continue;
+    }
+    plan->col_index[column] = (unsigned long int)slot;
+  }
+  StopTimer(1132);
+  if (remap_error != 0) return -1;
+  plan->columns_remapped = TRUE;
+  return 0;
+}
+
 void FreeSymmetryMatvecPlan(struct SymmetryMatvecPlan *plan)
 {
   if (plan == NULL) return;
@@ -315,6 +473,7 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
   int local_error = 0;
   int mpi_active;
   int mode;
+  int vector_exchange_mode;
   int halo_reference_mode;
 
   if (X == NULL || X->Sym == NULL || X->Sym->enabled != TRUE) return -1;
@@ -323,16 +482,40 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
 
   mode = select_matvec_mode();
   if (mode < 0) return -1;
-  X->Sym->matvec_mode = mode;
-  if (mode == SYMMETRY_MATVEC_MODE_LEGACY) {
-    fprintf(stdoutMPI,
-            "Symmetry matvec: mode=legacy (replicated beta scan).\n");
-    return 0;
-  }
+  vector_exchange_mode = select_vector_exchange_mode();
+  if (vector_exchange_mode < 0) return -1;
   halo_reference_mode = select_halo_reference_mode();
   if (halo_reference_mode < 0) return -1;
-
+  if (mode == SYMMETRY_MATVEC_MODE_LEGACY &&
+      vector_exchange_mode == SYMMETRY_VECTOR_EXCHANGE_HALO) {
+    fprintf(stdoutMPI,
+            "Error: symmetry legacy matvec requires "
+            "HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather.\n");
+    return -1;
+  }
+  if (halo_reference_mode == TRUE &&
+      (mode != SYMMETRY_MATVEC_MODE_PLAN ||
+       vector_exchange_mode != SYMMETRY_VECTOR_EXCHANGE_ALLGATHER)) {
+    fprintf(stdoutMPI,
+            "Error: HPHI_SYMMETRY_HALO_REFERENCE requires "
+            "plan/allgather mode.\n");
+    return -1;
+  }
+  X->Sym->matvec_mode = mode;
+  X->Sym->vector_exchange_mode = vector_exchange_mode;
   mpi_active = mpi_collectives_active();
+  if (configure_full_input_vector(
+          X, vector_exchange_mode == SYMMETRY_VECTOR_EXCHANGE_ALLGATHER,
+          mpi_active) != 0) {
+    return -1;
+  }
+  if (mode == SYMMETRY_MATVEC_MODE_LEGACY) {
+    fprintf(stdoutMPI,
+            "Symmetry matvec: mode=legacy vector_exchange=allgather "
+            "(replicated beta scan).\n");
+    return 0;
+  }
+
   plan = (struct SymmetryMatvecPlan *)calloc(1, sizeof(*plan));
   local_error = plan == NULL ? 1 : 0;
   if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
@@ -457,6 +640,13 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
         slot_count <= (size_t)UINT32_MAX ? 32U : 64U;
   }
   if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+  if (vector_exchange_mode == SYMMETRY_VECTOR_EXCHANGE_HALO) {
+    if (plan->halo.ready != TRUE ||
+        RemapSymmetryMatvecPlanColumns(plan) != 0) {
+      local_error = 1;
+    }
+    if (agree_plan_error(mpi_active, local_error) != 0) goto fail;
+  }
 
   if (row_ptr_bytes > SIZE_MAX - col_bytes ||
       row_ptr_bytes + col_bytes > SIZE_MAX - value_bytes) {
@@ -469,17 +659,22 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
   plan->ready = TRUE;
   X->Sym->matvec_plan = plan;
   fprintf(stdoutMPI,
-          "Symmetry matvec: mode=plan local_rows=%lu local_nnz=%zu "
+          "Symmetry matvec: mode=plan vector_exchange=%s "
+          "local_rows=%lu local_nnz=%zu "
           "row_nnz_min=%zu row_nnz_max=%zu row_nnz_mean=%.3f bytes=%zu "
           "local_column_nnz=%zu remote_column_nnz=%zu ghost_count=%zu "
           "incoming_peers=%zu outgoing_peers=%zu halo_schedule=%s "
-          "halo_reference=%s.\n",
+          "columns=%s halo_reference=%s.\n",
+          vector_exchange_mode == SYMMETRY_VECTOR_EXCHANGE_HALO
+              ? "halo"
+              : "allgather",
           plan->local_dim, plan->nnz, min_row_nnz, max_row_nnz,
           plan->local_dim > 0UL ? (double)plan->nnz / (double)plan->local_dim : 0.0,
           plan_bytes, plan->local_column_nnz, plan->remote_column_nnz,
           plan->halo.ghost_count, plan->halo.incoming_peer_count,
           plan->halo.outgoing_peer_count,
           plan->halo.ready == TRUE ? "ready" : "request-layout-only",
+          plan->columns_remapped == TRUE ? "local/ghost-slots" : "global",
           plan->halo.reference_enabled == TRUE ? "on" : "off");
   return 0;
 
@@ -505,7 +700,8 @@ int ApplySymmetryMatvecPlan(const struct BindStruct *X,
   plan = X->Sym->matvec_plan;
   if (plan == NULL || plan->ready != TRUE || plan->dim != X->Sym->dim ||
       plan->local_offset != X->Sym->local_offset ||
-      plan->local_dim != X->Sym->local_dim) {
+      plan->local_dim != X->Sym->local_dim ||
+      plan->columns_remapped == TRUE) {
     fprintf(stdoutMPI, "Error: symmetry matvec plan does not match the active sector.\n");
     return -1;
   }
@@ -523,6 +719,62 @@ int ApplySymmetryMatvecPlan(const struct BindStruct *X,
     tmp_v0[local_row + 1UL] += sum;
     prdct += conj(full_v1[global_alpha]) * sum;
   }
+  *local_prdct = prdct;
+  return 0;
+}
+
+int ApplySymmetryMatvecPlanHalo(const struct BindStruct *X,
+                                double complex *tmp_v0,
+                                const double complex *local_v1,
+                                double complex *local_prdct)
+{
+  unsigned long int local_row;
+  double complex prdct = 0.0;
+  const struct SymmetryMatvecPlan *plan;
+  size_t slot_count;
+  int apply_error = 0;
+  if (X == NULL || X->Sym == NULL || tmp_v0 == NULL || local_v1 == NULL ||
+      local_prdct == NULL) {
+    return -1;
+  }
+  plan = X->Sym->matvec_plan;
+  if (plan == NULL || plan->ready != TRUE ||
+      plan->columns_remapped != TRUE || plan->halo.ready != TRUE ||
+      plan->dim != X->Sym->dim ||
+      plan->local_offset != X->Sym->local_offset ||
+      plan->local_dim != X->Sym->local_dim ||
+      (size_t)plan->local_dim > SIZE_MAX - plan->halo.ghost_count) {
+    fprintf(stdoutMPI,
+            "Error: symmetry halo matvec plan does not match "
+            "the active sector.\n");
+    return -1;
+  }
+  slot_count = (size_t)plan->local_dim + plan->halo.ghost_count;
+
+#pragma omp parallel for default(none) schedule(static) \
+  reduction(+:prdct) reduction(|:apply_error) \
+  shared(plan, tmp_v0, local_v1, slot_count)
+  for (local_row = 0UL; local_row < plan->local_dim; local_row++) {
+    size_t p;
+    double complex sum = 0.0;
+    for (p = plan->row_ptr[local_row];
+         p < plan->row_ptr[local_row + 1UL]; p++) {
+      size_t slot = (size_t)plan->col_index[p];
+      double complex input_value;
+      if (slot >= slot_count) {
+        apply_error = 1;
+        continue;
+      }
+      input_value =
+          slot < (size_t)plan->local_dim
+              ? local_v1[slot + 1U]
+              : plan->halo.ghost_values[slot - (size_t)plan->local_dim];
+      sum += plan->values[p] * input_value;
+    }
+    tmp_v0[local_row + 1UL] += sum;
+    prdct += conj(local_v1[local_row + 1UL]) * sum;
+  }
+  if (apply_error != 0) return -1;
   *local_prdct = prdct;
   return 0;
 }

--- a/src/symmetry_matvec_plan.c
+++ b/src/symmetry_matvec_plan.c
@@ -232,10 +232,16 @@ static int select_matvec_mode(void)
   return BcastMPI_i(0, mode);
 }
 
-static int parse_vector_exchange_mode(void)
+static int parse_vector_exchange_mode(int matvec_mode)
 {
   const char *value = getenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
-  if (value == NULL || strcmp(value, "allgather") == 0) {
+  if (value == NULL) {
+    /* Keep the one-switch legacy rollback usable while plan uses halo. */
+    return matvec_mode == SYMMETRY_MATVEC_MODE_LEGACY
+               ? SYMMETRY_VECTOR_EXCHANGE_ALLGATHER
+               : SYMMETRY_VECTOR_EXCHANGE_HALO;
+  }
+  if (strcmp(value, "allgather") == 0) {
     return SYMMETRY_VECTOR_EXCHANGE_ALLGATHER;
   }
   if (strcmp(value, "halo") == 0) {
@@ -248,10 +254,10 @@ static int parse_vector_exchange_mode(void)
   return -1;
 }
 
-static int select_vector_exchange_mode(void)
+static int select_vector_exchange_mode(int matvec_mode)
 {
   int mode = SYMMETRY_VECTOR_EXCHANGE_ALLGATHER;
-  if (myrank == 0) mode = parse_vector_exchange_mode();
+  if (myrank == 0) mode = parse_vector_exchange_mode(matvec_mode);
   return BcastMPI_i(0, mode);
 }
 
@@ -534,7 +540,7 @@ int BuildSymmetryMatvecPlan(struct BindStruct *X)
 
   mode = select_matvec_mode();
   if (mode < 0) return -1;
-  vector_exchange_mode = select_vector_exchange_mode();
+  vector_exchange_mode = select_vector_exchange_mode(mode);
   if (vector_exchange_mode < 0) return -1;
   halo_reference_mode = select_halo_reference_mode();
   if (halo_reference_mode < 0) return -1;

--- a/src/symmetry_vector_halo.c
+++ b/src/symmetry_vector_halo.c
@@ -1,0 +1,666 @@
+#include <limits.h>
+#include <stdint.h>
+#ifdef MPI
+#include <mpi.h>
+#endif
+#include "DefCommon.h"
+struct BindStruct;
+#include "CalcTime.h"
+#include "symmetry_vector_halo.h"
+
+#ifndef HPHI_SYMMETRY_HALO_BITSET_CAP_BYTES
+#define HPHI_SYMMETRY_HALO_BITSET_CAP_BYTES (64U * 1024U * 1024U)
+#endif
+
+static int checked_size_add(size_t lhs, size_t rhs, size_t *result)
+{
+  if (result == NULL || lhs > SIZE_MAX - rhs) return -1;
+  *result = lhs + rhs;
+  return 0;
+}
+
+static int checked_size_mul(size_t lhs, size_t rhs, size_t *result)
+{
+  if (result == NULL || (lhs != 0U && rhs > SIZE_MAX / lhs)) return -1;
+  *result = lhs * rhs;
+  return 0;
+}
+
+static int halo_mpi_collectives_active(void)
+{
+#ifdef MPI
+  int initialized = 0;
+  int finalized = 0;
+  if (MPI_Initialized(&initialized) != MPI_SUCCESS || initialized == 0) {
+    return FALSE;
+  }
+  if (MPI_Finalized(&finalized) != MPI_SUCCESS || finalized != 0) {
+    return FALSE;
+  }
+  return TRUE;
+#else
+  return FALSE;
+#endif
+}
+
+static int agree_halo_error(int mpi_active, int local_error)
+{
+#ifdef MPI
+  int global_error = local_error;
+  if (mpi_active != FALSE &&
+      MPI_Allreduce(&local_error, &global_error, 1, MPI_INT, MPI_MAX,
+                    MPI_COMM_WORLD) != MPI_SUCCESS) {
+    return -1;
+  }
+  return global_error;
+#else
+  (void)mpi_active;
+  return local_error;
+#endif
+}
+
+static unsigned long long hash_bytes(unsigned long long hash,
+                                     const void *data,
+                                     size_t size)
+{
+  const unsigned char *bytes = (const unsigned char *)data;
+  size_t index;
+  for (index = 0U; index < size; index++) {
+    hash ^= (unsigned long long)bytes[index];
+    hash *= 1099511628211ULL;
+  }
+  return hash;
+}
+
+static unsigned long long halo_schedule_checksum(
+    const struct SymmetryVectorHaloPlan *halo)
+{
+  unsigned long long hash = 14695981039346656037ULL;
+  hash = hash_bytes(hash, &halo->dim, sizeof(halo->dim));
+  hash = hash_bytes(hash, &halo->local_offset, sizeof(halo->local_offset));
+  hash = hash_bytes(hash, &halo->local_dim, sizeof(halo->local_dim));
+  hash = hash_bytes(hash, &halo->nrank, sizeof(halo->nrank));
+  hash = hash_bytes(hash, &halo->rank, sizeof(halo->rank));
+  hash = hash_bytes(hash, &halo->ghost_count, sizeof(halo->ghost_count));
+  hash = hash_bytes(hash, &halo->send_value_count,
+                    sizeof(halo->send_value_count));
+  if (halo->nrank > 0) {
+    size_t count_bytes = (size_t)halo->nrank * sizeof(*halo->recv_counts);
+    hash = hash_bytes(hash, halo->recv_counts, count_bytes);
+    hash = hash_bytes(hash, halo->recv_displs, count_bytes);
+    hash = hash_bytes(hash, halo->send_counts, count_bytes);
+    hash = hash_bytes(hash, halo->send_displs, count_bytes);
+  }
+  if (halo->ghost_count > 0U) {
+    hash = hash_bytes(hash, halo->ghost_global_index,
+                      halo->ghost_count * sizeof(*halo->ghost_global_index));
+  }
+  if (halo->send_value_count > 0U) {
+    hash = hash_bytes(hash, halo->send_local_index,
+                      halo->send_value_count *
+                          sizeof(*halo->send_local_index));
+  }
+  return hash;
+}
+
+int SymmetryVectorOwnerOfGlobalIndex(unsigned long int dim,
+                                     int nrank,
+                                     unsigned long int global_index)
+{
+  unsigned long int base;
+  unsigned long int remainder;
+  unsigned long int zero_index;
+  unsigned long int large_block_end;
+  if (nrank < 1 || global_index == 0UL || global_index > dim) return -1;
+  base = dim / (unsigned long int)nrank;
+  remainder = dim % (unsigned long int)nrank;
+  zero_index = global_index - 1UL;
+  large_block_end =
+      remainder == 0UL ? 0UL : (base + 1UL) * remainder;
+  if (zero_index < large_block_end) {
+    return (int)(zero_index / (base + 1UL));
+  }
+  if (base == 0UL) return -1;
+  return (int)(remainder + (zero_index - large_block_end) / base);
+}
+
+void FreeSymmetryVectorHaloPlan(struct SymmetryVectorHaloPlan *halo)
+{
+  if (halo == NULL) return;
+  free(halo->send_counts);
+  free(halo->send_displs);
+  free(halo->recv_counts);
+  free(halo->recv_displs);
+  free(halo->ghost_global_index);
+  free(halo->send_local_index);
+  free(halo->send_values);
+  free(halo->ghost_values);
+  memset(halo, 0, sizeof(*halo));
+}
+
+int BuildSymmetryVectorHaloPlan(struct SymmetryVectorHaloPlan *halo,
+                                unsigned long int dim,
+                                unsigned long int local_offset,
+                                unsigned long int local_dim,
+                                const unsigned long int *global_columns,
+                                size_t column_count,
+                                int nrank,
+                                int rank,
+                                size_t *local_column_count,
+                                size_t *remote_column_count)
+{
+  unsigned char *remote_bits = NULL;
+  unsigned long long *request_counts = NULL;
+  unsigned long long *serve_counts = NULL;
+  unsigned long int *requested_global_index = NULL;
+#ifdef MPI
+  unsigned long int request_dummy = 0UL;
+#endif
+  unsigned long int first_local;
+  unsigned long int last_local;
+  unsigned long int expected_local_offset;
+  unsigned long int expected_local_dim;
+  unsigned long int block_base;
+  unsigned long int block_remainder;
+  unsigned long int unsigned_rank;
+  unsigned long int window_capacity;
+  unsigned long int window_zero;
+  unsigned long int window_dim;
+  size_t bitset_bytes = 0U;
+  size_t window_bytes = 0U;
+  size_t count64_bytes = 0U;
+  size_t count_int_bytes = 0U;
+  size_t request_bytes = 0U;
+  size_t index_bytes = 0U;
+  size_t schedule_scratch_bytes = 0U;
+  size_t total_count;
+  size_t column;
+  size_t ghost_position = 0U;
+  size_t byte_index;
+  int mpi_active;
+  int local_error = 0;
+  int owner;
+  int peer;
+
+  mpi_active = halo_mpi_collectives_active();
+  if (halo == NULL || local_column_count == NULL ||
+      remote_column_count == NULL || nrank < 1 || rank < 0 || rank >= nrank ||
+      local_offset > dim || local_dim > dim - local_offset ||
+      (column_count > 0U && global_columns == NULL)) {
+    local_error = 1;
+  }
+#ifdef MPI
+  if (mpi_active != FALSE) {
+    int comm_size = 0;
+    if (MPI_Comm_size(MPI_COMM_WORLD, &comm_size) != MPI_SUCCESS ||
+        comm_size != nrank) {
+      local_error = 1;
+    }
+  }
+#endif
+  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+
+  block_base = dim / (unsigned long int)nrank;
+  block_remainder = dim % (unsigned long int)nrank;
+  unsigned_rank = (unsigned long int)rank;
+  expected_local_dim =
+      block_base + (unsigned_rank < block_remainder ? 1UL : 0UL);
+  expected_local_offset =
+      block_base * unsigned_rank +
+      (unsigned_rank < block_remainder ? unsigned_rank : block_remainder);
+  if (local_offset != expected_local_offset ||
+      local_dim != expected_local_dim) {
+    local_error = 1;
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+
+  memset(halo, 0, sizeof(*halo));
+  *local_column_count = 0U;
+  *remote_column_count = 0U;
+  halo->nrank = nrank;
+  halo->rank = rank;
+  halo->dim = dim;
+  halo->local_offset = local_offset;
+  halo->local_dim = local_dim;
+  first_local = local_offset + 1UL;
+  last_local = local_offset + local_dim;
+
+  StartTimer(1130);
+  for (column = 0U; column < column_count; column++) {
+    unsigned long int global_index = global_columns[column];
+    if (global_index == 0UL || global_index > dim) {
+      local_error = 1;
+      break;
+    }
+    if (local_dim > 0UL &&
+        global_index >= first_local && global_index <= last_local) {
+      if (*local_column_count == SIZE_MAX) {
+        local_error = 1;
+        break;
+      }
+      (*local_column_count)++;
+    } else {
+      if (*remote_column_count == SIZE_MAX) {
+        local_error = 1;
+        break;
+      }
+      (*remote_column_count)++;
+    }
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_topology;
+  if (*remote_column_count > 0U) {
+    size_t bitset_cap = (size_t)HPHI_SYMMETRY_HALO_BITSET_CAP_BYTES;
+    if (bitset_cap == 0U) {
+      local_error = 1;
+    } else if (bitset_cap > ULONG_MAX / 8UL) {
+      window_capacity = ULONG_MAX;
+    } else {
+      window_capacity = (unsigned long int)bitset_cap * 8UL;
+    }
+    if (local_error == 0) {
+      window_dim = dim < window_capacity ? dim : window_capacity;
+      bitset_bytes = (size_t)(window_dim / 8UL);
+      if (window_dim % 8UL != 0UL) {
+        bitset_bytes++;
+      }
+    }
+    if (local_error == 0) {
+      remote_bits = (unsigned char *)calloc(bitset_bytes,
+                                             sizeof(*remote_bits));
+      if (remote_bits == NULL) local_error = 1;
+    }
+  }
+  if ((size_t)nrank > SIZE_MAX / sizeof(*request_counts)) {
+    local_error = 1;
+  } else {
+    request_counts = (unsigned long long *)calloc(
+        (size_t)nrank, sizeof(*request_counts));
+    serve_counts = (unsigned long long *)calloc(
+        (size_t)nrank, sizeof(*serve_counts));
+    halo->recv_counts = (int *)calloc((size_t)nrank,
+                                      sizeof(*halo->recv_counts));
+    halo->recv_displs = (int *)calloc((size_t)nrank,
+                                      sizeof(*halo->recv_displs));
+    halo->send_counts = (int *)calloc((size_t)nrank,
+                                      sizeof(*halo->send_counts));
+    halo->send_displs = (int *)calloc((size_t)nrank,
+                                      sizeof(*halo->send_displs));
+    if (request_counts == NULL || serve_counts == NULL ||
+        halo->recv_counts == NULL || halo->recv_displs == NULL ||
+        halo->send_counts == NULL || halo->send_displs == NULL) {
+      local_error = 1;
+    }
+  }
+  if (checked_size_mul(2U * sizeof(*request_counts), (size_t)nrank,
+                       &count64_bytes) != 0 ||
+      checked_size_mul(4U * sizeof(*halo->recv_counts), (size_t)nrank,
+                       &count_int_bytes) != 0) {
+    local_error = 1;
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_topology;
+
+  window_zero = 0UL;
+  while (window_zero < dim && *remote_column_count > 0U) {
+    unsigned long int remaining = dim - window_zero;
+    window_dim =
+        remaining < window_capacity ? remaining : window_capacity;
+    window_bytes = (size_t)(window_dim / 8UL);
+    if (window_dim % 8UL != 0UL) window_bytes++;
+    memset(remote_bits, 0, bitset_bytes);
+    for (column = 0U; column < column_count; column++) {
+      unsigned long int global_index = global_columns[column];
+      if (local_dim == 0UL ||
+          global_index < first_local || global_index > last_local) {
+        unsigned long int zero_index = global_index - 1UL;
+        if (zero_index >= window_zero &&
+            zero_index - window_zero < window_dim) {
+          unsigned long int relative_index = zero_index - window_zero;
+          remote_bits[(size_t)(relative_index / 8UL)] |=
+              (unsigned char)(1U <<
+                              (unsigned int)(relative_index % 8UL));
+        }
+      }
+    }
+    for (byte_index = 0U; byte_index < window_bytes; byte_index++) {
+      unsigned char bits = remote_bits[byte_index];
+      unsigned int bit;
+      for (bit = 0U; bits != 0U && bit < 8U; bit++) {
+        if ((bits & (unsigned char)(1U << bit)) == 0U) continue;
+        {
+          unsigned long int global_index =
+              window_zero + (unsigned long int)byte_index * 8UL +
+              (unsigned long int)bit + 1UL;
+          owner = SymmetryVectorOwnerOfGlobalIndex(
+              dim, nrank, global_index);
+          if (owner < 0 || owner == rank ||
+              request_counts[owner] == ULLONG_MAX ||
+              halo->ghost_count == SIZE_MAX) {
+            local_error = 1;
+            break;
+          }
+          request_counts[owner]++;
+          halo->ghost_count++;
+        }
+      }
+      if (local_error != 0) break;
+    }
+    if (local_error != 0) break;
+    window_zero += window_dim;
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_topology;
+
+  if (halo->ghost_count > 0U) {
+    if (halo->ghost_count >
+        SIZE_MAX / sizeof(*halo->ghost_global_index)) {
+      local_error = 1;
+    } else {
+      halo->ghost_global_index = (unsigned long int *)malloc(
+          halo->ghost_count * sizeof(*halo->ghost_global_index));
+      if (halo->ghost_global_index == NULL) local_error = 1;
+    }
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_topology;
+
+  window_zero = 0UL;
+  while (window_zero < dim && *remote_column_count > 0U) {
+    unsigned long int remaining = dim - window_zero;
+    window_dim =
+        remaining < window_capacity ? remaining : window_capacity;
+    window_bytes = (size_t)(window_dim / 8UL);
+    if (window_dim % 8UL != 0UL) window_bytes++;
+    memset(remote_bits, 0, bitset_bytes);
+    for (column = 0U; column < column_count; column++) {
+      unsigned long int global_index = global_columns[column];
+      if (local_dim == 0UL ||
+          global_index < first_local || global_index > last_local) {
+        unsigned long int zero_index = global_index - 1UL;
+        if (zero_index >= window_zero &&
+            zero_index - window_zero < window_dim) {
+          unsigned long int relative_index = zero_index - window_zero;
+          remote_bits[(size_t)(relative_index / 8UL)] |=
+              (unsigned char)(1U <<
+                              (unsigned int)(relative_index % 8UL));
+        }
+      }
+    }
+    for (byte_index = 0U; byte_index < window_bytes; byte_index++) {
+      unsigned char bits = remote_bits[byte_index];
+      unsigned int bit;
+      for (bit = 0U; bits != 0U && bit < 8U; bit++) {
+        if ((bits & (unsigned char)(1U << bit)) != 0U) {
+          halo->ghost_global_index[ghost_position++] =
+              window_zero + (unsigned long int)byte_index * 8UL +
+              (unsigned long int)bit + 1UL;
+        }
+      }
+    }
+    window_zero += window_dim;
+  }
+  if (ghost_position != halo->ghost_count) local_error = 1;
+
+  total_count = 0U;
+  for (peer = 0; peer < nrank; peer++) {
+    if (request_counts[peer] > (unsigned long long)INT_MAX ||
+        total_count > (size_t)INT_MAX -
+                          (size_t)request_counts[peer]) {
+      local_error = 1;
+      break;
+    }
+    halo->recv_counts[peer] = (int)request_counts[peer];
+    halo->recv_displs[peer] = (int)total_count;
+    total_count += (size_t)request_counts[peer];
+    if (request_counts[peer] > 0ULL) {
+      halo->incoming_peer_count++;
+      if ((size_t)request_counts[peer] > halo->max_recv_from_peer) {
+        halo->max_recv_from_peer = (size_t)request_counts[peer];
+      }
+    }
+  }
+  if (total_count != halo->ghost_count) local_error = 1;
+  if (checked_size_add(bitset_bytes, count64_bytes,
+                       &halo->topology_scratch_bytes) != 0) {
+    local_error = 1;
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_topology;
+  halo->request_layout_ready = TRUE;
+  free(remote_bits);
+  remote_bits = NULL;
+  StopTimer(1130);
+
+  StartTimer(1131);
+  if (nrank > 1 && mpi_active == FALSE) {
+    halo->schedule_checksum = halo_schedule_checksum(halo);
+    free(request_counts);
+    free(serve_counts);
+    StopTimer(1131);
+    return 0;
+  }
+#ifdef MPI
+  if (mpi_active != FALSE && nrank > 1) {
+    local_error =
+        MPI_Alltoall(request_counts, 1, MPI_UNSIGNED_LONG_LONG,
+                     serve_counts, 1, MPI_UNSIGNED_LONG_LONG,
+                     MPI_COMM_WORLD) == MPI_SUCCESS ? 0 : 1;
+  }
+#endif
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_schedule;
+
+  total_count = 0U;
+  for (peer = 0; peer < nrank; peer++) {
+    if (serve_counts[peer] > (unsigned long long)INT_MAX ||
+        total_count > (size_t)INT_MAX - (size_t)serve_counts[peer]) {
+      local_error = 1;
+      break;
+    }
+    halo->send_counts[peer] = (int)serve_counts[peer];
+    halo->send_displs[peer] = (int)total_count;
+    total_count += (size_t)serve_counts[peer];
+    if (serve_counts[peer] > 0ULL) {
+      halo->outgoing_peer_count++;
+      if ((size_t)serve_counts[peer] > halo->max_send_to_peer) {
+        halo->max_send_to_peer = (size_t)serve_counts[peer];
+      }
+    }
+  }
+  halo->send_value_count = total_count;
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_schedule;
+
+  if (halo->send_value_count > 0U) {
+    if (halo->send_value_count >
+        SIZE_MAX / sizeof(*requested_global_index)) {
+      local_error = 1;
+    } else {
+      requested_global_index = (unsigned long int *)malloc(
+          halo->send_value_count * sizeof(*requested_global_index));
+      halo->send_local_index = (unsigned long int *)malloc(
+          halo->send_value_count * sizeof(*halo->send_local_index));
+      if (requested_global_index == NULL ||
+          halo->send_local_index == NULL) {
+        local_error = 1;
+      }
+    }
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_schedule;
+
+#ifdef MPI
+  if (mpi_active != FALSE && nrank > 1) {
+    unsigned long int *request_send =
+        halo->ghost_count > 0U ? halo->ghost_global_index : &request_dummy;
+    unsigned long int *request_recv =
+        halo->send_value_count > 0U ? requested_global_index : &request_dummy;
+    local_error =
+        MPI_Alltoallv(request_send, halo->recv_counts, halo->recv_displs,
+                      MPI_UNSIGNED_LONG,
+                      request_recv, halo->send_counts, halo->send_displs,
+                      MPI_UNSIGNED_LONG, MPI_COMM_WORLD) == MPI_SUCCESS
+            ? 0
+            : 1;
+  }
+#endif
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_schedule;
+
+  for (column = 0U; column < halo->send_value_count; column++) {
+    unsigned long int global_index = requested_global_index[column];
+    owner = SymmetryVectorOwnerOfGlobalIndex(dim, nrank, global_index);
+    if (owner != rank || global_index <= local_offset ||
+        global_index > local_offset + local_dim) {
+      local_error = 1;
+      break;
+    }
+    halo->send_local_index[column] = global_index - local_offset;
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_schedule;
+
+#ifdef MPI
+  if (mpi_active != FALSE && nrank > 1) {
+    unsigned long long local_ghost_count =
+        (unsigned long long)halo->ghost_count;
+    unsigned long long local_send_count =
+        (unsigned long long)halo->send_value_count;
+    unsigned long long ghost_sum = 0ULL;
+    unsigned long long send_sum = 0ULL;
+    if (MPI_Allreduce(&local_ghost_count, &ghost_sum, 1,
+                      MPI_UNSIGNED_LONG_LONG, MPI_SUM,
+                      MPI_COMM_WORLD) != MPI_SUCCESS ||
+        MPI_Allreduce(&local_send_count, &send_sum, 1,
+                      MPI_UNSIGNED_LONG_LONG, MPI_SUM,
+                      MPI_COMM_WORLD) != MPI_SUCCESS ||
+        ghost_sum != send_sum) {
+      local_error = 1;
+    }
+  }
+#endif
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_schedule;
+
+  if (halo->send_value_count > 0U) {
+    halo->send_values = (double complex *)malloc(
+        halo->send_value_count * sizeof(*halo->send_values));
+    if (halo->send_values == NULL) local_error = 1;
+  }
+  if (halo->ghost_count > 0U) {
+    halo->ghost_values = (double complex *)malloc(
+        halo->ghost_count * sizeof(*halo->ghost_values));
+    if (halo->ghost_values == NULL) local_error = 1;
+  }
+  if (checked_size_add(halo->ghost_count, halo->send_value_count,
+                       &total_count) != 0 ||
+      checked_size_mul(total_count, sizeof(unsigned long int),
+                       &index_bytes) != 0 ||
+      checked_size_add(count_int_bytes, index_bytes,
+                       &halo->schedule_bytes) != 0 ||
+      checked_size_mul(total_count, sizeof(double complex),
+                       &halo->runtime_buffer_bytes) != 0 ||
+      checked_size_mul(halo->send_value_count,
+                       sizeof(*requested_global_index),
+                       &request_bytes) != 0 ||
+      checked_size_add(count64_bytes, request_bytes,
+                       &schedule_scratch_bytes) != 0) {
+    local_error = 1;
+  }
+  if (schedule_scratch_bytes > halo->topology_scratch_bytes) {
+    halo->topology_scratch_bytes = schedule_scratch_bytes;
+  }
+  if (agree_halo_error(mpi_active, local_error) != 0) goto fail_schedule;
+  halo->ready = TRUE;
+  halo->schedule_checksum = halo_schedule_checksum(halo);
+  free(requested_global_index);
+  free(request_counts);
+  free(serve_counts);
+  StopTimer(1131);
+  return 0;
+
+fail_schedule:
+  free(requested_global_index);
+  free(request_counts);
+  free(serve_counts);
+  StopTimer(1131);
+  FreeSymmetryVectorHaloPlan(halo);
+  return -1;
+
+fail_topology:
+  free(remote_bits);
+  free(request_counts);
+  free(serve_counts);
+  StopTimer(1130);
+  FreeSymmetryVectorHaloPlan(halo);
+  return -1;
+}
+
+int ExchangeSymmetryVectorHaloReference(
+    struct SymmetryVectorHaloPlan *halo,
+    const double complex *local_vector,
+    const double complex *full_vector)
+{
+  double complex send_dummy = 0.0;
+  double complex recv_dummy = 0.0;
+  size_t index;
+  int mpi_active;
+  int local_error = 0;
+
+  mpi_active = halo_mpi_collectives_active();
+  if (halo == NULL || halo->ready != TRUE || local_vector == NULL ||
+      full_vector == NULL ||
+      (halo != NULL && halo->nrank > 1 && mpi_active == FALSE)) {
+    local_error = 1;
+  }
+#ifdef MPI
+  if (mpi_active != FALSE && halo != NULL) {
+    int comm_rank = -1;
+    int comm_size = 0;
+    if (MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank) != MPI_SUCCESS ||
+        MPI_Comm_size(MPI_COMM_WORLD, &comm_size) != MPI_SUCCESS ||
+        comm_rank != halo->rank || comm_size != halo->nrank) {
+      local_error = 1;
+    }
+  }
+#endif
+  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+
+  StartTimer(1510);
+  for (index = 0U; index < halo->send_value_count; index++) {
+    unsigned long int local_index = halo->send_local_index[index];
+    if (local_index == 0UL || local_index > halo->local_dim) {
+      local_error = 1;
+      break;
+    }
+    halo->send_values[index] = local_vector[local_index];
+  }
+  StopTimer(1510);
+  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+
+  StartTimer(1511);
+#ifdef MPI
+  if (mpi_active != FALSE && halo->nrank > 1) {
+    double complex *send_buffer =
+        halo->send_value_count > 0U ? halo->send_values : &send_dummy;
+    double complex *recv_buffer =
+        halo->ghost_count > 0U ? halo->ghost_values : &recv_dummy;
+    local_error =
+        MPI_Alltoallv(send_buffer, halo->send_counts, halo->send_displs,
+                      MPI_DOUBLE_COMPLEX,
+                      recv_buffer, halo->recv_counts, halo->recv_displs,
+                      MPI_DOUBLE_COMPLEX, MPI_COMM_WORLD) == MPI_SUCCESS
+            ? 0
+            : 1;
+  }
+#else
+  (void)send_dummy;
+  (void)recv_dummy;
+#endif
+  StopTimer(1511);
+  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+
+  StartTimer(1512);
+  for (index = 0U; index < halo->ghost_count; index++) {
+    unsigned long int global_index = halo->ghost_global_index[index];
+    if (memcmp(&halo->ghost_values[index], &full_vector[global_index],
+               sizeof(halo->ghost_values[index])) != 0) {
+      local_error = 1;
+      break;
+    }
+  }
+  StopTimer(1512);
+  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+  halo->reference_exchange_calls++;
+  return 0;
+}

--- a/src/symmetry_vector_halo.c
+++ b/src/symmetry_vector_halo.c
@@ -586,10 +586,8 @@ fail_topology:
   return -1;
 }
 
-int ExchangeSymmetryVectorHaloReference(
-    struct SymmetryVectorHaloPlan *halo,
-    const double complex *local_vector,
-    const double complex *full_vector)
+int ExchangeSymmetryVectorHalo(struct SymmetryVectorHaloPlan *halo,
+                               const double complex *local_vector)
 {
   double complex send_dummy = 0.0;
   double complex recv_dummy = 0.0;
@@ -599,7 +597,6 @@ int ExchangeSymmetryVectorHaloReference(
 
   mpi_active = halo_mpi_collectives_active();
   if (halo == NULL || halo->ready != TRUE || local_vector == NULL ||
-      full_vector == NULL ||
       (halo != NULL && halo->nrank > 1 && mpi_active == FALSE)) {
     local_error = 1;
   }
@@ -649,6 +646,23 @@ int ExchangeSymmetryVectorHaloReference(
 #endif
   StopTimer(1511);
   if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+  halo->exchange_calls++;
+  return 0;
+}
+
+int ExchangeSymmetryVectorHaloReference(
+    struct SymmetryVectorHaloPlan *halo,
+    const double complex *local_vector,
+    const double complex *full_vector)
+{
+  size_t index;
+  int mpi_active;
+  int local_error = 0;
+
+  mpi_active = halo_mpi_collectives_active();
+  if (halo == NULL || full_vector == NULL) local_error = 1;
+  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
+  if (ExchangeSymmetryVectorHalo(halo, local_vector) != 0) return -1;
 
   StartTimer(1512);
   for (index = 0U; index < halo->ghost_count; index++) {

--- a/src/symmetry_vector_halo.c
+++ b/src/symmetry_vector_halo.c
@@ -593,37 +593,26 @@ int ExchangeSymmetryVectorHalo(struct SymmetryVectorHaloPlan *halo,
   double complex recv_dummy = 0.0;
   size_t index;
   int mpi_active;
-  int local_error = 0;
 
   mpi_active = halo_mpi_collectives_active();
   if (halo == NULL || halo->ready != TRUE || local_vector == NULL ||
       (halo != NULL && halo->nrank > 1 && mpi_active == FALSE)) {
-    local_error = 1;
+    return -1;
   }
-#ifdef MPI
-  if (mpi_active != FALSE && halo != NULL) {
-    int comm_rank = -1;
-    int comm_size = 0;
-    if (MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank) != MPI_SUCCESS ||
-        MPI_Comm_size(MPI_COMM_WORLD, &comm_size) != MPI_SUCCESS ||
-        comm_rank != halo->rank || comm_size != halo->nrank) {
-      local_error = 1;
-    }
-  }
-#endif
-  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
 
+  /*
+   * BuildSymmetryVectorHaloPlan() collectively validates every
+   * send_local_index and all count/displacement arrays before setting ready.
+   * The runtime schedule is immutable, so repeating those checks through
+   * scalar error-agreement Allreduces here would add three collectives to
+   * every matvec.
+   */
   StartTimer(1510);
   for (index = 0U; index < halo->send_value_count; index++) {
     unsigned long int local_index = halo->send_local_index[index];
-    if (local_index == 0UL || local_index > halo->local_dim) {
-      local_error = 1;
-      break;
-    }
     halo->send_values[index] = local_vector[local_index];
   }
   StopTimer(1510);
-  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
 
   StartTimer(1511);
 #ifdef MPI
@@ -632,20 +621,19 @@ int ExchangeSymmetryVectorHalo(struct SymmetryVectorHaloPlan *halo,
         halo->send_value_count > 0U ? halo->send_values : &send_dummy;
     double complex *recv_buffer =
         halo->ghost_count > 0U ? halo->ghost_values : &recv_dummy;
-    local_error =
-        MPI_Alltoallv(send_buffer, halo->send_counts, halo->send_displs,
+    if (MPI_Alltoallv(send_buffer, halo->send_counts, halo->send_displs,
                       MPI_DOUBLE_COMPLEX,
                       recv_buffer, halo->recv_counts, halo->recv_displs,
-                      MPI_DOUBLE_COMPLEX, MPI_COMM_WORLD) == MPI_SUCCESS
-            ? 0
-            : 1;
+                      MPI_DOUBLE_COMPLEX, MPI_COMM_WORLD) != MPI_SUCCESS) {
+      StopTimer(1511);
+      return -1;
+    }
   }
 #else
   (void)send_dummy;
   (void)recv_dummy;
 #endif
   StopTimer(1511);
-  if (agree_halo_error(mpi_active, local_error) != 0) return -1;
   halo->exchange_calls++;
   return 0;
 }

--- a/src/time.c
+++ b/src/time.c
@@ -73,7 +73,7 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
 {
   static const int timer_ids[] = {
     1100, 1110, 1115, 1111, 1112, 1113, 1114,
-    1101, 1120, 1121, 1122, 1130, 1131, 4113,
+    1101, 1120, 1121, 1122, 1130, 1131, 1132, 4113,
     1, 1501, 1502, 1503, 1510, 1511, 1512, 1513
   };
   static const char *work_keys[] = {
@@ -111,7 +111,10 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
     "prdct_allreduce_calls",
     "halo_schedule_ready",
     "halo_reference_enabled",
-    "halo_reference_exchange_calls"
+    "halo_reference_exchange_calls",
+    "columns_remapped",
+    "full_input_vector_allocated",
+    "halo_exchange_calls"
   };
   static const char *metric_keys[] = {
     "plan_remote_column_nnz_ratio",
@@ -126,7 +129,9 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
     "matvec_other_seconds_per_call",
     "halo_reference_pack_seconds_per_call",
     "halo_reference_exchange_seconds_per_call",
-    "halo_reference_validation_seconds_per_call"
+    "halo_reference_validation_seconds_per_call",
+    "halo_pack_seconds_per_call",
+    "halo_exchange_seconds_per_call"
   };
   const size_t timer_count = sizeof(timer_ids) / sizeof(timer_ids[0]);
   const size_t work_count = sizeof(work_keys) / sizeof(work_keys[0]);
@@ -228,6 +233,11 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
       plan != NULL && plan->halo.reference_enabled == TRUE ? 1ULL : 0ULL;
   work_local[34] =
       plan != NULL ? plan->halo.reference_exchange_calls : 0ULL;
+  work_local[35] =
+      plan != NULL && plan->columns_remapped == TRUE ? 1ULL : 0ULL;
+  work_local[36] = X->Sym->mpi_full_v1 != NULL ? 1ULL : 0ULL;
+  work_local[37] =
+      plan != NULL ? plan->halo.exchange_calls : 0ULL;
   row_mean_local = plan != NULL && plan->local_dim > 0UL
                        ? (double)plan->nnz / (double)plan->local_dim
                        : 0.0;
@@ -287,6 +297,14 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
           ? Timer[1512] /
                 (double)plan->halo.reference_exchange_calls
           : 0.0;
+  metric_local[13] =
+      plan != NULL && plan->halo.exchange_calls > 0ULL
+          ? Timer[1510] / (double)plan->halo.exchange_calls
+          : 0.0;
+  metric_local[14] =
+      plan != NULL && plan->halo.exchange_calls > 0ULL
+          ? Timer[1511] / (double)plan->halo.exchange_calls
+          : 0.0;
   basis_digest_local = SymmetryBasisDigest(X->Sym);
   halo_checksum_local =
       plan != NULL ? plan->halo.schedule_checksum : 0ULL;
@@ -327,12 +345,15 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
   sprintf(fileName, "CalcTimerRankStats.dat");
   if (childfopenMPI(fileName, "w", &fp) != 0) return;
   fprintf(fp,
-          "format=HPhiCalcTimerRankStats version=3 ranks=%d "
-          "basis_layout=replicated matvec_mode=%s vector_exchange=allgather\n",
+          "format=HPhiCalcTimerRankStats version=4 ranks=%d "
+          "basis_layout=replicated matvec_mode=%s vector_exchange=%s\n",
           nproc,
           X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN
               ? "plan"
-              : "legacy");
+              : "legacy",
+          X->Sym->vector_exchange_mode == SYMMETRY_VECTOR_EXCHANGE_HALO
+              ? "halo"
+              : "allgather");
   for (i = 0; i < timer_count; i++) {
     fprintf(fp, "timer id=%d ranks=%d min=%.17g max=%.17g mean=%.17g\n",
             timer_ids[i], nproc, timer_min[i], timer_max[i],
@@ -448,6 +469,7 @@ void OutputTimer(struct BindStruct *X) {
   StampTime(fp, "    symmetry plan fill", 1122);
   StampTime(fp, "    symmetry plan topology extraction", 1130);
   StampTime(fp, "    symmetry halo request schedule", 1131);
+  StampTime(fp, "    symmetry CSR column remap", 1132);
   StampTime(fp, "  diagonalcalc", 2000);
   if(X->Def.iFlgCalcSpec == CALCSPEC_NOT){
     if(X->Def.iCalcType==TPQCalc || X->Def.iCalcType==cTPQ) {
@@ -526,8 +548,8 @@ void OutputTimer(struct BindStruct *X) {
   StampTime(fp,"  symmetry input Allgatherv",1501);
   StampTime(fp,"  symmetry legacy beta scan",1502);
   StampTime(fp,"  symmetry local-row plan apply",1503);
-  StampTime(fp,"  symmetry halo reference pack",1510);
-  StampTime(fp,"  symmetry halo reference exchange",1511);
+  StampTime(fp,"  symmetry halo pack",1510);
+  StampTime(fp,"  symmetry halo exchange",1511);
   StampTime(fp,"  symmetry halo reference validation",1512);
   StampTime(fp,"  symmetry prdct scalar Allreduce",1513);
   StampTime(fp,"  diagonal", 100);

--- a/src/time.c
+++ b/src/time.c
@@ -73,7 +73,8 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
 {
   static const int timer_ids[] = {
     1100, 1110, 1115, 1111, 1112, 1113, 1114,
-    1101, 1120, 1121, 1122, 4113
+    1101, 1120, 1121, 1122, 1130, 4113,
+    1, 1501, 1502, 1503, 1513
   };
   static const char *work_keys[] = {
     "basis_raw_states",
@@ -90,10 +91,40 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
     "basis_gather_bytes",
     "plan_local_rows",
     "plan_local_nnz",
-    "plan_row_nnz_max"
+    "plan_row_nnz_max",
+    "plan_local_column_nnz",
+    "plan_remote_column_nnz",
+    "halo_ghost_count",
+    "halo_send_value_count",
+    "halo_incoming_peer_count",
+    "halo_outgoing_peer_count",
+    "halo_max_recv_from_peer",
+    "halo_max_send_to_peer",
+    "halo_schedule_bytes_estimate",
+    "halo_runtime_buffer_bytes_estimate",
+    "topology_scratch_bytes",
+    "column_slot_width",
+    "input_allgather_nonlocal_values_per_call",
+    "input_allgather_payload_bytes_per_call",
+    "symmetry_matvec_calls",
+    "input_allgather_calls",
+    "prdct_allreduce_calls"
+  };
+  static const char *metric_keys[] = {
+    "plan_remote_column_nnz_ratio",
+    "halo_ghost_global_ratio",
+    "halo_ghost_nonlocal_ratio",
+    "symmetry_matvec_seconds_per_call",
+    "input_allgather_seconds_per_call",
+    "input_allgather_effective_bandwidth_Bps",
+    "plan_apply_seconds_per_call",
+    "prdct_allreduce_seconds_per_call",
+    "matvec_other_seconds",
+    "matvec_other_seconds_per_call"
   };
   const size_t timer_count = sizeof(timer_ids) / sizeof(timer_ids[0]);
   const size_t work_count = sizeof(work_keys) / sizeof(work_keys[0]);
+  const size_t metric_count = sizeof(metric_keys) / sizeof(metric_keys[0]);
   const struct SymmetryMatvecPlan *plan;
   double timer_local[sizeof(timer_ids) / sizeof(timer_ids[0])];
   double timer_min[sizeof(timer_ids) / sizeof(timer_ids[0])];
@@ -103,6 +134,10 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
   unsigned long long work_min[sizeof(work_keys) / sizeof(work_keys[0])];
   unsigned long long work_max[sizeof(work_keys) / sizeof(work_keys[0])];
   unsigned long long work_sum[sizeof(work_keys) / sizeof(work_keys[0])];
+  double metric_local[sizeof(metric_keys) / sizeof(metric_keys[0])];
+  double metric_min[sizeof(metric_keys) / sizeof(metric_keys[0])];
+  double metric_max[sizeof(metric_keys) / sizeof(metric_keys[0])];
+  double metric_sum[sizeof(metric_keys) / sizeof(metric_keys[0])];
   double row_mean_local;
   double row_mean_min;
   double row_mean_max;
@@ -135,9 +170,90 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
   work_local[12] = plan != NULL ? (unsigned long long)plan->local_dim : 0ULL;
   work_local[13] = plan != NULL ? (unsigned long long)plan->nnz : 0ULL;
   work_local[14] = plan != NULL ? (unsigned long long)plan->row_nnz_max : 0ULL;
+  work_local[15] =
+      plan != NULL ? (unsigned long long)plan->local_column_nnz : 0ULL;
+  work_local[16] =
+      plan != NULL ? (unsigned long long)plan->remote_column_nnz : 0ULL;
+  work_local[17] =
+      plan != NULL ? (unsigned long long)plan->ghost_count : 0ULL;
+  work_local[18] =
+      plan != NULL ? (unsigned long long)plan->send_value_count : 0ULL;
+  work_local[19] =
+      plan != NULL ? (unsigned long long)plan->incoming_peer_count : 0ULL;
+  work_local[20] =
+      plan != NULL ? (unsigned long long)plan->outgoing_peer_count : 0ULL;
+  work_local[21] =
+      plan != NULL ? (unsigned long long)plan->max_recv_from_peer : 0ULL;
+  work_local[22] =
+      plan != NULL ? (unsigned long long)plan->max_send_to_peer : 0ULL;
+  work_local[23] = plan != NULL
+                       ? (unsigned long long)plan->halo_schedule_bytes_estimate
+                       : 0ULL;
+  work_local[24] =
+      plan != NULL
+          ? (unsigned long long)plan->halo_runtime_buffer_bytes_estimate
+          : 0ULL;
+  work_local[25] =
+      plan != NULL ? (unsigned long long)plan->topology_scratch_bytes : 0ULL;
+  work_local[26] =
+      plan != NULL ? (unsigned long long)plan->column_slot_width : 0ULL;
+  work_local[27] =
+      plan != NULL
+          ? (unsigned long long)plan->allgather_nonlocal_values_per_call
+          : 0ULL;
+  work_local[28] =
+      plan != NULL
+          ? (unsigned long long)plan->allgather_payload_bytes_per_call
+          : 0ULL;
+  work_local[29] =
+      plan != NULL ? plan->matvec_calls : 0ULL;
+  work_local[30] =
+      plan != NULL ? plan->input_allgather_calls : 0ULL;
+  work_local[31] =
+      plan != NULL ? plan->prdct_allreduce_calls : 0ULL;
   row_mean_local = plan != NULL && plan->local_dim > 0UL
                        ? (double)plan->nnz / (double)plan->local_dim
                        : 0.0;
+  metric_local[0] = plan != NULL && plan->nnz > 0U
+                        ? (double)plan->remote_column_nnz / (double)plan->nnz
+                        : 0.0;
+  metric_local[1] = plan != NULL && plan->dim > 0UL
+                        ? (double)plan->ghost_count / (double)plan->dim
+                        : 0.0;
+  metric_local[2] =
+      plan != NULL && plan->allgather_nonlocal_values_per_call > 0U
+          ? (double)plan->ghost_count /
+                (double)plan->allgather_nonlocal_values_per_call
+          : 0.0;
+  metric_local[3] =
+      plan != NULL && plan->matvec_calls > 0ULL
+          ? Timer[1] / (double)plan->matvec_calls
+          : 0.0;
+  metric_local[4] =
+      plan != NULL && plan->input_allgather_calls > 0ULL
+          ? Timer[1501] / (double)plan->input_allgather_calls
+          : 0.0;
+  metric_local[5] =
+      plan != NULL && plan->input_allgather_calls > 0ULL &&
+              Timer[1501] > 0.0
+          ? ((double)plan->allgather_payload_bytes_per_call *
+             (double)plan->input_allgather_calls) /
+                Timer[1501]
+          : 0.0;
+  metric_local[6] =
+      plan != NULL && plan->matvec_calls > 0ULL
+          ? Timer[1503] / (double)plan->matvec_calls
+          : 0.0;
+  metric_local[7] =
+      plan != NULL && plan->prdct_allreduce_calls > 0ULL
+          ? Timer[1513] / (double)plan->prdct_allreduce_calls
+          : 0.0;
+  metric_local[8] =
+      Timer[1] - Timer[1501] - Timer[1502] - Timer[1503] - Timer[1513];
+  metric_local[9] =
+      plan != NULL && plan->matvec_calls > 0ULL
+          ? metric_local[8] / (double)plan->matvec_calls
+          : 0.0;
   basis_digest_local = SymmetryBasisDigest(X->Sym);
 
   MPI_Allreduce(timer_local, timer_min, (int)timer_count, MPI_DOUBLE,
@@ -152,6 +268,12 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
                 MPI_MAX, MPI_COMM_WORLD);
   MPI_Allreduce(work_local, work_sum, (int)work_count, MPI_UNSIGNED_LONG_LONG,
                 MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(metric_local, metric_min, (int)metric_count, MPI_DOUBLE,
+                MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(metric_local, metric_max, (int)metric_count, MPI_DOUBLE,
+                MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(metric_local, metric_sum, (int)metric_count, MPI_DOUBLE,
+                MPI_SUM, MPI_COMM_WORLD);
   MPI_Allreduce(&row_mean_local, &row_mean_min, 1, MPI_DOUBLE,
                 MPI_MIN, MPI_COMM_WORLD);
   MPI_Allreduce(&row_mean_local, &row_mean_max, 1, MPI_DOUBLE,
@@ -165,7 +287,13 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
 
   sprintf(fileName, "CalcTimerRankStats.dat");
   if (childfopenMPI(fileName, "w", &fp) != 0) return;
-  fprintf(fp, "format=HPhiCalcTimerRankStats version=1 ranks=%d\n", nproc);
+  fprintf(fp,
+          "format=HPhiCalcTimerRankStats version=2 ranks=%d "
+          "basis_layout=replicated matvec_mode=%s vector_exchange=allgather\n",
+          nproc,
+          X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN
+              ? "plan"
+              : "legacy");
   for (i = 0; i < timer_count; i++) {
     fprintf(fp, "timer id=%d ranks=%d min=%.17g max=%.17g mean=%.17g\n",
             timer_ids[i], nproc, timer_min[i], timer_max[i],
@@ -175,6 +303,11 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
     fprintf(fp, "work key=%s ranks=%d min=%llu max=%llu mean=%.17g\n",
             work_keys[i], nproc, work_min[i], work_max[i],
             (double)work_sum[i] / (double)nproc);
+  }
+  for (i = 0; i < metric_count; i++) {
+    fprintf(fp, "metric key=%s ranks=%d min=%.17g max=%.17g mean=%.17g\n",
+            metric_keys[i], nproc, metric_min[i], metric_max[i],
+            metric_sum[i] / (double)nproc);
   }
   fprintf(fp,
           "work key=plan_row_nnz_mean ranks=%d min=%.17g max=%.17g mean=%.17g\n",
@@ -270,6 +403,7 @@ void OutputTimer(struct BindStruct *X) {
   StampTime(fp, "    symmetry plan count/prefix", 1120);
   StampTime(fp, "    symmetry plan storage allocation", 1121);
   StampTime(fp, "    symmetry plan fill", 1122);
+  StampTime(fp, "    symmetry plan topology extraction", 1130);
   StampTime(fp, "  diagonalcalc", 2000);
   if(X->Def.iFlgCalcSpec == CALCSPEC_NOT){
     if(X->Def.iCalcType==TPQCalc || X->Def.iCalcType==cTPQ) {
@@ -348,6 +482,7 @@ void OutputTimer(struct BindStruct *X) {
   StampTime(fp,"  symmetry input Allgatherv",1501);
   StampTime(fp,"  symmetry legacy beta scan",1502);
   StampTime(fp,"  symmetry local-row plan apply",1503);
+  StampTime(fp,"  symmetry prdct scalar Allreduce",1513);
   StampTime(fp,"  diagonal", 100);
 
   switch(X->Def.iCalcModel){

--- a/src/time.c
+++ b/src/time.c
@@ -73,8 +73,8 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
 {
   static const int timer_ids[] = {
     1100, 1110, 1115, 1111, 1112, 1113, 1114,
-    1101, 1120, 1121, 1122, 1130, 4113,
-    1, 1501, 1502, 1503, 1513
+    1101, 1120, 1121, 1122, 1130, 1131, 4113,
+    1, 1501, 1502, 1503, 1510, 1511, 1512, 1513
   };
   static const char *work_keys[] = {
     "basis_raw_states",
@@ -100,15 +100,18 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
     "halo_outgoing_peer_count",
     "halo_max_recv_from_peer",
     "halo_max_send_to_peer",
-    "halo_schedule_bytes_estimate",
-    "halo_runtime_buffer_bytes_estimate",
+    "halo_schedule_bytes",
+    "halo_runtime_buffer_bytes",
     "topology_scratch_bytes",
     "column_slot_width",
     "input_allgather_nonlocal_values_per_call",
     "input_allgather_payload_bytes_per_call",
     "symmetry_matvec_calls",
     "input_allgather_calls",
-    "prdct_allreduce_calls"
+    "prdct_allreduce_calls",
+    "halo_schedule_ready",
+    "halo_reference_enabled",
+    "halo_reference_exchange_calls"
   };
   static const char *metric_keys[] = {
     "plan_remote_column_nnz_ratio",
@@ -120,7 +123,10 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
     "plan_apply_seconds_per_call",
     "prdct_allreduce_seconds_per_call",
     "matvec_other_seconds",
-    "matvec_other_seconds_per_call"
+    "matvec_other_seconds_per_call",
+    "halo_reference_pack_seconds_per_call",
+    "halo_reference_exchange_seconds_per_call",
+    "halo_reference_validation_seconds_per_call"
   };
   const size_t timer_count = sizeof(timer_ids) / sizeof(timer_ids[0]);
   const size_t work_count = sizeof(work_keys) / sizeof(work_keys[0]);
@@ -145,6 +151,9 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
   unsigned long long basis_digest_local;
   unsigned long long basis_digest_min;
   unsigned long long basis_digest_max;
+  unsigned long long halo_checksum_local;
+  unsigned long long halo_checksum_xor;
+  unsigned long long halo_checksum_sum;
   char fileName[D_FileNameMax];
   FILE *fp;
   size_t i;
@@ -175,26 +184,28 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
   work_local[16] =
       plan != NULL ? (unsigned long long)plan->remote_column_nnz : 0ULL;
   work_local[17] =
-      plan != NULL ? (unsigned long long)plan->ghost_count : 0ULL;
+      plan != NULL ? (unsigned long long)plan->halo.ghost_count : 0ULL;
   work_local[18] =
-      plan != NULL ? (unsigned long long)plan->send_value_count : 0ULL;
+      plan != NULL ? (unsigned long long)plan->halo.send_value_count : 0ULL;
   work_local[19] =
-      plan != NULL ? (unsigned long long)plan->incoming_peer_count : 0ULL;
+      plan != NULL ? (unsigned long long)plan->halo.incoming_peer_count : 0ULL;
   work_local[20] =
-      plan != NULL ? (unsigned long long)plan->outgoing_peer_count : 0ULL;
+      plan != NULL ? (unsigned long long)plan->halo.outgoing_peer_count : 0ULL;
   work_local[21] =
-      plan != NULL ? (unsigned long long)plan->max_recv_from_peer : 0ULL;
+      plan != NULL ? (unsigned long long)plan->halo.max_recv_from_peer : 0ULL;
   work_local[22] =
-      plan != NULL ? (unsigned long long)plan->max_send_to_peer : 0ULL;
+      plan != NULL ? (unsigned long long)plan->halo.max_send_to_peer : 0ULL;
   work_local[23] = plan != NULL
-                       ? (unsigned long long)plan->halo_schedule_bytes_estimate
+                       ? (unsigned long long)plan->halo.schedule_bytes
                        : 0ULL;
   work_local[24] =
       plan != NULL
-          ? (unsigned long long)plan->halo_runtime_buffer_bytes_estimate
+          ? (unsigned long long)plan->halo.runtime_buffer_bytes
           : 0ULL;
   work_local[25] =
-      plan != NULL ? (unsigned long long)plan->topology_scratch_bytes : 0ULL;
+      plan != NULL
+          ? (unsigned long long)plan->halo.topology_scratch_bytes
+          : 0ULL;
   work_local[26] =
       plan != NULL ? (unsigned long long)plan->column_slot_width : 0ULL;
   work_local[27] =
@@ -211,6 +222,12 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
       plan != NULL ? plan->input_allgather_calls : 0ULL;
   work_local[31] =
       plan != NULL ? plan->prdct_allreduce_calls : 0ULL;
+  work_local[32] =
+      plan != NULL && plan->halo.ready == TRUE ? 1ULL : 0ULL;
+  work_local[33] =
+      plan != NULL && plan->halo.reference_enabled == TRUE ? 1ULL : 0ULL;
+  work_local[34] =
+      plan != NULL ? plan->halo.reference_exchange_calls : 0ULL;
   row_mean_local = plan != NULL && plan->local_dim > 0UL
                        ? (double)plan->nnz / (double)plan->local_dim
                        : 0.0;
@@ -218,11 +235,11 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
                         ? (double)plan->remote_column_nnz / (double)plan->nnz
                         : 0.0;
   metric_local[1] = plan != NULL && plan->dim > 0UL
-                        ? (double)plan->ghost_count / (double)plan->dim
+                        ? (double)plan->halo.ghost_count / (double)plan->dim
                         : 0.0;
   metric_local[2] =
       plan != NULL && plan->allgather_nonlocal_values_per_call > 0U
-          ? (double)plan->ghost_count /
+          ? (double)plan->halo.ghost_count /
                 (double)plan->allgather_nonlocal_values_per_call
           : 0.0;
   metric_local[3] =
@@ -249,12 +266,30 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
           ? Timer[1513] / (double)plan->prdct_allreduce_calls
           : 0.0;
   metric_local[8] =
-      Timer[1] - Timer[1501] - Timer[1502] - Timer[1503] - Timer[1513];
+      Timer[1] - Timer[1501] - Timer[1502] - Timer[1503] -
+      Timer[1510] - Timer[1511] - Timer[1512] - Timer[1513];
   metric_local[9] =
       plan != NULL && plan->matvec_calls > 0ULL
           ? metric_local[8] / (double)plan->matvec_calls
           : 0.0;
+  metric_local[10] =
+      plan != NULL && plan->halo.reference_exchange_calls > 0ULL
+          ? Timer[1510] /
+                (double)plan->halo.reference_exchange_calls
+          : 0.0;
+  metric_local[11] =
+      plan != NULL && plan->halo.reference_exchange_calls > 0ULL
+          ? Timer[1511] /
+                (double)plan->halo.reference_exchange_calls
+          : 0.0;
+  metric_local[12] =
+      plan != NULL && plan->halo.reference_exchange_calls > 0ULL
+          ? Timer[1512] /
+                (double)plan->halo.reference_exchange_calls
+          : 0.0;
   basis_digest_local = SymmetryBasisDigest(X->Sym);
+  halo_checksum_local =
+      plan != NULL ? plan->halo.schedule_checksum : 0ULL;
 
   MPI_Allreduce(timer_local, timer_min, (int)timer_count, MPI_DOUBLE,
                 MPI_MIN, MPI_COMM_WORLD);
@@ -284,11 +319,15 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
                 MPI_UNSIGNED_LONG_LONG, MPI_MIN, MPI_COMM_WORLD);
   MPI_Allreduce(&basis_digest_local, &basis_digest_max, 1,
                 MPI_UNSIGNED_LONG_LONG, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&halo_checksum_local, &halo_checksum_xor, 1,
+                MPI_UNSIGNED_LONG_LONG, MPI_BXOR, MPI_COMM_WORLD);
+  MPI_Allreduce(&halo_checksum_local, &halo_checksum_sum, 1,
+                MPI_UNSIGNED_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
 
   sprintf(fileName, "CalcTimerRankStats.dat");
   if (childfopenMPI(fileName, "w", &fp) != 0) return;
   fprintf(fp,
-          "format=HPhiCalcTimerRankStats version=2 ranks=%d "
+          "format=HPhiCalcTimerRankStats version=3 ranks=%d "
           "basis_layout=replicated matvec_mode=%s vector_exchange=allgather\n",
           nproc,
           X->Sym->matvec_mode == SYMMETRY_MATVEC_MODE_PLAN
@@ -315,6 +354,10 @@ static void OutputSymmetryRankStats(const struct BindStruct *X)
   fprintf(fp,
           "basis_digest algorithm=fnv1a64-fields ranks=%d min=%016llx max=%016llx\n",
           nproc, basis_digest_min, basis_digest_max);
+  fprintf(fp,
+          "halo_schedule_digest algorithm=fnv1a64-layout ranks=%d "
+          "xor=%016llx sum=%016llx\n",
+          nproc, halo_checksum_xor, halo_checksum_sum);
   fclose(fp);
 }
 #endif
@@ -404,6 +447,7 @@ void OutputTimer(struct BindStruct *X) {
   StampTime(fp, "    symmetry plan storage allocation", 1121);
   StampTime(fp, "    symmetry plan fill", 1122);
   StampTime(fp, "    symmetry plan topology extraction", 1130);
+  StampTime(fp, "    symmetry halo request schedule", 1131);
   StampTime(fp, "  diagonalcalc", 2000);
   if(X->Def.iFlgCalcSpec == CALCSPEC_NOT){
     if(X->Def.iCalcType==TPQCalc || X->Def.iCalcType==cTPQ) {
@@ -482,6 +526,9 @@ void OutputTimer(struct BindStruct *X) {
   StampTime(fp,"  symmetry input Allgatherv",1501);
   StampTime(fp,"  symmetry legacy beta scan",1502);
   StampTime(fp,"  symmetry local-row plan apply",1503);
+  StampTime(fp,"  symmetry halo reference pack",1510);
+  StampTime(fp,"  symmetry halo reference exchange",1511);
+  StampTime(fp,"  symmetry halo reference validation",1512);
   StampTime(fp,"  symmetry prdct scalar Allreduce",1513);
   StampTime(fp,"  diagonal", 100);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,13 +50,15 @@ add_executable(unittest_symmetry_basis
     ${CMAKE_SOURCE_DIR}/test/unittest_symmetry_basis.c
     ${CMAKE_SOURCE_DIR}/src/symmetry_basis.c
     ${CMAKE_SOURCE_DIR}/src/symmetry_matvec_plan.c
+    ${CMAKE_SOURCE_DIR}/src/symmetry_vector_halo.c
     ${CMAKE_SOURCE_DIR}/src/bitcalc.c
     ${CMAKE_SOURCE_DIR}/src/ErrorMessage.c)
 target_include_directories(unittest_symmetry_basis
     PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
 target_compile_definitions(unittest_symmetry_basis PRIVATE
     DSFMT_MEXP=19937 HPHI_SYMMETRY_PARITY_VERIFY
-    HPHI_SYMMETRY_CANONICAL_VERIFY HPHI_SYMMETRY_SPIN_VERIFY)
+    HPHI_SYMMETRY_CANONICAL_VERIFY HPHI_SYMMETRY_SPIN_VERIFY
+    HPHI_SYMMETRY_HALO_BITSET_CAP_BYTES=1)
 target_link_libraries(unittest_symmetry_basis m)
 if(MPI_FOUND)
     target_link_libraries(unittest_symmetry_basis ${MPI_C_LIBRARIES})

--- a/test/symmetry_hubbard_lanczos.sh
+++ b/test/symmetry_hubbard_lanczos.sh
@@ -262,6 +262,7 @@ assert_rank_stats() {
     expected_ranks="$2"
     log="$3"
     expected_digest="${4:-}"
+    expected_reference="${5:-0}"
     stats=output/CalcTimerRankStats.dat
     if [ ! -f output/CalcTimer.dat ]; then
         return
@@ -272,7 +273,8 @@ assert_rank_stats() {
         exit 1
     fi
     if ! awk -v expected_dim="${expected_dim}" -v expected_ranks="${expected_ranks}" \
-        -v expected_digest="${expected_digest}" '
+        -v expected_digest="${expected_digest}" \
+        -v expected_reference="${expected_reference}" '
         function abs(x) { return x < 0 ? -x : x }
         function value(field, parts) {
             split(field, parts, "=")
@@ -334,13 +336,23 @@ assert_rank_stats() {
             if (expected_digest != "" && digest_min != expected_digest) bad = 1
             next
         }
+        $1 == "halo_schedule_digest" {
+            schedule_digest_count++
+            ranks = value($3)
+            schedule_digest_xor = value($4)
+            schedule_digest_sum = value($5)
+            if (ranks != expected_ranks ||
+                schedule_digest_xor == "" || schedule_digest_sum == "") bad = 1
+            next
+        }
         END {
-            if (header_version != 2 || header_ranks != expected_ranks ||
+            if (header_version != 3 || header_ranks != expected_ranks ||
                 header_basis_layout != "replicated" ||
                 header_matvec_mode != "plan" ||
                 header_vector_exchange != "allgather" ||
-                timer_count != 18 || work_count != 33 ||
-                metric_count != 10 || digest_count != 1) bad = 1
+                timer_count != 22 || work_count != 36 ||
+                metric_count != 13 || digest_count != 1 ||
+                schedule_digest_count != 1) bad = 1
             if (abs(work_mean["basis_raw_states"] * expected_ranks - 16) > 1.0e-12) bad = 1
             if (abs(work_mean["basis_representative_candidates"] * expected_ranks - 4) > 1.0e-12) bad = 1
             if (abs(work_mean["basis_compatible_survivors"] * expected_ranks - expected_dim) > 1.0e-12) bad = 1
@@ -354,9 +366,21 @@ assert_rank_stats() {
                 work_max["halo_outgoing_peer_count"] >= expected_ranks) bad = 1
             if (work_min["column_slot_width"] != 32 ||
                 work_max["column_slot_width"] != 32) bad = 1
+            if (work_min["halo_schedule_ready"] != 1 ||
+                work_max["halo_schedule_ready"] != 1) bad = 1
+            if (work_min["halo_schedule_bytes"] <= 0) bad = 1
+            if (abs(work_mean["halo_runtime_buffer_bytes"] - 16 * (work_mean["halo_ghost_count"] + work_mean["halo_send_value_count"])) > 1.0e-12) bad = 1
+            if (work_min["halo_reference_enabled"] != expected_reference ||
+                work_max["halo_reference_enabled"] != expected_reference) bad = 1
             if (work_min["symmetry_matvec_calls"] <= 0) bad = 1
             if (work_min["prdct_allreduce_calls"] <= 0) bad = 1
             if (abs(work_mean["symmetry_matvec_calls"] - work_mean["prdct_allreduce_calls"]) > 1.0e-12) bad = 1
+            if (expected_reference == 1) {
+                if (work_min["halo_reference_exchange_calls"] <= 0) bad = 1
+                if (abs(work_mean["halo_reference_exchange_calls"] - work_mean["symmetry_matvec_calls"]) > 1.0e-12) bad = 1
+            } else if (work_max["halo_reference_exchange_calls"] != 0) {
+                bad = 1
+            }
             if (abs(work_mean["input_allgather_payload_bytes_per_call"] - 16 * work_mean["input_allgather_nonlocal_values_per_call"]) > 1.0e-12) bad = 1
             if (expected_ranks > 1) {
                 if (abs(work_mean["halo_send_value_count"] - work_mean["halo_ghost_count"]) > 1.0e-12) bad = 1
@@ -377,7 +401,10 @@ assert_rank_stats() {
                 metric_min["input_allgather_seconds_per_call"] < 0 ||
                 metric_min["input_allgather_effective_bandwidth_Bps"] < 0 ||
                 metric_min["plan_apply_seconds_per_call"] < 0 ||
-                metric_min["prdct_allreduce_seconds_per_call"] < 0) bad = 1
+                metric_min["prdct_allreduce_seconds_per_call"] < 0 ||
+                metric_min["halo_reference_pack_seconds_per_call"] < 0 ||
+                metric_min["halo_reference_exchange_seconds_per_call"] < 0 ||
+                metric_min["halo_reference_validation_seconds_per_call"] < 0) bad = 1
             exit bad
         }
     ' "${stats}"; then
@@ -397,7 +424,8 @@ run_mpi_symmetry_case() {
     expected_digest="$6"
     log_file="hubbard_${label}_mpi.log"
     rm -rf output
-    if ! ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
+    if ! env HPHI_SYMMETRY_HALO_REFERENCE=1 \
+        ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
         cat "${log_file}"
         exit 1
     fi
@@ -407,7 +435,7 @@ run_mpi_symmetry_case() {
     fi
     assert_symmetry_log "${expected_dim}" "${log_file}"
     assert_rank_stats "${expected_dim}" "${expected_ranks}" "${log_file}" \
-        "${expected_digest}"
+        "${expected_digest}" 1
 }
 
 run_mpi_if_available() {
@@ -458,6 +486,9 @@ if grep -q "MPI site separation summary" hubbard_k0.log; then
 fi
 assert_rank_stats 4 1 hubbard_k0.log
 run_mpi_if_available k0 "${ref_energy}" 4 "${ref_doublon}"
+expect_failure "HPHI_SYMMETRY_HALO_REFERENCE must be" \
+    invalid_halo_reference.log env HPHI_SYMMETRY_HALO_REFERENCE=invalid \
+    ../../src/HPhi -e namelist.def
 
 rm -rf output
 write_kpi2_transsym
@@ -478,11 +509,12 @@ write_calcmod
 write_k0_transsym
 write_sym_namelist yes
 perl -0pi -e 's/CalcType 0/CalcType 3/' calcmod.def
-../../src/HPhi -e namelist.def > hubbard_k0_cg.log 2>&1
+env HPHI_SYMMETRY_HALO_REFERENCE=1 \
+    ../../src/HPhi -e namelist.def > hubbard_k0_cg.log 2>&1
 assert_energy_matches_reference "${ref_energy}" hubbard_k0_cg.log
 assert_doublon_matches_reference "${ref_doublon}" hubbard_k0_cg.log
 assert_symmetry_log 4 hubbard_k0_cg.log
-assert_rank_stats 4 1 hubbard_k0_cg.log
+assert_rank_stats 4 1 hubbard_k0_cg.log "" 1
 run_mpi_if_available k0_cg "${ref_energy}" 4 "${ref_doublon}"
 write_calcmod
 

--- a/test/symmetry_hubbard_lanczos.sh
+++ b/test/symmetry_hubbard_lanczos.sh
@@ -279,11 +279,16 @@ assert_rank_stats() {
             return parts[2]
         }
         /^format=/ {
+            header_version = value($2)
             header_ranks = value($3)
+            header_basis_layout = value($4)
+            header_matvec_mode = value($5)
+            header_vector_exchange = value($6)
             next
         }
         $1 == "timer" {
             timer_count++
+            id = value($2)
             ranks = value($3)
             min = value($4)
             max = value($5)
@@ -291,6 +296,7 @@ assert_rank_stats() {
             if (ranks != expected_ranks || min > mean || mean > max) bad = 1
             if (expected_ranks == 1 &&
                 (abs(min - max) > 1.0e-15 || abs(min - mean) > 1.0e-15)) bad = 1
+            timer_mean[id] = mean
             next
         }
         $1 == "work" {
@@ -306,6 +312,19 @@ assert_rank_stats() {
             work_mean[key] = mean
             next
         }
+        $1 == "metric" {
+            metric_count++
+            key = value($2)
+            ranks = value($3)
+            min = value($4)
+            max = value($5)
+            mean = value($6)
+            if (ranks != expected_ranks || min > mean || mean > max) bad = 1
+            metric_min[key] = min
+            metric_max[key] = max
+            metric_mean[key] = mean
+            next
+        }
         $1 == "basis_digest" {
             digest_count++
             ranks = value($3)
@@ -316,8 +335,12 @@ assert_rank_stats() {
             next
         }
         END {
-            if (header_ranks != expected_ranks || timer_count != 12 ||
-                work_count != 16 || digest_count != 1) bad = 1
+            if (header_version != 2 || header_ranks != expected_ranks ||
+                header_basis_layout != "replicated" ||
+                header_matvec_mode != "plan" ||
+                header_vector_exchange != "allgather" ||
+                timer_count != 18 || work_count != 33 ||
+                metric_count != 10 || digest_count != 1) bad = 1
             if (abs(work_mean["basis_raw_states"] * expected_ranks - 16) > 1.0e-12) bad = 1
             if (abs(work_mean["basis_representative_candidates"] * expected_ranks - 4) > 1.0e-12) bad = 1
             if (abs(work_mean["basis_compatible_survivors"] * expected_ranks - expected_dim) > 1.0e-12) bad = 1
@@ -325,6 +348,36 @@ assert_rank_stats() {
             if (abs(work_mean["basis_orbit_metadata_calls"] * expected_ranks - 4) > 1.0e-12) bad = 1
             if (work_min["basis_thread_count"] < 1) bad = 1
             if (abs(work_mean["plan_local_rows"] * expected_ranks - expected_dim) > 1.0e-12) bad = 1
+            if (abs(work_mean["plan_local_column_nnz"] + work_mean["plan_remote_column_nnz"] - work_mean["plan_local_nnz"]) > 1.0e-12) bad = 1
+            if (work_max["halo_ghost_count"] > work_max["plan_remote_column_nnz"]) bad = 1
+            if (work_max["halo_incoming_peer_count"] >= expected_ranks ||
+                work_max["halo_outgoing_peer_count"] >= expected_ranks) bad = 1
+            if (work_min["column_slot_width"] != 32 ||
+                work_max["column_slot_width"] != 32) bad = 1
+            if (work_min["symmetry_matvec_calls"] <= 0) bad = 1
+            if (work_min["prdct_allreduce_calls"] <= 0) bad = 1
+            if (abs(work_mean["symmetry_matvec_calls"] - work_mean["prdct_allreduce_calls"]) > 1.0e-12) bad = 1
+            if (abs(work_mean["input_allgather_payload_bytes_per_call"] - 16 * work_mean["input_allgather_nonlocal_values_per_call"]) > 1.0e-12) bad = 1
+            if (expected_ranks > 1) {
+                if (abs(work_mean["halo_send_value_count"] - work_mean["halo_ghost_count"]) > 1.0e-12) bad = 1
+                if (work_min["input_allgather_calls"] <= 0) bad = 1
+                if (abs(work_mean["input_allgather_calls"] - work_mean["symmetry_matvec_calls"]) > 1.0e-12) bad = 1
+            } else {
+                if (work_max["plan_remote_column_nnz"] != 0 ||
+                    work_max["halo_ghost_count"] != 0 ||
+                    work_max["input_allgather_calls"] != 0) bad = 1
+            }
+            if (metric_min["plan_remote_column_nnz_ratio"] < 0 ||
+                metric_max["plan_remote_column_nnz_ratio"] > 1 ||
+                metric_min["halo_ghost_global_ratio"] < 0 ||
+                metric_max["halo_ghost_global_ratio"] > 1 ||
+                metric_min["halo_ghost_nonlocal_ratio"] < 0 ||
+                metric_max["halo_ghost_nonlocal_ratio"] > 1 ||
+                metric_min["symmetry_matvec_seconds_per_call"] < 0 ||
+                metric_min["input_allgather_seconds_per_call"] < 0 ||
+                metric_min["input_allgather_effective_bandwidth_Bps"] < 0 ||
+                metric_min["plan_apply_seconds_per_call"] < 0 ||
+                metric_min["prdct_allreduce_seconds_per_call"] < 0) bad = 1
             exit bad
         }
     ' "${stats}"; then

--- a/test/symmetry_hubbard_lanczos.sh
+++ b/test/symmetry_hubbard_lanczos.sh
@@ -263,6 +263,7 @@ assert_rank_stats() {
     log="$3"
     expected_digest="${4:-}"
     expected_reference="${5:-0}"
+    expected_exchange="${6:-allgather}"
     stats=output/CalcTimerRankStats.dat
     if [ ! -f output/CalcTimer.dat ]; then
         return
@@ -274,7 +275,8 @@ assert_rank_stats() {
     fi
     if ! awk -v expected_dim="${expected_dim}" -v expected_ranks="${expected_ranks}" \
         -v expected_digest="${expected_digest}" \
-        -v expected_reference="${expected_reference}" '
+        -v expected_reference="${expected_reference}" \
+        -v expected_exchange="${expected_exchange}" '
         function abs(x) { return x < 0 ? -x : x }
         function value(field, parts) {
             split(field, parts, "=")
@@ -346,12 +348,12 @@ assert_rank_stats() {
             next
         }
         END {
-            if (header_version != 3 || header_ranks != expected_ranks ||
+            if (header_version != 4 || header_ranks != expected_ranks ||
                 header_basis_layout != "replicated" ||
                 header_matvec_mode != "plan" ||
-                header_vector_exchange != "allgather" ||
-                timer_count != 22 || work_count != 36 ||
-                metric_count != 13 || digest_count != 1 ||
+                header_vector_exchange != expected_exchange ||
+                timer_count != 23 || work_count != 39 ||
+                metric_count != 15 || digest_count != 1 ||
                 schedule_digest_count != 1) bad = 1
             if (abs(work_mean["basis_raw_states"] * expected_ranks - 16) > 1.0e-12) bad = 1
             if (abs(work_mean["basis_representative_candidates"] * expected_ranks - 4) > 1.0e-12) bad = 1
@@ -372,6 +374,13 @@ assert_rank_stats() {
             if (abs(work_mean["halo_runtime_buffer_bytes"] - 16 * (work_mean["halo_ghost_count"] + work_mean["halo_send_value_count"])) > 1.0e-12) bad = 1
             if (work_min["halo_reference_enabled"] != expected_reference ||
                 work_max["halo_reference_enabled"] != expected_reference) bad = 1
+            expected_remapped = expected_exchange == "halo" ? 1 : 0
+            if (work_min["columns_remapped"] != expected_remapped ||
+                work_max["columns_remapped"] != expected_remapped) bad = 1
+            expected_full = expected_exchange == "allgather" &&
+                            expected_ranks > 1 ? 1 : 0
+            if (work_min["full_input_vector_allocated"] != expected_full ||
+                work_max["full_input_vector_allocated"] != expected_full) bad = 1
             if (work_min["symmetry_matvec_calls"] <= 0) bad = 1
             if (work_min["prdct_allreduce_calls"] <= 0) bad = 1
             if (abs(work_mean["symmetry_matvec_calls"] - work_mean["prdct_allreduce_calls"]) > 1.0e-12) bad = 1
@@ -381,15 +390,22 @@ assert_rank_stats() {
             } else if (work_max["halo_reference_exchange_calls"] != 0) {
                 bad = 1
             }
+            if (expected_reference == 1 || expected_exchange == "halo") {
+                if (work_min["halo_exchange_calls"] <= 0) bad = 1
+                if (abs(work_mean["halo_exchange_calls"] - work_mean["symmetry_matvec_calls"]) > 1.0e-12) bad = 1
+            } else if (work_max["halo_exchange_calls"] != 0) {
+                bad = 1
+            }
             if (abs(work_mean["input_allgather_payload_bytes_per_call"] - 16 * work_mean["input_allgather_nonlocal_values_per_call"]) > 1.0e-12) bad = 1
-            if (expected_ranks > 1) {
+            if (expected_ranks > 1 && expected_exchange == "allgather") {
                 if (abs(work_mean["halo_send_value_count"] - work_mean["halo_ghost_count"]) > 1.0e-12) bad = 1
                 if (work_min["input_allgather_calls"] <= 0) bad = 1
                 if (abs(work_mean["input_allgather_calls"] - work_mean["symmetry_matvec_calls"]) > 1.0e-12) bad = 1
             } else {
-                if (work_max["plan_remote_column_nnz"] != 0 ||
-                    work_max["halo_ghost_count"] != 0 ||
-                    work_max["input_allgather_calls"] != 0) bad = 1
+                if (work_max["input_allgather_calls"] != 0) bad = 1
+                if (expected_ranks == 1 &&
+                    (work_max["plan_remote_column_nnz"] != 0 ||
+                     work_max["halo_ghost_count"] != 0)) bad = 1
             }
             if (metric_min["plan_remote_column_nnz_ratio"] < 0 ||
                 metric_max["plan_remote_column_nnz_ratio"] > 1 ||
@@ -404,7 +420,9 @@ assert_rank_stats() {
                 metric_min["prdct_allreduce_seconds_per_call"] < 0 ||
                 metric_min["halo_reference_pack_seconds_per_call"] < 0 ||
                 metric_min["halo_reference_exchange_seconds_per_call"] < 0 ||
-                metric_min["halo_reference_validation_seconds_per_call"] < 0) bad = 1
+                metric_min["halo_reference_validation_seconds_per_call"] < 0 ||
+                metric_min["halo_pack_seconds_per_call"] < 0 ||
+                metric_min["halo_exchange_seconds_per_call"] < 0) bad = 1
             exit bad
         }
     ' "${stats}"; then
@@ -436,6 +454,23 @@ run_mpi_symmetry_case() {
     assert_symmetry_log "${expected_dim}" "${log_file}"
     assert_rank_stats "${expected_dim}" "${expected_ranks}" "${log_file}" \
         "${expected_digest}" 1
+
+    log_file="hubbard_${label}_halo_mpi.log"
+    rm -rf output
+    if ! env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+        ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
+        cat "${log_file}"
+        exit 1
+    fi
+    assert_energy_matches_reference "${expected_energy}" "${log_file}"
+    if [ -n "${expected_doublon}" ]; then
+        assert_doublon_matches_reference "${expected_doublon}" "${log_file}"
+    fi
+    assert_symmetry_log "${expected_dim}" "${log_file}"
+    grep -q "vector_exchange=halo" "${log_file}"
+    grep -q "columns=local/ghost-slots" "${log_file}"
+    assert_rank_stats "${expected_dim}" "${expected_ranks}" "${log_file}" \
+        "${expected_digest}" 0 halo
 }
 
 run_mpi_if_available() {
@@ -489,6 +524,16 @@ run_mpi_if_available k0 "${ref_energy}" 4 "${ref_doublon}"
 expect_failure "HPHI_SYMMETRY_HALO_REFERENCE must be" \
     invalid_halo_reference.log env HPHI_SYMMETRY_HALO_REFERENCE=invalid \
     ../../src/HPhi -e namelist.def
+expect_failure "HPHI_SYMMETRY_VECTOR_EXCHANGE must be" \
+    invalid_vector_exchange.log env HPHI_SYMMETRY_VECTOR_EXCHANGE=invalid \
+    ../../src/HPhi -e namelist.def
+expect_failure "symmetry legacy matvec requires" \
+    invalid_legacy_halo.log env HPHI_SYMMETRY_MATVEC=legacy \
+    HPHI_SYMMETRY_VECTOR_EXCHANGE=halo ../../src/HPhi -e namelist.def
+expect_failure "HPHI_SYMMETRY_HALO_REFERENCE requires" \
+    invalid_halo_reference_production.log \
+    env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+    HPHI_SYMMETRY_HALO_REFERENCE=1 ../../src/HPhi -e namelist.def
 
 rm -rf output
 write_kpi2_transsym
@@ -515,6 +560,14 @@ assert_energy_matches_reference "${ref_energy}" hubbard_k0_cg.log
 assert_doublon_matches_reference "${ref_doublon}" hubbard_k0_cg.log
 assert_symmetry_log 4 hubbard_k0_cg.log
 assert_rank_stats 4 1 hubbard_k0_cg.log "" 1
+rm -rf output
+env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+    ../../src/HPhi -e namelist.def > hubbard_k0_cg_halo.log 2>&1
+assert_energy_matches_reference "${ref_energy}" hubbard_k0_cg_halo.log
+assert_doublon_matches_reference "${ref_doublon}" hubbard_k0_cg_halo.log
+assert_symmetry_log 4 hubbard_k0_cg_halo.log
+grep -q "vector_exchange=halo" hubbard_k0_cg_halo.log
+assert_rank_stats 4 1 hubbard_k0_cg_halo.log "" 0 halo
 run_mpi_if_available k0_cg "${ref_energy}" 4 "${ref_doublon}"
 write_calcmod
 

--- a/test/symmetry_hubbard_lanczos.sh
+++ b/test/symmetry_hubbard_lanczos.sh
@@ -263,7 +263,7 @@ assert_rank_stats() {
     log="$3"
     expected_digest="${4:-}"
     expected_reference="${5:-0}"
-    expected_exchange="${6:-allgather}"
+    expected_exchange="${6:-halo}"
     stats=output/CalcTimerRankStats.dat
     if [ ! -f output/CalcTimer.dat ]; then
         return
@@ -442,7 +442,8 @@ run_mpi_symmetry_case() {
     expected_digest="$6"
     log_file="hubbard_${label}_mpi.log"
     rm -rf output
-    if ! env HPHI_SYMMETRY_HALO_REFERENCE=1 \
+    if ! env HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather \
+        HPHI_SYMMETRY_HALO_REFERENCE=1 \
         ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
         cat "${log_file}"
         exit 1
@@ -453,12 +454,11 @@ run_mpi_symmetry_case() {
     fi
     assert_symmetry_log "${expected_dim}" "${log_file}"
     assert_rank_stats "${expected_dim}" "${expected_ranks}" "${log_file}" \
-        "${expected_digest}" 1
+        "${expected_digest}" 1 allgather
 
-    log_file="hubbard_${label}_halo_mpi.log"
+    log_file="hubbard_${label}_default_mpi.log"
     rm -rf output
-    if ! env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
-        ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
+    if ! ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
         cat "${log_file}"
         exit 1
     fi
@@ -514,6 +514,8 @@ write_sym_namelist yes
 assert_energy_matches_reference "${ref_energy}" hubbard_k0.log
 assert_doublon_matches_reference "${ref_doublon}" hubbard_k0.log
 grep -q "Symmetry basis: raw_dim=16 sector_dim=4 group_order=4" hubbard_k0.log
+grep -q "vector_exchange=halo" hubbard_k0.log
+grep -q "columns=local/ghost-slots" hubbard_k0.log
 if grep -q "MPI site separation summary" hubbard_k0.log; then
     cat hubbard_k0.log
     echo "TransSym Hubbard serial path unexpectedly used site decomposition."
@@ -532,8 +534,7 @@ expect_failure "symmetry legacy matvec requires" \
     HPHI_SYMMETRY_VECTOR_EXCHANGE=halo ../../src/HPhi -e namelist.def
 expect_failure "HPHI_SYMMETRY_HALO_REFERENCE requires" \
     invalid_halo_reference_production.log \
-    env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
-    HPHI_SYMMETRY_HALO_REFERENCE=1 ../../src/HPhi -e namelist.def
+    env HPHI_SYMMETRY_HALO_REFERENCE=1 ../../src/HPhi -e namelist.def
 
 rm -rf output
 write_kpi2_transsym
@@ -541,6 +542,8 @@ write_sym_namelist no
 ../../src/HPhi -e namelist.def > hubbard_kpi2.log 2>&1
 assert_energy "-2.0" hubbard_kpi2.log
 grep -q "Symmetry basis: raw_dim=16 sector_dim=4 group_order=4" hubbard_kpi2.log
+grep -q "vector_exchange=halo" hubbard_kpi2.log
+grep -q "columns=local/ghost-slots" hubbard_kpi2.log
 if grep -q "MPI site separation summary" hubbard_kpi2.log; then
     cat hubbard_kpi2.log
     echo "TransSym Hubbard serial path unexpectedly used site decomposition."
@@ -554,20 +557,21 @@ write_calcmod
 write_k0_transsym
 write_sym_namelist yes
 perl -0pi -e 's/CalcType 0/CalcType 3/' calcmod.def
-env HPHI_SYMMETRY_HALO_REFERENCE=1 \
+env HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather \
+    HPHI_SYMMETRY_HALO_REFERENCE=1 \
     ../../src/HPhi -e namelist.def > hubbard_k0_cg.log 2>&1
 assert_energy_matches_reference "${ref_energy}" hubbard_k0_cg.log
 assert_doublon_matches_reference "${ref_doublon}" hubbard_k0_cg.log
 assert_symmetry_log 4 hubbard_k0_cg.log
-assert_rank_stats 4 1 hubbard_k0_cg.log "" 1
+assert_rank_stats 4 1 hubbard_k0_cg.log "" 1 allgather
 rm -rf output
-env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
-    ../../src/HPhi -e namelist.def > hubbard_k0_cg_halo.log 2>&1
-assert_energy_matches_reference "${ref_energy}" hubbard_k0_cg_halo.log
-assert_doublon_matches_reference "${ref_doublon}" hubbard_k0_cg_halo.log
-assert_symmetry_log 4 hubbard_k0_cg_halo.log
-grep -q "vector_exchange=halo" hubbard_k0_cg_halo.log
-assert_rank_stats 4 1 hubbard_k0_cg_halo.log "" 0 halo
+../../src/HPhi -e namelist.def > hubbard_k0_cg_default.log 2>&1
+assert_energy_matches_reference "${ref_energy}" hubbard_k0_cg_default.log
+assert_doublon_matches_reference "${ref_doublon}" hubbard_k0_cg_default.log
+assert_symmetry_log 4 hubbard_k0_cg_default.log
+grep -q "vector_exchange=halo" hubbard_k0_cg_default.log
+grep -q "columns=local/ghost-slots" hubbard_k0_cg_default.log
+assert_rank_stats 4 1 hubbard_k0_cg_default.log "" 0 halo
 run_mpi_if_available k0_cg "${ref_energy}" 4 "${ref_doublon}"
 write_calcmod
 

--- a/test/symmetry_hubbard_standard_generation.sh
+++ b/test/symmetry_hubbard_standard_generation.sh
@@ -154,6 +154,8 @@ assert_symmetry_log() {
         echo "TransSym Hubbard path unexpectedly used site decomposition."
         exit 1
     fi
+    grep -q "Symmetry matvec: mode=plan vector_exchange=halo" "${log}"
+    grep -q "columns=local/ghost-slots" "${log}"
 }
 
 assert_generated_files() {

--- a/test/symmetry_spin_chain_lanczos.sh
+++ b/test/symmetry_spin_chain_lanczos.sh
@@ -196,7 +196,9 @@ Ising ising.def
 TransSym qptransidx.def
 EOF
 
-run_hphi symmetry_heisenberg.log env HPHI_SYMMETRY_MATVEC=plan ../../src/HPhi -e namelist_heisenberg.def
+run_hphi symmetry_heisenberg.log env HPHI_SYMMETRY_MATVEC=plan \
+    HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+    ../../src/HPhi -e namelist_heisenberg.def
 sym_heisenberg_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
 test -n "${ref_heisenberg_energy}"
 test -n "${sym_heisenberg_energy}"
@@ -204,6 +206,7 @@ heisenberg_diff=`awk -v a="${sym_heisenberg_energy}" -v b="${ref_heisenberg_ener
 test "${heisenberg_diff}" = "0.000000"
 grep -q "Symmetry basis: raw_dim=20 sector_dim=4 group_order=6" symmetry_heisenberg.log
 grep -q "Symmetry matvec: mode=plan" symmetry_heisenberg.log
+grep -q "vector_exchange=halo" symmetry_heisenberg.log
 
 rm -rf output
 write_kpi_over_3_transsym_l6
@@ -214,6 +217,15 @@ complex_diff=`awk -v a="${complex_energy}" 'BEGIN{d=a+1.0; if(d<0)d=-d; printf "
 test "${complex_diff}" = "0.000000"
 grep -q "Symmetry basis: raw_dim=20 sector_dim=3 group_order=6" symmetry_complex.log
 grep -q "Symmetry matvec: mode=plan" symmetry_complex.log
+
+rm -rf output
+run_hphi symmetry_complex_halo.log env HPHI_SYMMETRY_MATVEC=plan \
+    HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+    ../../src/HPhi -e namelist.def
+complex_halo_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+complex_halo_diff=`awk -v a="${complex_halo_energy}" -v b="${complex_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.16e", d}'`
+awk -v d="${complex_halo_diff}" 'BEGIN{exit !(d <= 1.0e-12)}'
+grep -q "vector_exchange=halo" symmetry_complex_halo.log
 
 rm -rf output
 run_hphi symmetry_complex_legacy.log env HPHI_SYMMETRY_MATVEC=legacy ../../src/HPhi -e namelist.def
@@ -251,6 +263,34 @@ run_mpi_symmetry_case() {
         echo "TransSym MPI path unexpectedly used site decomposition."
         exit 1
     fi
+
+    log_file="symmetry_${label}_halo_mpi.log"
+    rm -rf output
+    if ! HPHI_SYMMETRY_MATVEC=plan \
+        HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+        ${MPIRUN} ../../src/HPhi -e "${namelist}" > "${log_file}" 2>&1; then
+        cat "${log_file}"
+        exit 1
+    fi
+    mpi_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+    test -n "${mpi_energy}"
+    mpi_diff=`awk -v a="${mpi_energy}" -v b="${expected_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
+    test "${mpi_diff}" = "0.000000"
+    grep -q "Symmetry basis: raw_dim=20 sector_dim=${expected_dim} group_order=6" "${log_file}"
+    grep -q "vector_exchange=halo" "${log_file}"
+
+    log_file="symmetry_${label}_legacy_mpi.log"
+    rm -rf output
+    if ! HPHI_SYMMETRY_MATVEC=legacy \
+        ${MPIRUN} ../../src/HPhi -e "${namelist}" > "${log_file}" 2>&1; then
+        cat "${log_file}"
+        exit 1
+    fi
+    mpi_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+    test -n "${mpi_energy}"
+    mpi_diff=`awk -v a="${mpi_energy}" -v b="${expected_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
+    test "${mpi_diff}" = "0.000000"
+    grep -q "mode=legacy vector_exchange=allgather" "${log_file}"
 }
 
 if [ -n "${MPIRUN}" ]; then

--- a/test/symmetry_spin_chain_lanczos.sh
+++ b/test/symmetry_spin_chain_lanczos.sh
@@ -196,9 +196,7 @@ Ising ising.def
 TransSym qptransidx.def
 EOF
 
-run_hphi symmetry_heisenberg.log env HPHI_SYMMETRY_MATVEC=plan \
-    HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
-    ../../src/HPhi -e namelist_heisenberg.def
+run_hphi symmetry_heisenberg.log ../../src/HPhi -e namelist_heisenberg.def
 sym_heisenberg_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
 test -n "${ref_heisenberg_energy}"
 test -n "${sym_heisenberg_energy}"
@@ -207,6 +205,7 @@ test "${heisenberg_diff}" = "0.000000"
 grep -q "Symmetry basis: raw_dim=20 sector_dim=4 group_order=6" symmetry_heisenberg.log
 grep -q "Symmetry matvec: mode=plan" symmetry_heisenberg.log
 grep -q "vector_exchange=halo" symmetry_heisenberg.log
+grep -q "columns=local/ghost-slots" symmetry_heisenberg.log
 
 rm -rf output
 write_kpi_over_3_transsym_l6
@@ -217,15 +216,18 @@ complex_diff=`awk -v a="${complex_energy}" 'BEGIN{d=a+1.0; if(d<0)d=-d; printf "
 test "${complex_diff}" = "0.000000"
 grep -q "Symmetry basis: raw_dim=20 sector_dim=3 group_order=6" symmetry_complex.log
 grep -q "Symmetry matvec: mode=plan" symmetry_complex.log
+grep -q "vector_exchange=halo" symmetry_complex.log
+grep -q "columns=local/ghost-slots" symmetry_complex.log
 
 rm -rf output
-run_hphi symmetry_complex_halo.log env HPHI_SYMMETRY_MATVEC=plan \
-    HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+run_hphi symmetry_complex_allgather.log env HPHI_SYMMETRY_MATVEC=plan \
+    HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather \
     ../../src/HPhi -e namelist.def
-complex_halo_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
-complex_halo_diff=`awk -v a="${complex_halo_energy}" -v b="${complex_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.16e", d}'`
-awk -v d="${complex_halo_diff}" 'BEGIN{exit !(d <= 1.0e-12)}'
-grep -q "vector_exchange=halo" symmetry_complex_halo.log
+complex_allgather_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+complex_allgather_diff=`awk -v a="${complex_allgather_energy}" -v b="${complex_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.16e", d}'`
+awk -v d="${complex_allgather_diff}" 'BEGIN{exit !(d <= 1.0e-12)}'
+grep -q "vector_exchange=allgather" symmetry_complex_allgather.log
+grep -q "columns=global" symmetry_complex_allgather.log
 
 rm -rf output
 run_hphi symmetry_complex_legacy.log env HPHI_SYMMETRY_MATVEC=legacy ../../src/HPhi -e namelist.def
@@ -234,6 +236,7 @@ test -n "${legacy_energy}"
 legacy_diff=`awk -v a="${legacy_energy}" -v b="${complex_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.16e", d}'`
 awk -v d="${legacy_diff}" 'BEGIN{exit !(d <= 1.0e-12)}'
 grep -q "Symmetry matvec: mode=legacy" symmetry_complex_legacy.log
+grep -q "mode=legacy vector_exchange=allgather" symmetry_complex_legacy.log
 
 rm -rf output
 if env HPHI_SYMMETRY_MATVEC=invalid ../../src/HPhi -e namelist.def > symmetry_invalid_mode.log 2>&1; then
@@ -259,15 +262,17 @@ run_mpi_symmetry_case() {
     test "${mpi_diff}" = "0.000000"
     grep -q "Symmetry basis: raw_dim=20 sector_dim=${expected_dim} group_order=6" "${log_file}"
     grep -q "Symmetry matvec: mode=plan" "${log_file}"
+    grep -q "vector_exchange=halo" "${log_file}"
+    grep -q "columns=local/ghost-slots" "${log_file}"
     if grep -q "MPI site separation summary" "${log_file}"; then
         echo "TransSym MPI path unexpectedly used site decomposition."
         exit 1
     fi
 
-    log_file="symmetry_${label}_halo_mpi.log"
+    log_file="symmetry_${label}_allgather_mpi.log"
     rm -rf output
     if ! HPHI_SYMMETRY_MATVEC=plan \
-        HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+        HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather \
         ${MPIRUN} ../../src/HPhi -e "${namelist}" > "${log_file}" 2>&1; then
         cat "${log_file}"
         exit 1
@@ -277,7 +282,8 @@ run_mpi_symmetry_case() {
     mpi_diff=`awk -v a="${mpi_energy}" -v b="${expected_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
     test "${mpi_diff}" = "0.000000"
     grep -q "Symmetry basis: raw_dim=20 sector_dim=${expected_dim} group_order=6" "${log_file}"
-    grep -q "vector_exchange=halo" "${log_file}"
+    grep -q "vector_exchange=allgather" "${log_file}"
+    grep -q "columns=global" "${log_file}"
 
     log_file="symmetry_${label}_legacy_mpi.log"
     rm -rf output
@@ -322,6 +328,7 @@ EOF
         rank_env_diff=`awk -v a="${rank_env_energy}" -v b="${complex_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
         test "${rank_env_diff}" = "0.000000"
         grep -q "Symmetry matvec: mode=plan" symmetry_rank_env_mpi.log
+        grep -q "vector_exchange=halo" symmetry_rank_env_mpi.log
         if grep -q "HPHI_SYMMETRY_MATVEC must be" symmetry_rank_env_mpi.log; then
             cat symmetry_rank_env_mpi.log
             exit 1

--- a/test/symmetry_spin_chain_lobcg.sh
+++ b/test/symmetry_spin_chain_lobcg.sh
@@ -115,6 +115,8 @@ diff=`awk -v a="${sym_energy}" -v b="${ref_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; p
 test "${diff}" = "0.000000"
 
 grep -q "Symmetry basis: raw_dim=6 sector_dim=2 group_order=4" symmetry.log
+grep -q "Symmetry matvec: mode=plan vector_exchange=halo" symmetry.log
+grep -q "columns=local/ghost-slots" symmetry.log
 
 if [ -n "${MPIRUN}" ]; then
     MPI_NP=`printf "%s\n" "${MPIRUN}" | awk '{for(i=1;i<=NF;i++){if($i=="-np"||$i=="-n"){print $(i+1); exit}}}'`
@@ -126,6 +128,8 @@ if [ -n "${MPIRUN}" ]; then
         mpi_diff=`awk -v a="${mpi_energy}" -v b="${sym_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
         test "${mpi_diff}" = "0.000000"
         grep -q "Symmetry basis: raw_dim=6 sector_dim=2 group_order=4" symmetry_mpi.log
+        grep -q "Symmetry matvec: mode=plan vector_exchange=halo" symmetry_mpi.log
+        grep -q "columns=local/ghost-slots" symmetry_mpi.log
         if grep -q "MPI site separation summary" symmetry_mpi.log; then
             echo "TransSym MPI path unexpectedly used site decomposition."
             exit 1

--- a/test/symmetry_spin_chain_standard_generation.sh
+++ b/test/symmetry_spin_chain_standard_generation.sh
@@ -65,6 +65,8 @@ test -n "${auto_energy}"
 grep -q "qptransidx.def is written for MomentumIndex = 1" auto.log
 grep -q "TransSym  qptransidx.def" namelist.def
 grep -q "Symmetry basis: raw_dim=20 sector_dim=3 group_order=6" auto.log
+grep -q "Symmetry matvec: mode=plan vector_exchange=halo" auto.log
+grep -q "columns=local/ghost-slots" auto.log
 awk 'NF == 3 && $1 == 1 {found=1; re=$2; im=$3; if(re<0) re=-re; if(im+0.8660254037844386<0) d=-(im+0.8660254037844386); else d=(im+0.8660254037844386); ok=(re-0.5 < 0.000001 && re-0.5 > -0.000001 && d < 0.000001)} END{exit found && ok ? 0 : 1}' qptransidx.def
 
 rm -rf expert output
@@ -80,6 +82,8 @@ test -n "${expert_energy}"
 diff=`awk -v a="${auto_energy}" -v b="${expert_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
 test "${diff}" = "0.000000"
 grep -q "Symmetry basis: raw_dim=20 sector_dim=3 group_order=6" expert.log
+grep -q "Symmetry matvec: mode=plan vector_exchange=halo" expert.log
+grep -q "columns=local/ghost-slots" expert.log
 cd ..
 
 write_exchange_only_stan "MomentumIndex = 6"

--- a/test/symmetry_spinless_fermion_lanczos.sh
+++ b/test/symmetry_spinless_fermion_lanczos.sh
@@ -229,14 +229,16 @@ run_mpi_symmetry_case() {
         echo "Expected SpinlessFermion symmetry sector_dim=${expected_dim} was not found"
         exit 1
     fi
+    grep -q "vector_exchange=halo" "${log_file}"
+    grep -q "columns=local/ghost-slots" "${log_file}"
     if grep -q "MPI site separation summary" "${log_file}"; then
         echo "TransSym SpinlessFermion MPI path unexpectedly used site decomposition."
         exit 1
     fi
 
-    log_file="spinless_${label}_halo_mpi.log"
+    log_file="spinless_${label}_allgather_mpi.log"
     rm -rf output
-    if ! env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+    if ! env HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather \
         ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
         cat "${log_file}"
         exit 1
@@ -246,11 +248,12 @@ run_mpi_symmetry_case() {
     mpi_diff=`awk -v a="${mpi_energy}" -v b="${expected_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
     if [ "${mpi_diff}" != "0.000000" ]; then
         cat "${log_file}"
-        echo "MPI halo energy mismatch: got ${mpi_energy}, expected ${expected_energy}"
+        echo "MPI allgather energy mismatch: got ${mpi_energy}, expected ${expected_energy}"
         exit 1
     fi
     grep -q "Symmetry basis: raw_dim=.* sector_dim=${expected_dim} group_order=4" "${log_file}"
-    grep -q "vector_exchange=halo" "${log_file}"
+    grep -q "vector_exchange=allgather" "${log_file}"
+    grep -q "columns=global" "${log_file}"
 }
 
 run_mpi_if_available() {
@@ -290,6 +293,8 @@ write_namelist
 ../../src/HPhi -e namelist.def > spinless_k0.log 2>&1
 assert_energy "-2.0" spinless_k0.log
 grep -q "Symmetry basis: raw_dim=4 sector_dim=1 group_order=4" spinless_k0.log
+grep -q "vector_exchange=halo" spinless_k0.log
+grep -q "columns=local/ghost-slots" spinless_k0.log
 run_mpi_if_available k0 "-2.0" 1
 
 rm -rf output
@@ -299,11 +304,14 @@ write_kpi2_transsym
 ../../src/HPhi -e namelist.def > spinless_kpi2.log 2>&1
 assert_energy "-2.0" spinless_kpi2.log
 grep -q "Symmetry basis: raw_dim=6 sector_dim=2 group_order=4" spinless_kpi2.log
+grep -q "vector_exchange=halo" spinless_kpi2.log
+grep -q "columns=local/ghost-slots" spinless_kpi2.log
 rm -rf output
-env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
-    ../../src/HPhi -e namelist.def > spinless_kpi2_halo.log 2>&1
-assert_energy "-2.0" spinless_kpi2_halo.log
-grep -q "vector_exchange=halo" spinless_kpi2_halo.log
+env HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather \
+    ../../src/HPhi -e namelist.def > spinless_kpi2_allgather.log 2>&1
+assert_energy "-2.0" spinless_kpi2_allgather.log
+grep -q "vector_exchange=allgather" spinless_kpi2_allgather.log
+grep -q "columns=global" spinless_kpi2_allgather.log
 run_mpi_if_available kpi2 "-2.0" 2
 
 rm -rf output
@@ -327,6 +335,7 @@ rm -rf output
 ../../src/HPhi -e namelist.def > spinless_coulombinter.log 2>&1
 assert_energy "0.25" spinless_coulombinter.log
 grep -q "Symmetry basis: raw_dim=6 sector_dim=1 group_order=4" spinless_coulombinter.log
+grep -q "vector_exchange=halo" spinless_coulombinter.log
 test -s output/zvo_energy.dat
 run_mpi_if_available coulombinter "0.25" 1
 write_coulombinter

--- a/test/symmetry_spinless_fermion_lanczos.sh
+++ b/test/symmetry_spinless_fermion_lanczos.sh
@@ -233,6 +233,24 @@ run_mpi_symmetry_case() {
         echo "TransSym SpinlessFermion MPI path unexpectedly used site decomposition."
         exit 1
     fi
+
+    log_file="spinless_${label}_halo_mpi.log"
+    rm -rf output
+    if ! env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+        ${MPIRUN} ../../src/HPhi -e namelist.def > "${log_file}" 2>&1; then
+        cat "${log_file}"
+        exit 1
+    fi
+    mpi_energy=`awk '$1 == "Energy" {print $2; exit}' output/zvo_energy.dat`
+    test -n "${mpi_energy}"
+    mpi_diff=`awk -v a="${mpi_energy}" -v b="${expected_energy}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%8.6f", d}'`
+    if [ "${mpi_diff}" != "0.000000" ]; then
+        cat "${log_file}"
+        echo "MPI halo energy mismatch: got ${mpi_energy}, expected ${expected_energy}"
+        exit 1
+    fi
+    grep -q "Symmetry basis: raw_dim=.* sector_dim=${expected_dim} group_order=4" "${log_file}"
+    grep -q "vector_exchange=halo" "${log_file}"
 }
 
 run_mpi_if_available() {
@@ -281,6 +299,11 @@ write_kpi2_transsym
 ../../src/HPhi -e namelist.def > spinless_kpi2.log 2>&1
 assert_energy "-2.0" spinless_kpi2.log
 grep -q "Symmetry basis: raw_dim=6 sector_dim=2 group_order=4" spinless_kpi2.log
+rm -rf output
+env HPHI_SYMMETRY_VECTOR_EXCHANGE=halo \
+    ../../src/HPhi -e namelist.def > spinless_kpi2_halo.log 2>&1
+assert_energy "-2.0" spinless_kpi2_halo.log
+grep -q "vector_exchange=halo" spinless_kpi2_halo.log
 run_mpi_if_available kpi2 "-2.0" 2
 
 rm -rf output

--- a/test/symmetry_spinless_fermion_standard_generation.sh
+++ b/test/symmetry_spinless_fermion_standard_generation.sh
@@ -99,6 +99,8 @@ run_case() {
     grep -q "CalcModel   7" calcmod.def
     grep -q "Ncond          ${ncond}" modpara.def
     grep -q "Symmetry basis: raw_dim=${expected_raw_dim} sector_dim=${expected_sector_dim} group_order=4" auto.log
+    grep -q "Symmetry matvec: mode=plan vector_exchange=halo" auto.log
+    grep -q "columns=local/ghost-slots" auto.log
     awk -v re0="${char_op1_re}" -v im0="${char_op1_im}" '
       NF == 3 && $1 == 1 {
         found = 1;
@@ -120,6 +122,8 @@ run_case() {
     test -n "${expert_energy}" || { cat expert.log; exit 1; }
     assert_close "${auto_energy}" "${expert_energy}"
     grep -q "Symmetry basis: raw_dim=${expected_raw_dim} sector_dim=${expected_sector_dim} group_order=4" expert.log
+    grep -q "Symmetry matvec: mode=plan vector_exchange=halo" expert.log
+    grep -q "columns=local/ghost-slots" expert.log
     cd ../..
 }
 

--- a/test/unittest_symmetry_basis.c
+++ b/test/unittest_symmetry_basis.c
@@ -970,6 +970,36 @@ static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
                 "plan snapshot guard");
   X->Sym->local_offset--;
 
+  memset(output, 0, ((size_t)X->Sym->dim + 1U) * sizeof(*output));
+  plan_prdct = 0.0;
+  if (setenv("HPHI_SYMMETRY_VECTOR_EXCHANGE", "halo", 1) != 0 ||
+      BuildSymmetryMatvecPlan(X) != 0) {
+    fprintf(stderr, "%s: serial halo plan setup failed\n", label);
+    exit(1);
+  }
+  unsetenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
+  plan = X->Sym->matvec_plan;
+  assert_int_eq(plan != NULL && plan->ready == TRUE, 1, label);
+  assert_int_eq(plan->columns_remapped, TRUE, label);
+  assert_int_eq(X->Sym->vector_exchange_mode,
+                SYMMETRY_VECTOR_EXCHANGE_HALO, label);
+  assert_int_eq(X->Sym->mpi_full_v1 == NULL, 1, label);
+  for (p = 0U; p < plan->nnz; p++) {
+    assert_int_eq(plan->col_index[p] <
+                      plan->local_dim + plan->halo.ghost_count,
+                  1, label);
+  }
+  assert_int_eq(ExchangeSymmetryVectorHalo(&plan->halo, input), 0, label);
+  assert_int_eq(ApplySymmetryMatvecPlan(X, output, input, &plan_prdct), -1,
+                "global-column apply rejects remapped plan");
+  assert_int_eq(
+      ApplySymmetryMatvecPlanHalo(X, output, input, &plan_prdct), 0, label);
+  for (alpha = 1UL; alpha <= plan->dim; alpha++) {
+    assert_complex_close(output[alpha], legacy_output[alpha], 1.0e-12, label);
+  }
+  assert_complex_close(plan_prdct, expected_prdct, 1.0e-12, label);
+  assert_ulong_eq((unsigned long int)plan->halo.exchange_calls, 1UL, label);
+
   free(dense);
   free(multiplicity);
   free(input);
@@ -1352,6 +1382,43 @@ static void assert_remote_topology_plan(const char *label)
   free(list_Diagonal);
   list_1 = NULL;
   list_Diagonal = NULL;
+}
+
+static void assert_mixed_column_remap(const char *label)
+{
+  unsigned long int columns[] = {5UL, 1UL, 4UL, 8UL, 10UL, 7UL};
+  const unsigned long int expected_slots[] = {0UL, 3UL, 4UL, 5UL, 6UL, 2UL};
+  unsigned long int missing_ghost_column[] = {9UL};
+  unsigned long int ghosts[] = {1UL, 4UL, 8UL, 10UL};
+  struct SymmetryMatvecPlan plan;
+  struct SymmetryMatvecPlan invalid_plan;
+  size_t index;
+  memset(&plan, 0, sizeof(plan));
+  plan.dim = 10UL;
+  plan.local_offset = 4UL;
+  plan.local_dim = 3UL;
+  plan.nnz = sizeof(columns) / sizeof(columns[0]);
+  plan.col_index = columns;
+  plan.halo.ghost_count = sizeof(ghosts) / sizeof(ghosts[0]);
+  plan.halo.ghost_global_index = ghosts;
+  assert_int_eq(RemapSymmetryMatvecPlanColumns(&plan), 0, label);
+  assert_int_eq(plan.columns_remapped, TRUE, label);
+  for (index = 0U; index < plan.nnz; index++) {
+    assert_ulong_eq(plan.col_index[index], expected_slots[index], label);
+  }
+  assert_int_eq(RemapSymmetryMatvecPlanColumns(&plan), -1,
+                "column remap rejects a second in-place remap");
+
+  memset(&invalid_plan, 0, sizeof(invalid_plan));
+  invalid_plan.dim = plan.dim;
+  invalid_plan.local_offset = plan.local_offset;
+  invalid_plan.local_dim = plan.local_dim;
+  invalid_plan.nnz = 1U;
+  invalid_plan.col_index = missing_ghost_column;
+  invalid_plan.halo.ghost_count = plan.halo.ghost_count;
+  invalid_plan.halo.ghost_global_index = ghosts;
+  assert_int_eq(RemapSymmetryMatvecPlanColumns(&invalid_plan), -1,
+                "column remap rejects a missing ghost index");
 }
 
 static void assert_zero_row_plan(const char *label)
@@ -1898,6 +1965,8 @@ int main(void)
       "halo owner mapping and request layout are deterministic");
   assert_remote_topology_plan(
       "local-row plan reports remote-column topology without changing CSR");
+  assert_mixed_column_remap(
+      "mixed local/remote columns remap to bounded local/ghost slots");
   assert_zero_row_plan("local-row plan supports zero-row rank");
   assert_representative_hash_matches_basis(6, 3, 1,
                                            "C6 k=pi/3 representative hash matches basis");

--- a/test/unittest_symmetry_basis.c
+++ b/test/unittest_symmetry_basis.c
@@ -870,10 +870,13 @@ static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
   unsigned int *multiplicity;
   struct SymmetryMatvecPlan *plan;
 
-  if (ActivateSymmetryBasisDimension(X) != 0 || BuildSymmetryMatvecPlan(X) != 0) {
+  if (setenv("HPHI_SYMMETRY_VECTOR_EXCHANGE", "allgather", 1) != 0 ||
+      ActivateSymmetryBasisDimension(X) != 0 ||
+      BuildSymmetryMatvecPlan(X) != 0) {
     fprintf(stderr, "%s: plan setup failed\n", label);
     exit(1);
   }
+  unsetenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
   plan = X->Sym->matvec_plan;
   assert_int_eq(plan != NULL && plan->ready == TRUE, 1, label);
   assert_ulong_eq(plan->dim, X->Sym->dim, label);
@@ -1000,12 +1003,10 @@ static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
 
   memset(output, 0, ((size_t)X->Sym->dim + 1U) * sizeof(*output));
   plan_prdct = 0.0;
-  if (setenv("HPHI_SYMMETRY_VECTOR_EXCHANGE", "halo", 1) != 0 ||
-      BuildSymmetryMatvecPlan(X) != 0) {
-    fprintf(stderr, "%s: serial halo plan setup failed\n", label);
+  if (BuildSymmetryMatvecPlan(X) != 0) {
+    fprintf(stderr, "%s: default serial halo plan setup failed\n", label);
     exit(1);
   }
-  unsetenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
   plan = X->Sym->matvec_plan;
   assert_int_eq(plan != NULL && plan->ready == TRUE, 1, label);
   assert_int_eq(plan->columns_remapped, TRUE, label);
@@ -1240,7 +1241,8 @@ static void assert_parallel_plan_matches_serial(const char *label)
   setup_hubbard_bind(&X, 6, 3, 3, 1);
   setup_hubbard_transfer_ring(&X.Def, 6);
   setup_hubbard_coulomb_intra(&X.Def, 6, 0.5);
-  if (BuildSymmetryBasis(&X) != 0 ||
+  if (setenv("HPHI_SYMMETRY_VECTOR_EXCHANGE", "allgather", 1) != 0 ||
+      BuildSymmetryBasis(&X) != 0 ||
       ActivateSymmetryBasisDimension(&X) != 0 ||
       BuildSymmetryMatvecPlan(&X) != 0) {
     fprintf(stderr, "%s: serial plan setup failed\n", label);
@@ -1275,6 +1277,7 @@ static void assert_parallel_plan_matches_serial(const char *label)
     exit(1);
   }
   parallel_plan = X.Sym->matvec_plan;
+  unsetenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
   assert_ulong_eq((unsigned long int)parallel_plan->nnz,
                   (unsigned long int)serial_nnz, label);
   assert_ulong_eq((unsigned long int)parallel_plan->row_nnz_max,
@@ -1389,11 +1392,13 @@ static void assert_remote_topology_plan(const char *label)
   }
   nproc = 4;
   myrank = 0;
-  if (ActivateSymmetryBasisDimension(&X) != 0 ||
+  if (setenv("HPHI_SYMMETRY_VECTOR_EXCHANGE", "allgather", 1) != 0 ||
+      ActivateSymmetryBasisDimension(&X) != 0 ||
       BuildSymmetryMatvecPlan(&X) != 0) {
     fprintf(stderr, "%s: remote topology plan setup failed\n", label);
     exit(1);
   }
+  unsetenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
   plan = X.Sym->matvec_plan;
   assert_int_eq(plan != NULL && plan->ready == TRUE, 1, label);
   assert_ulong_eq(
@@ -1606,10 +1611,13 @@ static void assert_zero_row_plan(const char *label)
   }
   nproc = 2;
   myrank = 1;
-  if (ActivateSymmetryBasisDimension(&X) != 0 || BuildSymmetryMatvecPlan(&X) != 0) {
+  if (setenv("HPHI_SYMMETRY_VECTOR_EXCHANGE", "allgather", 1) != 0 ||
+      ActivateSymmetryBasisDimension(&X) != 0 ||
+      BuildSymmetryMatvecPlan(&X) != 0) {
     fprintf(stderr, "%s: zero-row plan setup failed\n", label);
     exit(1);
   }
+  unsetenv("HPHI_SYMMETRY_VECTOR_EXCHANGE");
   assert_ulong_eq(X.Sym->local_dim, 0UL, label);
   assert_int_eq(X.Sym->matvec_plan != NULL, 1, label);
   assert_ulong_eq((unsigned long int)X.Sym->matvec_plan->nnz, 0UL, label);

--- a/test/unittest_symmetry_basis.c
+++ b/test/unittest_symmetry_basis.c
@@ -656,6 +656,21 @@ static void assert_complex_close(double complex got,
   }
 }
 
+static uint64_t symmetry_plan_column_slot(
+    const struct SymmetryMatvecPlan *plan, size_t column)
+{
+  if (plan->column_slot_width == SYMMETRY_COLUMN_U32 &&
+      plan->column_slot32 != NULL) {
+    return (uint64_t)plan->column_slot32[column];
+  }
+  if (plan->column_slot_width == SYMMETRY_COLUMN_U64 &&
+      plan->column_slot64 != NULL) {
+    return plan->column_slot64[column];
+  }
+  fprintf(stderr, "column slot storage is not initialized\n");
+  exit(1);
+}
+
 static void reference_fermion_permutation(unsigned long int state,
                                           const int *perm,
                                           unsigned int nsite,
@@ -877,6 +892,19 @@ static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
                   label);
   assert_int_eq(plan->halo.schedule_checksum != 0ULL, 1, label);
   assert_ulong_eq((unsigned long int)plan->column_slot_width, 32UL, label);
+  assert_int_eq(plan->nnz == 0U || plan->col_index != NULL, 1, label);
+  assert_int_eq(plan->column_slot32 == NULL, 1, label);
+  assert_int_eq(plan->column_slot64 == NULL, 1, label);
+  assert_ulong_eq(
+      (unsigned long int)plan->column_storage_bytes,
+      (unsigned long int)(plan->nnz * sizeof(*plan->col_index)), label);
+  assert_ulong_eq(
+      (unsigned long int)plan->matrix_storage_bytes,
+      (unsigned long int)(
+          ((size_t)plan->local_dim + 1U) * sizeof(*plan->row_ptr) +
+          plan->nnz *
+              (sizeof(*plan->col_index) + sizeof(*plan->values))),
+      label);
   assert_ulong_eq(
       (unsigned long int)plan->allgather_nonlocal_values_per_call, 0UL, label);
   assert_ulong_eq(
@@ -984,9 +1012,24 @@ static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
   assert_int_eq(X->Sym->vector_exchange_mode,
                 SYMMETRY_VECTOR_EXCHANGE_HALO, label);
   assert_int_eq(X->Sym->mpi_full_v1 == NULL, 1, label);
+  assert_int_eq(plan->col_index == NULL, 1, label);
+  assert_int_eq(plan->nnz == 0U || plan->column_slot32 != NULL, 1, label);
+  assert_int_eq(plan->column_slot64 == NULL, 1, label);
+  assert_int_eq(plan->halo.ghost_global_index == NULL, 1, label);
+  assert_ulong_eq(
+      (unsigned long int)plan->column_storage_bytes,
+      (unsigned long int)(plan->nnz * sizeof(*plan->column_slot32)), label);
+  assert_ulong_eq(
+      (unsigned long int)plan->matrix_storage_bytes,
+      (unsigned long int)(
+          ((size_t)plan->local_dim + 1U) * sizeof(*plan->row_ptr) +
+          plan->nnz *
+              (sizeof(*plan->column_slot32) + sizeof(*plan->values))),
+      label);
   for (p = 0U; p < plan->nnz; p++) {
-    assert_int_eq(plan->col_index[p] <
-                      plan->local_dim + plan->halo.ghost_count,
+    assert_int_eq(symmetry_plan_column_slot(plan, p) <
+                      (uint64_t)plan->local_dim +
+                          (uint64_t)plan->halo.ghost_count,
                   1, label);
   }
   assert_int_eq(ExchangeSymmetryVectorHalo(&plan->halo, input), 0, label);
@@ -1386,25 +1429,40 @@ static void assert_remote_topology_plan(const char *label)
 
 static void assert_mixed_column_remap(const char *label)
 {
-  unsigned long int columns[] = {5UL, 1UL, 4UL, 8UL, 10UL, 7UL};
+  const unsigned long int initial_columns[] =
+      {5UL, 1UL, 4UL, 8UL, 10UL, 7UL};
   const unsigned long int expected_slots[] = {0UL, 3UL, 4UL, 5UL, 6UL, 2UL};
   unsigned long int missing_ghost_column[] = {9UL};
   unsigned long int ghosts[] = {1UL, 4UL, 8UL, 10UL};
+  unsigned long int *columns;
   struct SymmetryMatvecPlan plan;
   struct SymmetryMatvecPlan invalid_plan;
   size_t index;
+  columns = (unsigned long int *)malloc(sizeof(initial_columns));
+  if (columns == NULL) {
+    fprintf(stderr, "%s: column allocation failed\n", label);
+    exit(1);
+  }
+  memcpy(columns, initial_columns, sizeof(initial_columns));
   memset(&plan, 0, sizeof(plan));
   plan.dim = 10UL;
   plan.local_offset = 4UL;
   plan.local_dim = 3UL;
-  plan.nnz = sizeof(columns) / sizeof(columns[0]);
+  plan.nnz = sizeof(initial_columns) / sizeof(initial_columns[0]);
   plan.col_index = columns;
   plan.halo.ghost_count = sizeof(ghosts) / sizeof(ghosts[0]);
   plan.halo.ghost_global_index = ghosts;
   assert_int_eq(RemapSymmetryMatvecPlanColumns(&plan), 0, label);
   assert_int_eq(plan.columns_remapped, TRUE, label);
+  assert_int_eq(plan.col_index == NULL, 1, label);
+  assert_ulong_eq(
+      (unsigned long int)plan.column_slot_width,
+      (unsigned long int)SYMMETRY_COLUMN_U32, label);
+  assert_int_eq(plan.column_slot32 != NULL, 1, label);
+  assert_int_eq(plan.column_slot64 == NULL, 1, label);
   for (index = 0U; index < plan.nnz; index++) {
-    assert_ulong_eq(plan.col_index[index], expected_slots[index], label);
+    assert_ulong_eq((unsigned long int)symmetry_plan_column_slot(&plan, index),
+                    expected_slots[index], label);
   }
   assert_int_eq(RemapSymmetryMatvecPlanColumns(&plan), -1,
                 "column remap rejects a second in-place remap");
@@ -1419,6 +1477,120 @@ static void assert_mixed_column_remap(const char *label)
   invalid_plan.halo.ghost_global_index = ghosts;
   assert_int_eq(RemapSymmetryMatvecPlanColumns(&invalid_plan), -1,
                 "column remap rejects a missing ghost index");
+  free(plan.column_slot32);
+  free(plan.column_slot64);
+}
+
+static void assert_column_slot_width_boundaries(const char *label)
+{
+  struct SymmetryMatvecPlan plan32;
+  unsigned long int *column32 =
+      (unsigned long int *)malloc(sizeof(*column32));
+  if (column32 == NULL) {
+    fprintf(stderr, "%s: 32-bit boundary allocation failed\n", label);
+    exit(1);
+  }
+  *column32 = (unsigned long int)UINT32_MAX;
+  memset(&plan32, 0, sizeof(plan32));
+  plan32.dim = (unsigned long int)UINT32_MAX;
+  plan32.local_dim = (unsigned long int)UINT32_MAX;
+  plan32.nnz = 1U;
+  plan32.col_index = column32;
+  assert_int_eq(RemapSymmetryMatvecPlanColumns(&plan32), 0, label);
+  assert_ulong_eq(
+      (unsigned long int)plan32.column_slot_width,
+      (unsigned long int)SYMMETRY_COLUMN_U32, label);
+  assert_ulong_eq(
+      (unsigned long int)symmetry_plan_column_slot(&plan32, 0U),
+      (unsigned long int)UINT32_MAX - 1UL, label);
+  free(plan32.column_slot32);
+  free(plan32.column_slot64);
+
+#if ULONG_MAX > UINT32_MAX
+  {
+    struct SymmetryMatvecPlan plan64;
+    unsigned long int *column64 =
+        (unsigned long int *)malloc(sizeof(*column64));
+    unsigned long int count64 = (unsigned long int)UINT32_MAX + 2UL;
+    if (column64 == NULL) {
+      fprintf(stderr, "%s: 64-bit boundary allocation failed\n", label);
+      exit(1);
+    }
+    *column64 = count64;
+    memset(&plan64, 0, sizeof(plan64));
+    plan64.dim = count64;
+    plan64.local_dim = count64;
+    plan64.nnz = 1U;
+    plan64.col_index = column64;
+    assert_int_eq(RemapSymmetryMatvecPlanColumns(&plan64), 0, label);
+    assert_ulong_eq(
+        (unsigned long int)plan64.column_slot_width,
+        (unsigned long int)SYMMETRY_COLUMN_U64, label);
+    assert_ulong_eq(
+        (unsigned long int)symmetry_plan_column_slot(&plan64, 0U),
+        (unsigned long int)UINT32_MAX + 1UL, label);
+    free(plan64.column_slot32);
+    free(plan64.column_slot64);
+  }
+#endif
+}
+
+static void assert_u64_column_slot_apply(const char *label)
+{
+#if ULONG_MAX > UINT32_MAX
+  struct BindStruct X;
+  struct SymmetryBasisRuntime sym;
+  struct SymmetryMatvecPlan plan;
+  size_t row_ptr[] = {0U, 1U};
+  uint64_t column_slot64[] = {0U};
+  double complex values[] = {2.0 - I};
+  double complex ghost_value = 3.0 + 4.0 * I;
+  double complex input[] = {0.0, 1.0 + 2.0 * I};
+  double complex output[] = {0.0, 0.0};
+  double complex prdct = 0.0;
+  double complex expected = values[0] * input[1];
+  memset(&X, 0, sizeof(X));
+  memset(&sym, 0, sizeof(sym));
+  memset(&plan, 0, sizeof(plan));
+  X.Sym = &sym;
+  sym.dim = (unsigned long int)UINT32_MAX + 1UL;
+  sym.local_dim = 1UL;
+  sym.matvec_plan = &plan;
+  plan.ready = TRUE;
+  plan.columns_remapped = TRUE;
+  plan.dim = sym.dim;
+  plan.local_dim = sym.local_dim;
+  plan.nnz = 1U;
+  plan.row_ptr = row_ptr;
+  plan.column_slot_width = SYMMETRY_COLUMN_U64;
+  plan.column_slot64 = column_slot64;
+  plan.values = values;
+  plan.halo.ready = TRUE;
+  plan.halo.ghost_count = (size_t)UINT32_MAX;
+  plan.halo.ghost_values = &ghost_value;
+  assert_int_eq(
+      ApplySymmetryMatvecPlanHalo(&X, output, input, &prdct), 0, label);
+  assert_complex_close(output[1], expected, 1.0e-12, label);
+  assert_complex_close(prdct, conj(input[1]) * expected, 1.0e-12, label);
+
+  column_slot64[0] = 1U;
+  output[1] = 0.0;
+  prdct = 0.0;
+  expected = values[0] * ghost_value;
+  assert_int_eq(
+      ApplySymmetryMatvecPlanHalo(&X, output, input, &prdct), 0, label);
+  assert_complex_close(output[1], expected, 1.0e-12, label);
+  assert_complex_close(prdct, conj(input[1]) * expected, 1.0e-12, label);
+
+  column_slot64[0] = (uint64_t)UINT32_MAX + 1ULL;
+  output[1] = 0.0;
+  prdct = 0.0;
+  assert_int_eq(
+      ApplySymmetryMatvecPlanHalo(&X, output, input, &prdct), -1,
+      "64-bit column apply rejects an out-of-range slot");
+#else
+  (void)label;
+#endif
 }
 
 static void assert_zero_row_plan(const char *label)
@@ -1967,6 +2139,10 @@ int main(void)
       "local-row plan reports remote-column topology without changing CSR");
   assert_mixed_column_remap(
       "mixed local/remote columns remap to bounded local/ghost slots");
+  assert_column_slot_width_boundaries(
+      "column slot storage switches at the UINT32_MAX boundary");
+  assert_u64_column_slot_apply(
+      "64-bit column slot apply preserves values and bounds checks");
   assert_zero_row_plan("local-row plan supports zero-row rank");
   assert_representative_hash_matches_basis(6, 3, 1,
                                            "C6 k=pi/3 representative hash matches basis");

--- a/test/unittest_symmetry_basis.c
+++ b/test/unittest_symmetry_basis.c
@@ -863,6 +863,18 @@ static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
   assert_ulong_eq(plan->dim, X->Sym->dim, label);
   assert_ulong_eq(plan->local_offset, 0UL, label);
   assert_ulong_eq(plan->local_dim, X->Sym->dim, label);
+  assert_ulong_eq((unsigned long int)plan->local_column_nnz,
+                  (unsigned long int)plan->nnz, label);
+  assert_ulong_eq((unsigned long int)plan->remote_column_nnz, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->ghost_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->send_value_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->incoming_peer_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->outgoing_peer_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->column_slot_width, 32UL, label);
+  assert_ulong_eq(
+      (unsigned long int)plan->allgather_nonlocal_values_per_call, 0UL, label);
+  assert_ulong_eq(
+      (unsigned long int)plan->allgather_payload_bytes_per_call, 0UL, label);
 
   if (plan->dim > SIZE_MAX / plan->dim) {
     fprintf(stderr, "%s: dense matrix size overflow\n", label);
@@ -1213,6 +1225,51 @@ static void assert_parallel_plan_matches_serial(const char *label)
 }
 #endif
 
+static void assert_remote_topology_plan(const char *label)
+{
+  struct BindStruct X;
+  struct SymmetryMatvecPlan *plan;
+  setup_bind(&X, 6, 3, 1);
+  if (BuildSymmetryBasis(&X) != 0) {
+    fprintf(stderr, "%s: BuildSymmetryBasis failed\n", label);
+    exit(1);
+  }
+  nproc = 4;
+  myrank = 0;
+  if (ActivateSymmetryBasisDimension(&X) != 0 ||
+      BuildSymmetryMatvecPlan(&X) != 0) {
+    fprintf(stderr, "%s: remote topology plan setup failed\n", label);
+    exit(1);
+  }
+  plan = X.Sym->matvec_plan;
+  assert_int_eq(plan != NULL && plan->ready == TRUE, 1, label);
+  assert_ulong_eq(
+      (unsigned long int)(plan->local_column_nnz + plan->remote_column_nnz),
+      (unsigned long int)plan->nnz, label);
+  assert_int_eq(plan->remote_column_nnz > 0U, 1, label);
+  assert_int_eq(plan->ghost_count > 0U, 1, label);
+  assert_int_eq(plan->ghost_count <= plan->remote_column_nnz, 1, label);
+  assert_int_eq(plan->incoming_peer_count > 0U, 1, label);
+  assert_int_eq(plan->max_recv_from_peer > 0U, 1, label);
+  assert_ulong_eq((unsigned long int)plan->send_value_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->outgoing_peer_count, 0UL, label);
+  assert_int_eq(plan->topology_scratch_bytes > 0U, 1, label);
+  assert_ulong_eq((unsigned long int)plan->column_slot_width, 32UL, label);
+  assert_ulong_eq(
+      (unsigned long int)plan->allgather_nonlocal_values_per_call,
+      X.Sym->dim - X.Sym->local_dim, label);
+  assert_ulong_eq(
+      (unsigned long int)plan->allgather_payload_bytes_per_call,
+      (X.Sym->dim - X.Sym->local_dim) * sizeof(double complex), label);
+  nproc = 1;
+  myrank = 0;
+  FreeSymmetryBasis(X.Sym);
+  free(list_1);
+  free(list_Diagonal);
+  list_1 = NULL;
+  list_Diagonal = NULL;
+}
+
 static void assert_zero_row_plan(const char *label)
 {
   struct BindStruct X;
@@ -1234,6 +1291,12 @@ static void assert_zero_row_plan(const char *label)
   assert_int_eq(X.Sym->matvec_plan != NULL, 1, label);
   assert_ulong_eq((unsigned long int)X.Sym->matvec_plan->nnz, 0UL, label);
   assert_ulong_eq((unsigned long int)X.Sym->matvec_plan->row_nnz_max, 0UL, label);
+  assert_ulong_eq(
+      (unsigned long int)X.Sym->matvec_plan->remote_column_nnz, 0UL, label);
+  assert_ulong_eq((unsigned long int)X.Sym->matvec_plan->ghost_count, 0UL,
+                  label);
+  assert_ulong_eq(
+      (unsigned long int)X.Sym->matvec_plan->column_slot_width, 32UL, label);
   assert_int_eq(ApplySymmetryMatvecPlan(&X, output, input, &prdct), 0, label);
   assert_complex_close(prdct, 0.0, 1.0e-12, label);
   nproc = 1;
@@ -1745,6 +1808,8 @@ int main(void)
   assert_parallel_plan_matches_serial(
       "Hubbard plan CSR is identical for one and four OpenMP threads");
 #endif
+  assert_remote_topology_plan(
+      "local-row plan reports remote-column topology without changing CSR");
   assert_zero_row_plan("local-row plan supports zero-row rank");
   assert_representative_hash_matches_basis(6, 3, 1,
                                            "C6 k=pi/3 representative hash matches basis");

--- a/test/unittest_symmetry_basis.c
+++ b/test/unittest_symmetry_basis.c
@@ -6,6 +6,7 @@
 #include "DefCommon.h"
 #include "symmetry_basis.h"
 #include "symmetry_matvec_plan.h"
+#include "symmetry_vector_halo.h"
 #include "struct.h"
 
 #ifdef _OPENMP
@@ -866,10 +867,15 @@ static void assert_plan_matches_canonicalized_matrix(struct BindStruct *X,
   assert_ulong_eq((unsigned long int)plan->local_column_nnz,
                   (unsigned long int)plan->nnz, label);
   assert_ulong_eq((unsigned long int)plan->remote_column_nnz, 0UL, label);
-  assert_ulong_eq((unsigned long int)plan->ghost_count, 0UL, label);
-  assert_ulong_eq((unsigned long int)plan->send_value_count, 0UL, label);
-  assert_ulong_eq((unsigned long int)plan->incoming_peer_count, 0UL, label);
-  assert_ulong_eq((unsigned long int)plan->outgoing_peer_count, 0UL, label);
+  assert_int_eq(plan->halo.request_layout_ready, TRUE, label);
+  assert_int_eq(plan->halo.ready, TRUE, label);
+  assert_ulong_eq((unsigned long int)plan->halo.ghost_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->halo.send_value_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->halo.incoming_peer_count, 0UL,
+                  label);
+  assert_ulong_eq((unsigned long int)plan->halo.outgoing_peer_count, 0UL,
+                  label);
+  assert_int_eq(plan->halo.schedule_checksum != 0ULL, 1, label);
   assert_ulong_eq((unsigned long int)plan->column_slot_width, 32UL, label);
   assert_ulong_eq(
       (unsigned long int)plan->allgather_nonlocal_values_per_call, 0UL, label);
@@ -1225,6 +1231,80 @@ static void assert_parallel_plan_matches_serial(const char *label)
 }
 #endif
 
+static void assert_vector_owner_and_request_layout(const char *label)
+{
+  const unsigned long int columns[] = {5UL, 1UL, 1UL, 4UL,
+                                       8UL, 10UL, 8UL};
+  const unsigned long int expected_ghosts[] = {1UL, 4UL, 8UL, 10UL};
+  struct SymmetryVectorHaloPlan first;
+  struct SymmetryVectorHaloPlan second;
+  size_t local_columns = 0U;
+  size_t remote_columns = 0U;
+  size_t index;
+
+  memset(&first, 0, sizeof(first));
+  memset(&second, 0, sizeof(second));
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(10UL, 3, 1UL), 0, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(10UL, 3, 4UL), 0, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(10UL, 3, 5UL), 1, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(10UL, 3, 7UL), 1, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(10UL, 3, 8UL), 2, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(10UL, 3, 10UL), 2, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(2UL, 4, 1UL), 0, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(2UL, 4, 2UL), 1, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(2UL, 4, 0UL), -1, label);
+  assert_int_eq(SymmetryVectorOwnerOfGlobalIndex(2UL, 4, 3UL), -1, label);
+
+  assert_int_eq(
+      BuildSymmetryVectorHaloPlan(
+          &first, 10UL, 4UL, 3UL, columns,
+          sizeof(columns) / sizeof(columns[0]), 3, 1,
+          &local_columns, &remote_columns),
+      0, label);
+  assert_ulong_eq((unsigned long int)local_columns, 1UL, label);
+  assert_ulong_eq((unsigned long int)remote_columns, 6UL, label);
+  assert_int_eq(first.request_layout_ready, TRUE, label);
+  assert_int_eq(first.ready, FALSE, label);
+  assert_ulong_eq((unsigned long int)first.ghost_count, 4UL, label);
+  assert_ulong_eq((unsigned long int)first.incoming_peer_count, 2UL, label);
+  assert_ulong_eq((unsigned long int)first.max_recv_from_peer, 2UL, label);
+  assert_int_eq(first.recv_counts[0], 2, label);
+  assert_int_eq(first.recv_counts[1], 0, label);
+  assert_int_eq(first.recv_counts[2], 2, label);
+  assert_int_eq(first.recv_displs[0], 0, label);
+  assert_int_eq(first.recv_displs[1], 2, label);
+  assert_int_eq(first.recv_displs[2], 2, label);
+  for (index = 0U; index < first.ghost_count; index++) {
+    assert_ulong_eq(first.ghost_global_index[index],
+                    expected_ghosts[index], label);
+  }
+
+  local_columns = 0U;
+  remote_columns = 0U;
+  assert_int_eq(
+      BuildSymmetryVectorHaloPlan(
+          &second, 10UL, 4UL, 3UL, columns,
+          sizeof(columns) / sizeof(columns[0]), 3, 1,
+          &local_columns, &remote_columns),
+      0, label);
+  assert_int_eq(first.schedule_checksum == second.schedule_checksum, 1,
+                label);
+  assert_int_eq(
+      memcmp(first.ghost_global_index, second.ghost_global_index,
+             first.ghost_count * sizeof(*first.ghost_global_index)) == 0,
+      1, label);
+  FreeSymmetryVectorHaloPlan(&first);
+  FreeSymmetryVectorHaloPlan(&second);
+
+  memset(&first, 0, sizeof(first));
+  assert_int_eq(
+      BuildSymmetryVectorHaloPlan(
+          &first, 10UL, 3UL, 3UL, columns,
+          sizeof(columns) / sizeof(columns[0]), 3, 1,
+          &local_columns, &remote_columns),
+      -1, label);
+}
+
 static void assert_remote_topology_plan(const char *label)
 {
   struct BindStruct X;
@@ -1247,13 +1327,17 @@ static void assert_remote_topology_plan(const char *label)
       (unsigned long int)(plan->local_column_nnz + plan->remote_column_nnz),
       (unsigned long int)plan->nnz, label);
   assert_int_eq(plan->remote_column_nnz > 0U, 1, label);
-  assert_int_eq(plan->ghost_count > 0U, 1, label);
-  assert_int_eq(plan->ghost_count <= plan->remote_column_nnz, 1, label);
-  assert_int_eq(plan->incoming_peer_count > 0U, 1, label);
-  assert_int_eq(plan->max_recv_from_peer > 0U, 1, label);
-  assert_ulong_eq((unsigned long int)plan->send_value_count, 0UL, label);
-  assert_ulong_eq((unsigned long int)plan->outgoing_peer_count, 0UL, label);
-  assert_int_eq(plan->topology_scratch_bytes > 0U, 1, label);
+  assert_int_eq(plan->halo.request_layout_ready, TRUE, label);
+  assert_int_eq(plan->halo.ready, FALSE, label);
+  assert_int_eq(plan->halo.ghost_count > 0U, 1, label);
+  assert_int_eq(plan->halo.ghost_count <= plan->remote_column_nnz, 1, label);
+  assert_int_eq(plan->halo.incoming_peer_count > 0U, 1, label);
+  assert_int_eq(plan->halo.max_recv_from_peer > 0U, 1, label);
+  assert_ulong_eq((unsigned long int)plan->halo.send_value_count, 0UL, label);
+  assert_ulong_eq((unsigned long int)plan->halo.outgoing_peer_count, 0UL,
+                  label);
+  assert_int_eq(plan->halo.topology_scratch_bytes > 0U, 1, label);
+  assert_int_eq(plan->halo.schedule_checksum != 0ULL, 1, label);
   assert_ulong_eq((unsigned long int)plan->column_slot_width, 32UL, label);
   assert_ulong_eq(
       (unsigned long int)plan->allgather_nonlocal_values_per_call,
@@ -1293,8 +1377,10 @@ static void assert_zero_row_plan(const char *label)
   assert_ulong_eq((unsigned long int)X.Sym->matvec_plan->row_nnz_max, 0UL, label);
   assert_ulong_eq(
       (unsigned long int)X.Sym->matvec_plan->remote_column_nnz, 0UL, label);
-  assert_ulong_eq((unsigned long int)X.Sym->matvec_plan->ghost_count, 0UL,
-                  label);
+  assert_int_eq(X.Sym->matvec_plan->halo.request_layout_ready, TRUE, label);
+  assert_int_eq(X.Sym->matvec_plan->halo.ready, FALSE, label);
+  assert_ulong_eq(
+      (unsigned long int)X.Sym->matvec_plan->halo.ghost_count, 0UL, label);
   assert_ulong_eq(
       (unsigned long int)X.Sym->matvec_plan->column_slot_width, 32UL, label);
   assert_int_eq(ApplySymmetryMatvecPlan(&X, output, input, &prdct), 0, label);
@@ -1808,6 +1894,8 @@ int main(void)
   assert_parallel_plan_matches_serial(
       "Hubbard plan CSR is identical for one and four OpenMP threads");
 #endif
+  assert_vector_owner_and_request_layout(
+      "halo owner mapping and request layout are deterministic");
   assert_remote_topology_plan(
       "local-row plan reports remote-column topology without changing CSR");
   assert_zero_row_plan("local-row plan supports zero-row rank");


### PR DESCRIPTION
## Summary

- build a persistent peer schedule from the remote columns referenced by each rank's local symmetry-matvec rows
- replace the production plan's full-vector `MPI_Allgatherv` with an `MPI_Alltoallv` halo exchange of only the required vector values
- remap global CSR columns to local/ghost slots and compress those slots with adaptive 32/64-bit storage
- keep explicit plan/Allgather and legacy rollback paths while making plan/halo the default
- add topology, communication, memory, and timing diagnostics together with unit and MPI integration coverage

## Motivation

After the local-row matvec plan removed the replicated transition scan, each MPI rank still gathered and stored the full input vector on every matvec. A rank only needs the unique remote columns referenced by its owned rows. This change communicates those values directly and removes the full-vector allocation from the production halo path.

## User impact

- No input syntax changes are required.
- MomentumIndex plan mode now uses halo exchange by default.
- `HPHI_SYMMETRY_VECTOR_EXCHANGE=allgather` retains the plan/Allgather developer rollback path.
- `HPHI_SYMMETRY_MATVEC=legacy` retains the legacy reference path.
- The existing `Symmetry matvec:` diagnostic reports the selected exchange and column layout.

## Performance

Measured on the Kagome30 `k=(0,0)` fixed-six-matvec workload using up to 8 nodes, 16 MPI ranks per node, and 8 OpenMP threads per rank:

- production halo reduced rank-max matvec time by 20.8--54.3% relative to the default Allgatherv at 8/16/32/64/128 MPI ranks
- at 16 ranks, halo/equal-count-Allgather rank-max time was `0.974`, passing the tuned-collective gate
- adaptive local/ghost column slots reduced plan bytes by 16.47--16.48%
- the column-compressed apply rank-max ratio was `0.891--0.957` relative to the uncompressed halo plan, with lower MaxRSS in all 15 measured pairs

## Validation

- push CI: 7/7 matrix jobs passed on commit `4847a6e6`
- local Debug/Release, MPI on/off, OpenMP, ASan, and UBSan coverage
- Spin, SpinlessFermion, and Hubbard MomentumIndex regression coverage
- MPI 4-rank symmetry suite: 9/9 passed with GCC 10.1.0 and Open MPI 4.0.4
- halo performance gate: 36/36 cases passed at 8--128 MPI ranks
- column-compression gate: 30/30 cases and 15/15 bitwise comparison pairs passed
- V3 explicit halo, V4 default, V4 explicit halo, and V4 explicit Allgather produced bitwise-identical residual histories
