### PR TITLE
Fix symmetry halo linkage in expec trace test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -549,6 +549,7 @@ add_executable(expec_trace_ham_check unit/expec_trace_ham_check.c
     ${CMAKE_SOURCE_DIR}/src/symmetry_basis.c
     ${CMAKE_SOURCE_DIR}/src/symmetry_basis_io.c
     ${CMAKE_SOURCE_DIR}/src/symmetry_matvec_plan.c
+    ${CMAKE_SOURCE_DIR}/src/symmetry_vector_halo.c
     ${CMAKE_SOURCE_DIR}/src/splash.c
     ${CMAKE_SOURCE_DIR}/src/time.c
     ${CMAKE_SOURCE_DIR}/src/common/setmemory.c


### PR DESCRIPTION
## Summary

- link `symmetry_vector_halo.c` into the `expec_trace_ham_check` target
- resolve the undefined halo symbols that currently break every `develop` CI build after PR #276

## Testing

- MPI-enabled Release build of all targets
- `ctest -L unit --output-on-failure`
- `expec_trace_ham_check` with MPI enabled and disabled
- `expec_trace_ham_finalize_mpi` with 2 MPI ranks